### PR TITLE
Check reward payout eligibility before claiming for reward

### DIFF
--- a/packages/core/src/operator/operatorRuntime.ts
+++ b/packages/core/src/operator/operatorRuntime.ts
@@ -259,7 +259,7 @@ export async function operatorRuntime(
                 logFunction(`Checking for unclaimed rewards on Challenge '${challengeId}'.`);
     
                 // call the process claim and update statuses/logs accoridngly
-                if (submission.submitted && !submission.claimed) {
+                if (submission.submitted && submission.eligibleForPayout && !submission.claimed) {
                     nodeLicenseStatusMap.set(nodeLicenseId, {
                         ...nodeLicenseStatusMap.get(nodeLicenseId) as NodeLicenseInformation,
                         status: `Found Unclaimed Reward for Challenge '${challengeId}'`,


### PR DESCRIPTION
The function `submitAssertionToChallenge` of the Referee contract does not check for reward payout eligibility. So if there is a submission does not mean that it can be claimed for reward.