### PR TITLE
Fb restart challlenger

### DIFF
--- a/apps/cli/src/commands/boot-challenger.ts
+++ b/apps/cli/src/commands/boot-challenger.ts
@@ -2,102 +2,122 @@ import Vorpal from "vorpal";
 import axios from "axios";
 import { config, createBlsKeyPair, getAssertion, getSignerFromPrivateKey, listenForAssertions, submitAssertionToReferee } from "@sentry/core";
 
+let cachedSigner: any;
+let cachedWebhookUrl: string | undefined;
+let cachedSecretKey: string;
+let lastAssertionTime: number;
+
+type PromptBodyKey = "secretKeyPrompt" | "walletKeyPrompt" | "webhookUrlPrompt";
+
+const INIT_PROMPTS: { [key in PromptBodyKey]: Vorpal.PromptObject } = {
+    secretKeyPrompt: {
+        type: 'password',
+        name: 'secretKey',
+        message: 'Enter the secret key of the challenger (You can run \'create-bls-key-pair\' to create this key):',
+        mask: '*'
+    },
+    walletKeyPrompt: {
+        type: 'password',
+        name: 'walletKey',
+        message: 'Enter the private key of the wallet that the challenger wants to use:',
+        mask: '*'
+    },
+    webhookUrlPrompt: {
+        type: 'input',
+        name: 'webhookUrl',
+        message: 'Enter the webhook URL if you want to post errors (optional):',
+    }
+}
+
+const initCli = async (commandInstance: Vorpal.CommandInstance) => {
+
+    const { secretKey }: any = await commandInstance.prompt(INIT_PROMPTS["secretKeyPrompt"]);
+
+    if (!secretKey || secretKey.length < 1) {
+        throw new Error("No secret key passed in. Please generate one with  'create-bls-key-pair'.")
+    }
+    cachedSecretKey = secretKey;
+    const { publicKeyHex } = await createBlsKeyPair(secretKey);
+    commandInstance.log(`[${new Date().toISOString()}] Public Key of the Challenger: ${publicKeyHex}`);
+
+    const { walletKey }: any = await commandInstance.prompt(INIT_PROMPTS["walletKeyPrompt"]);
+    if (!walletKey || walletKey.length < 1) {
+        throw new Error("No private key passed in. Please provide a valid private key.")
+    }
+
+    const { address, signer } = getSignerFromPrivateKey(walletKey);
+    commandInstance.log(`[${new Date().toISOString()}] Address of the Wallet: ${address}`);
+    cachedSigner = signer;
+
+    const { webhookUrl }: any = await commandInstance.prompt(INIT_PROMPTS["webhookUrlPrompt"]);
+    cachedWebhookUrl = webhookUrl;
+    sendNotification('Challenger has started.');
+
+    lastAssertionTime = Date.now();
+}
+
+const onAssertionConfirmedCb = async (nodeNum: any, commandInstance: Vorpal.CommandInstance) => {
+    commandInstance.log(`[${new Date().toISOString()}] Assertion confirmed ${nodeNum}. Looking up the assertion information...`);
+    const assertionNode = await getAssertion(nodeNum);
+    commandInstance.log(`[${new Date().toISOString()}] Assertion data retrieved. Starting the submission process...`);
+    try {
+        await submitAssertionToReferee(
+            cachedSecretKey,
+            nodeNum,
+            assertionNode,
+            cachedSigner,
+        );
+        commandInstance.log(`[${new Date().toISOString()}] Submitted assertion: ${nodeNum}`);
+        lastAssertionTime = Date.now();
+    } catch (error) {
+        sendNotification(`Error: ${(error as Error).message}`);
+        throw error;
+    }
+};
+
+const checkTimeSinceLastAssertion = async (lastAssertionTime: number, webhookUrlInstance: string | undefined, commandInstance: Vorpal.CommandInstance,) => {
+    const currentTime = Date.now();
+    if (currentTime - lastAssertionTime > 70 * 60 * 1000) {
+        const timeSinceLastAssertion = Math.round((currentTime - lastAssertionTime) / 60000);
+        commandInstance.log(`[${new Date().toISOString()}] It has been ${timeSinceLastAssertion} minutes since the last assertion. Please check the Rollup Protocol (${config.rollupAddress}).`);
+        sendNotification(`It has been ${timeSinceLastAssertion} minutes since the last assertion. Please check the Rollup Protocol (${config.rollupAddress}).`);
+    }
+    lastAssertionTime = currentTime;
+};
+
+const sendNotification = async (message: string) => {
+    if (cachedWebhookUrl) {
+        await axios.post(cachedWebhookUrl, { text: message });
+    }
+}
+
 /**
  * Starts a runtime of the challenger.
  * @param {Vorpal} cli - The Vorpal instance to attach the command to.
  */
 export function bootChallenger(cli: Vorpal) {
+    
     cli
         .command('boot-challenger', 'Starts a runtime of the challenger. You will need the secret key of the challenger to start. You can run \'create-bls-key-pair\' to create this key.')
         .action(async function (this: Vorpal.CommandInstance) {
-            const secretKeyPrompt: Vorpal.PromptObject = {
-                type: 'password',
-                name: 'secretKey',
-                message: 'Enter the secret key of the challenger (You can run \'create-bls-key-pair\' to create this key):',
-                mask: '*'
-            };
-            const { secretKey } = await this.prompt(secretKeyPrompt);
 
-            if (!secretKey || secretKey.length < 1) {
-                throw new Error("No secret key passed in. Please generate one with  'create-bls-key-pair'.")
-            }
+            const commandInstance = this;
+            await initCli(commandInstance);
 
-            const { publicKeyHex } = await createBlsKeyPair(secretKey);
-            this.log(`[${new Date().toISOString()}] Public Key of the Challenger: ${publicKeyHex}`);
-
-            const walletKeyPrompt: Vorpal.PromptObject = {
-                type: 'password',
-                name: 'walletKey',
-                message: 'Enter the private key of the wallet that the challenger wants to use:',
-                mask: '*'
-            };
-            const { walletKey } = await this.prompt(walletKeyPrompt);
-
-            if (!walletKey || walletKey.length < 1) {
-                throw new Error("No private key passed in. Please provide a valid private key.")
-            }
-
-            const { address, signer } = getSignerFromPrivateKey(walletKey);
-            this.log(`[${new Date().toISOString()}] Address of the Wallet: ${address}`);
-
-            const webhookUrlPrompt: Vorpal.PromptObject = {
-                type: 'input',
-                name: 'webhookUrl',
-                message: 'Enter the webhook URL if you want to post errors (optional):',
-            };
-            const { webhookUrl } = await this.prompt(webhookUrlPrompt);
-
-            if (webhookUrl) {
-                await axios.post(webhookUrl, { text: 'Challenger has started.' });
-            }
-
-            let lastAssertionTime = Date.now();
-
-            // start a listener for the assertions coming in
-            // @ts-ignore
-            listenForAssertions(async (nodeNum, blockHash, sendRoot, event) => {
-                this.log(`[${new Date().toISOString()}] Assertion confirmed ${nodeNum}. Looking up the assertion information...`);
-                const assertionNode = await getAssertion(nodeNum);
-                this.log(`[${new Date().toISOString()}] Assertion data retrieved. Starting the submission process...`);
-                try {
-                    await submitAssertionToReferee(
-                        secretKey,
-                        nodeNum,
-                        assertionNode,
-                        signer,
-                    );
-                    this.log(`[${new Date().toISOString()}] Submitted assertion: ${nodeNum}`);
-                    lastAssertionTime = Date.now();
-                } catch (error) {
-                    if (webhookUrl) {
-                        await axios.post(webhookUrl, { text: `Error: ${(error as Error).message}` });
-                    }
-                    throw error;
-                }
-            }, (v: string) => this.log(v));
+            listenForAssertions((nodeNum: any, blockHash: any, sendRoot: any, event: any) => { onAssertionConfirmedCb(nodeNum, commandInstance) }, (v: string) => this.log(v));
 
             // Check if submit assertion has not been run for over 1 hour and 10 minutes
-            setInterval(async () => {
-                const currentTime = Date.now();
-                if (currentTime - lastAssertionTime > 70 * 60 * 1000) {
-                    const timeSinceLastAssertion = Math.round((currentTime - lastAssertionTime) / 60000);
-                    this.log(`[${new Date().toISOString()}] It has been ${timeSinceLastAssertion} minutes since the last assertion. Please check the Rollup Protocol (${config.rollupAddress}).`);
-                    if (webhookUrl) {
-                        await axios.post(webhookUrl, { text: `It has been ${timeSinceLastAssertion} minutes since the last assertion. Please check the Rollup Protocol (${config.rollupAddress}).` });
-                    }
-                }
-                lastAssertionTime = currentTime;
-            }, 5 * 60 * 1000); // Check every 5 minutes
+            setInterval(() => {
+                checkTimeSinceLastAssertion(lastAssertionTime, cachedWebhookUrl, this);
+            }, 5 * 60 * 1000);
 
-            // Listen for process termination and send a message to slack
+            // Listen for process termination and call the handler
             process.on('SIGINT', async () => {
-                if (webhookUrl) {
-                    await axios.post(webhookUrl, { text: `The challenger is shutting down...` });
-                }
+                sendNotification(`The challenger is shutting down...`);
                 process.exit();
             });
 
-            this.log(`[${new Date().toISOString()}] The challenger is now listening for assertions...`);
+            commandInstance.log(`[${new Date().toISOString()}] The challenger is now listening for assertions...`);
             return new Promise((resolve, reject) => { }); // Keep the command alive
         });
 }

