### PR TITLE
Add jsonrpc attribute per JSON-RPC specs

### DIFF
--- a/packages/core/src/utils/resilientEventListener.ts
+++ b/packages/core/src/utils/resilientEventListener.ts
@@ -42,6 +42,7 @@ export function resilientEventListener(args: ResilientEventListenerArgs) {
         args.log && args.log(`[${new Date().toISOString()}] subscribing to event listener with topic hash: ${topicHash}`);
 
         const request = {
+            jsonrpc: "2.0",
             id: 1,
             method: "eth_subscribe",
             params: [


### PR DESCRIPTION
In newer versions of Arbitrum nitro node (`v2.2.2`) subscribing on websocket using `eth_subscribe` without `jsonrpc` attribute will result in error

```
{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}
```

[JSON-RPC specs](https://www.jsonrpc.org/specification) specifically said that `"jsonrpc":"2.0"` must be presented in the request object
