### PR TITLE
feat(cli): support command-line args for boot-operator

### DIFF
--- a/apps/cli/src/commands/operator-control/operator-runtime.ts
+++ b/apps/cli/src/commands/operator-control/operator-runtime.ts
@@ -1,6 +1,13 @@
 import Vorpal from "vorpal";
 import { getSignerFromPrivateKey, operatorRuntime, listOwnersForOperator } from "@sentry/core";
 
+interface BootOperatorArgs {
+    options: {
+        walletKey?: string;
+        useWhitelist?: boolean;
+        owners?: string[];
+    };
+}
 /**
  * Starts a runtime of the operator.
  * @param {Vorpal} cli - The Vorpal instance to attach the command to.
@@ -10,15 +17,21 @@ export function bootOperator(cli: Vorpal) {
 
     cli
         .command('boot-operator', 'Starts a runtime of the operator.')
-        .action(async function (this: Vorpal.CommandInstance) {
-            const walletKeyPrompt: Vorpal.PromptObject = {
-                type: 'password',
-                name: 'walletKey',
-                message: 'Enter the private key of the operator:',
-                mask: '*'
-            };
-
-            const { walletKey } = await this.prompt(walletKeyPrompt);
+        .option('-k, --wallet-key <walletKey>', 'The private key of the operator.')
+        .option('-w, --use-whitelist', 'Flag to use a whitelist for the operator runtime.')
+        .option('-o, --owners <owners>', 'A comma-separated list of owners if using a whitelist.', list => list.split(','))
+        .action(async function (this: Vorpal.CommandInstance, args: BootOperatorArgs) {
+            let walletKey = args.options.walletKey;
+            if (!walletKey) {
+                const walletKeyPrompt: Vorpal.PromptObject = {
+                    type: 'password',
+                    name: 'walletKey',
+                    message: 'Enter the private key of the operator:',
+                    mask: '*'
+                };
+                const result = await this.prompt(walletKeyPrompt);
+                walletKey = result.walletKey;
+            }
 
             if (!walletKey || walletKey.length < 1) {
                 throw new Error("No private key passed in. Please provide a valid private key.")
@@ -26,39 +39,39 @@ export function bootOperator(cli: Vorpal) {
 
             const { signer } = getSignerFromPrivateKey(walletKey);
 
-            const whitelistPrompt: Vorpal.PromptObject = {
-                type: 'confirm',
-                name: 'useWhitelist',
-                message: 'Do you want to use a whitelist for the operator runtime?',
-                default: false
-            };
-
-            const { useWhitelist } = await this.prompt(whitelistPrompt);
-
-            // If useWhitelist is false, selectedOwners will be undefined
+            let useWhitelist = args.options.useWhitelist;
             let selectedOwners;
-            if (useWhitelist) {
-                
-                const operatorAddress = await signer.getAddress();
-                const owners = await listOwnersForOperator(operatorAddress);
-
-                const ownerPrompt: Vorpal.PromptObject = {
-                    type: 'checkbox',
-                    name: 'selectedOwners',
-                    message: 'Select the owners for the operator to run for:',
-                    choices: [operatorAddress, ...owners]
+            if (useWhitelist === undefined) {
+                const whitelistPrompt: Vorpal.PromptObject = {
+                    type: 'confirm',
+                    name: 'useWhitelist',
+                    message: 'Do you want to use a whitelist for the operator runtime?',
+                    default: false
                 };
+                const result = await this.prompt(whitelistPrompt);
+                useWhitelist = result.useWhitelist;
+            }
 
-                const result = await this.prompt(ownerPrompt);
-                selectedOwners = result.selectedOwners;
-
-                console.log("selectedOwners", selectedOwners);
+            if (useWhitelist) {
+                if (!args.options.owners || args.options.owners.length < 1) {
+                    const operatorAddress = await signer.getAddress();
+                    const owners = await listOwnersForOperator(operatorAddress);
+                    const ownerPrompt: Vorpal.PromptObject = {
+                        type: 'checkbox',
+                        name: 'selectedOwners',
+                        message: 'Select the owners for the operator to run for:',
+                        choices: [operatorAddress, ...owners]
+                    };
+                    const result = await this.prompt(ownerPrompt);
+                    selectedOwners = result.selectedOwners;
+                } else {
+                    selectedOwners = args.options.owners;
+                }
 
                 if (!selectedOwners || selectedOwners.length < 1) {
                     throw new Error("No owners selected. Please select at least one owner.")
                 }
             }
-
 
             stopFunction = await operatorRuntime(
                 signer,


### PR DESCRIPTION
Enhanced the 'boot-operator' command to accept command-line arguments for wallet key, whitelist usage, and owner selection. This update retains interactive prompts while allowing for a more streamlined and scriptable command execution. Command-line arguments for the private key, whitelist flag, and a comma-separated list of owners can be provided, bypassing the interactive prompts if the required information is already supplied.

- Added command-line options for wallet key (-k, --wallet-key), whitelist usage (-w, --use-whitelist), and owner list (-o, --owners).
- Integrated checks to determine whether to use the provided command-line arguments or to fall back on interactive prompts.
- Modified the handling of whitelist and owner selection to accommodate both interactive and non-interactive input methods.

This improvement enhances the flexibility and usability of the CLI interface, catering to both interactive use and automated scripts.