--- a/apps/cli/src/commands/boot-challenger.ts
+++ b/apps/cli/src/commands/boot-challenger.ts
@@ -84,6 +84,7 @@ const onAssertionConfirmedCb = async (nodeNum: any, commandInstance: Vorpal.Comm
         commandInstance.log(`[${new Date().toISOString()}] Submitted assertion: ${nodeNum}`);
         lastAssertionTime = Date.now();
     } catch (error) {
+        commandInstance.log(`[${new Date().toISOString()}] Submit Assertion Error: ${(error as Error).message}`);
         sendNotification(`Submit Assertion Error: ${(error as Error).message}`, commandInstance);
         throw error;
     }

--- a/packages/core/src/challenger/isCheckingAssertions.ts
+++ b/packages/core/src/challenger/isCheckingAssertions.ts
@@ -8,7 +8,7 @@ import { getProvider } from "../utils/getProvider.js";
  * @returns The value of isCheckingAssertions.
  */
 export async function getIsCheckingAssertions(): Promise<boolean> {
-    const provider = getProvider("https://icy-thrilling-frog.arbitrum-goerli.quiknode.pro/4d27f3253823ff8ec0afbabc49cbe924bfc9acdb/"); // goerli for now
+    const provider = getProvider(config.arbitrumOneJsonRpcUrl);
     const rollupContract = new ethers.Contract(config.rollupAddress, RollupAdminLogicAbi, provider);
     const isCheckingAssertions = await rollupContract.isCheckingAssertions();
     return isCheckingAssertions;

--- a/packages/core/src/challenger/listenForAssertions.ts
+++ b/packages/core/src/challenger/listenForAssertions.ts
@@ -17,7 +17,7 @@ export function listenForAssertions(callback: (nodeNum: any, blockHash: any, sen
 
     // listen for the NodeConfirmed event
     const listener = resilientEventListener({
-        rpcUrl: "wss://arb-goerli.g.alchemy.com/v2/WNOJEZxrhn3a0PzKUVEZgeRJqxOL7brv",
+        rpcUrl: config.arbitrumOneWebSocketUrl,
         contractAddress: config.rollupAddress,
         abi: RollupAdminLogicAbi,
         eventName: "NodeConfirmed",

--- a/packages/core/src/challenger/listenForAssertions.ts
+++ b/packages/core/src/challenger/listenForAssertions.ts
@@ -1,7 +1,7 @@
 import { LogDescription } from "ethers";
 import { RollupAdminLogicAbi } from "../abis/RollupAdminLogicAbi.js";
 import { config } from "../config.js";
-import { resilientEventListener } from "../utils/resilientEventListener.js";
+import { resilientEventListener, EventListenerError } from "../utils/resilientEventListener.js";
 
 /**
  * Listens for NodeConfirmed events and triggers a callback function when the event is emitted.
@@ -10,7 +10,8 @@ import { resilientEventListener } from "../utils/resilientEventListener.js";
  * @param log - The logging function to be used for logging.
  * @returns A function that can be called to stop listening for the event.
  */
-export function listenForAssertions(callback: (nodeNum: any, blockHash: any, sendRoot: any, event: any) => void, _log: (log: string) => void): () => void {
+
+export function listenForAssertions(callback: (nodeNum: any, blockHash: any, sendRoot: any, event: any, error?: EventListenerError) => void, _log: (log: string) => void) {
     // create a map to keep track of nodeNums that have called the callback
     const nodeNumMap: { [nodeNum: string]: boolean } = {};
 
@@ -21,21 +22,31 @@ export function listenForAssertions(callback: (nodeNum: any, blockHash: any, sen
         abi: RollupAdminLogicAbi,
         eventName: "NodeConfirmed",
         log: _log,
-        callback: (log: LogDescription | null) => {
-            const nodeNum = BigInt(log?.args[0]);
-            const blockHash = log?.args[1];
-            const sendRoot = log?.args[2];
+        callback: (log: LogDescription | null, error?: EventListenerError) => {
 
-            // if the nodeNum has not been seen before, call the callback and add it to the map
-            if (!nodeNumMap[nodeNum.toString()]) {
-                nodeNumMap[nodeNum.toString()] = true;
-                void callback(nodeNum, blockHash, sendRoot, log);
+            if (error) {
+                void callback(undefined, undefined, undefined, undefined, error);
+            } else {
+
+                try {
+                    const nodeNum = BigInt(log?.args[0]);
+                    const blockHash = log?.args[1];
+                    const sendRoot = log?.args[2];
+
+                    // if the nodeNum has not been seen before, call the callback and add it to the map
+                    if (!nodeNumMap[nodeNum.toString()]) {
+                        nodeNumMap[nodeNum.toString()] = true;
+                        void callback(nodeNum, blockHash, sendRoot, log);
+                    }
+                } catch (ex: any) {
+                    void callback(undefined, undefined, undefined, undefined, ex);
+                }
             }
         }
     });
 
     // return a function that can be used to stop listening for the event
-    return () => {
-        listener.stop();
+    return {
+        stop: () => listener.stop()
     };
 }

--- a/packages/core/src/utils/getAssertion.ts
+++ b/packages/core/src/utils/getAssertion.ts
@@ -40,7 +40,7 @@ export interface AssertionNode {
  * @returns The node.
  */
 export async function getAssertion(assertionId: number): Promise<AssertionNode> {
-    const provider = getProvider("https://icy-thrilling-frog.arbitrum-goerli.quiknode.pro/4d27f3253823ff8ec0afbabc49cbe924bfc9acdb/"); // goerli for now
+    const provider = getProvider(config.arbitrumOneJsonRpcUrl);
     const rollupContract = new ethers.Contract(config.rollupAddress, RollupAdminLogicAbi, provider);
     const [
         stateHash,

--- a/packages/core/src/utils/resilientEventListener.ts
+++ b/packages/core/src/utils/resilientEventListener.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'isomorphic-ws';
-import {Contract, InterfaceAbi, LogDescription} from "ethers";
+import { Contract, InterfaceAbi, LogDescription } from "ethers";
 
 interface ResilientEventListenerArgs {
     rpcUrl: string,
@@ -7,7 +7,12 @@ interface ResilientEventListenerArgs {
     abi: InterfaceAbi,
     eventName: string,
     log?: (value: string, ...values: string[]) => void;
-    callback?: (log: LogDescription | null) => void;
+    callback?: (log: LogDescription | null, err?: EventListenerError) => void;
+}
+
+export interface EventListenerError {
+    message: string;
+    type: "onclose" | "onerror" | "onmessage";
 }
 
 const EXPECTED_PONG_BACK = 15000;
@@ -31,99 +36,123 @@ export function resilientEventListener(args: ResilientEventListenerArgs) {
 
     let pingTimeout: NodeJS.Timeout;
     let keepAliveInterval: NodeJS.Timeout;
+    let isStoppedManually = false;
+
+    const log = args.log ? args.log : (value: string, ...values: string[]) => { };
+    const callback = args.callback ? args.callback : (log: LogDescription | null, error: any | undefined) => { };
 
     const connect = () => {
-        ws = new WebSocket(args.rpcUrl);
+        try {
+            ws = new WebSocket(args.rpcUrl);
 
-        const contract = new Contract(args.contractAddress, args.abi);
-        const topicHash = contract.getEvent(args.eventName).getFragment().topicHash;
-        let subscriptionId: string;
+            const contract = new Contract(args.contractAddress, args.abi);
+            const topicHash = contract.getEvent(args.eventName).getFragment().topicHash;
+            let subscriptionId: string;
 
-        args.log && args.log(`[${new Date().toISOString()}] subscribing to event listener with topic hash: ${topicHash}`);
+            log(`[${new Date().toISOString()}] subscribing to event listener with topic hash: ${topicHash}`);
 
-        const request = {
-            id: 1,
-            method: "eth_subscribe",
-            params: [
-                "logs",
-                {
-                    topics: [topicHash],
-                    address: args.contractAddress,
-                }
-            ]
-        };
+            const request = {
+                id: 1,
+                method: "eth_subscribe",
+                params: [
+                    "logs",
+                    {
+                        topics: [topicHash],
+                        address: args.contractAddress,
+                    }
+                ]
+            };
 
-        // sending this backs should return a result of true
-        const ping = {
-            id: 2,
-            method: "net_listening",
-            params:[],
-        };
+            // sending this backs should return a result of true
+            const ping = {
+                id: 2,
+                method: "net_listening",
+                params: [],
+            };
 
-        ws.onerror = function error(err: any) {
-            args.log && args.log(`[${new Date().toISOString()}] WebSocket error: ${err}`);
-        };
+            ws.onerror = function error(err: WebSocket.ErrorEvent) {
+                log(`[${new Date().toISOString()}] WebSocket error: ${err.error}: ${err.message}`);
+                callback(null, { type: "onerror", message: `WebSocket error: ${err.message}` });
+            };
 
-        ws.onclose = function close() {
-            args.log && args.log(`[${new Date().toISOString()}] WebSocket closed`);
-            if (keepAliveInterval) clearInterval(keepAliveInterval);
-            if (pingTimeout) clearTimeout(pingTimeout);
-            ws = null;
-            // Reconnect when the connection is closed
-            setTimeout(connect, 1000);
-        };
-
-        ws.onmessage = function message(event: any) {
-            let parsedData;
-            if (typeof event.data === 'string') {
-                parsedData = JSON.parse(event.data);
-            } else if (event.data instanceof ArrayBuffer) {
-                const dataString = new TextDecoder().decode(event.data);
-                parsedData = JSON.parse(dataString);
-            }
-
-            if (parsedData?.id === request.id) {
-                subscriptionId = parsedData.result;
-                args.log && args.log(`[${new Date().toISOString()}] Subscription to event '${args.eventName}' established with subscription ID '${parsedData.result}'.`);
-            } else if(parsedData?.id === ping.id && parsedData?.result === true) { 
-                args.log && args.log(`[${new Date().toISOString()}] Health check complete, subscription to '${args.eventName}' is still active.`)
-                if (pingTimeout) clearInterval(pingTimeout);
-            } else if (parsedData?.method === 'eth_subscription' && parsedData.params.subscription === subscriptionId) {
-                const log = parsedData.params.result;
-                const event = contract.interface.parseLog(log);
-                args.log && args.log(`[${new Date().toISOString()}] Received event ${event?.name}: ${event?.args}`);
-                args.callback && args.callback(event);
-            }
-        };
-
-        ws.onopen = function open() {
-            args.log && args.log(`[${new Date().toISOString()}] Opened connection to Web Socket RPC`)
-            ws!.send(JSON.stringify(request));
-
-            keepAliveInterval = setInterval(() => {
-                if (!ws) {
-                  args.log && args.log(`[${new Date().toISOString()}] No websocket, exiting keep alive interval`);
-                  return;
-                }
-                args.log && args.log(`[${new Date().toISOString()}] Performing health check on the Web Socket RPC, to maintain subscription to '${args.eventName}'.`);
-        
-                ws.send(JSON.stringify(ping));
-                pingTimeout = setTimeout(() => {
-                  if (ws) ws.terminate();
-                }, EXPECTED_PONG_BACK);
+            ws.onclose = function close() {
+                if (keepAliveInterval) clearInterval(keepAliveInterval);
+                if (pingTimeout) clearTimeout(pingTimeout);
+                ws = null;
                 
-            }, KEEP_ALIVE_CHECK_INTERVAL);
+                if (!isStoppedManually) {
+                    setTimeout(connect, 1000);
+                    log(`[${new Date().toISOString()}] WebSocket closed, reconnecting automatically`);
+                    callback(null, { type: "onclose", message: `WebSocket closed, reconnecting automatically` });
+                } else {
+                    log(`[${new Date().toISOString()}] WebSocket closed`);
+                    callback(null, { type: "onclose", message: `WebSocket closed` });
+                }
+            };
 
-        };
+            ws.onmessage = function message(event: any) {
+                try {
+                    let parsedData;
+                    if (typeof event.data === 'string') {
+                        parsedData = JSON.parse(event.data);
+                    } else if (event.data instanceof ArrayBuffer) {
+                        const dataString = new TextDecoder().decode(event.data);
+                        parsedData = JSON.parse(dataString);
+                    }
+
+                    if (parsedData?.id === request.id) {
+                        subscriptionId = parsedData.result;
+                        log(`[${new Date().toISOString()}] Subscription to event '${args.eventName}' established with subscription ID '${parsedData.result}'.`);
+                    } else if (parsedData?.id === ping.id && parsedData?.result === true) {
+                        log(`[${new Date().toISOString()}] Health check complete, subscription to '${args.eventName}' is still active.`)
+                        if (pingTimeout) clearInterval(pingTimeout);
+                    } else if (parsedData?.method === 'eth_subscription' && parsedData.params.subscription === subscriptionId) {
+                        const log = parsedData.params.result;
+                        const event = contract.interface.parseLog(log);
+                        log(`[${new Date().toISOString()}] Received event ${event?.name}: ${event?.args}`);
+                        callback(event);
+                    }
+
+                } catch (error) {
+                    log(`[${new Date().toISOString()}] Error in message handling: ${error}`);
+                    callback(null, { type: "onmessage", message: `Error in message handling: ${error && (error as Error).message ? (error as Error).message : error as string}` });
+                }
+            };
+
+            ws.onopen = function open() {
+                log(`[${new Date().toISOString()}] Opened connection to Web Socket RPC`)
+                ws!.send(JSON.stringify(request));
+
+                keepAliveInterval = setInterval(() => {
+                    if (!ws) {
+                        log(`[${new Date().toISOString()}] No websocket, exiting keep alive interval`);
+                        return;
+                    }
+                    log(`[${new Date().toISOString()}] Performing health check on the Web Socket RPC, to maintain subscription to '${args.eventName}'.`);
+
+                    ws.send(JSON.stringify(ping));
+                    pingTimeout = setTimeout(() => {
+                        if (ws) ws.terminate();
+                    }, EXPECTED_PONG_BACK);
+
+                }, KEEP_ALIVE_CHECK_INTERVAL);
+
+            };
+
+        } catch (error) {
+            log(`[${new Date().toISOString()}] Error in connect function: ${error}`);
+            throw error;
+        }
     }
 
     const stop = () => {
+        isStoppedManually = true;
+        if (keepAliveInterval) clearInterval(keepAliveInterval);
+        if (pingTimeout) clearTimeout(pingTimeout);
         if (ws) {
             ws.close();
             ws = null;
         }
-        if (keepAliveInterval) clearInterval(keepAliveInterval);
-        if (pingTimeout) clearTimeout(pingTimeout);
     };
 
     connect();


### PR DESCRIPTION
- Update resilientEventListener
  - Allow for manual stop
  - Send error in callback
  - catch error if invalid RPC
  - catch error onMessage invalid JSON
  
- Update listenForAssertions
  - Handle error in event parse
  - Send callback errors

- Update boot-challenger
  - Handle callback errors
  - Allow for 3 attempts to restart the listener
  - Send Notifications if restarting failed
  - Allow for custom number of websocket errors before restart (e.g. websocket tries to reconnect a couple times until it works)
  