### PR TITLE
Update operator to compare challenge against public CDN

### DIFF
--- a/apps/cli/src/commands/operator-control/operator-runtime.ts
+++ b/apps/cli/src/commands/operator-control/operator-runtime.ts
@@ -1,5 +1,5 @@
 import Vorpal from "vorpal";
-import { getSignerFromPrivateKey, operatorRuntime, listOwnersForOperator } from "@sentry/core";
+import { getSignerFromPrivateKey, operatorRuntime, listOwnersForOperator, Challenge, PublicNodeBucketInformation } from "@sentry/core";
 
 /**
  * Starts a runtime of the operator.
@@ -59,12 +59,21 @@ export function bootOperator(cli: Vorpal) {
                 }
             }
 
-
             stopFunction = await operatorRuntime(
                 signer,
                 undefined,
-                (log) => this.log(log),
+                (log: string) => this.log(log),
                 selectedOwners,
+                (publicNodeData: PublicNodeBucketInformation | undefined, challenge: Challenge, message: string) => {
+                    const errorMessage = `The comparison between public node and challenge failed:\n` +
+                        `${message}\n\n` +
+                        `Public node data:\n` +
+                        `${JSON.stringify(publicNodeData, null, 2)}\n\n` +
+                        `Challenge data:\n` +
+                        `${JSON.stringify(challenge, null, 2)}\n`;
+
+                    this.log(errorMessage)
+                }
             );
 
             return new Promise((resolve, reject) => { }); // Keep the command alive

--- a/apps/sentry-client-desktop/src/hooks/useOperatorRuntime.ts
+++ b/apps/sentry-client-desktop/src/hooks/useOperatorRuntime.ts
@@ -1,8 +1,19 @@
-import {NodeLicenseInformation, NodeLicenseStatusMap, operatorRuntime} from "@sentry/core";
+import {Challenge, NodeLicenseInformation, NodeLicenseStatusMap, operatorRuntime, PublicNodeBucketInformation} from "@sentry/core";
 import {useOperator} from "@/features/operator";
 import {atom, useAtom} from "jotai";
 import {useEffect, useState} from "react";
 import {useStorage} from "@/features/storage";
+
+function onAssertionMissMatch(publicNodeData: PublicNodeBucketInformation, challenge: Challenge, message: string) {
+	const errorMessage = `The comparison between public node and challenge failed:\n` +
+		`${message}\n\n` +
+		`Public node data:\n` +
+		`${JSON.stringify(publicNodeData, null, 2)}\n\n` +
+		`Challenge data:\n` +
+		`${JSON.stringify(challenge, null, 2)}\n`;
+
+	alert(errorMessage);
+}
 
 let stop: (() => Promise<void>) | undefined;
 export const sentryRunningAtom = atom(stop != null);
@@ -42,7 +53,7 @@ export function useOperatorRuntime() {
 			await setData({...data, sentryRunning: true});
 
 			// @ts-ignore
-			stop = await operatorRuntime(signer, setNodeLicenseStatusMap, writeLog, whitelistedWallets);
+			stop = await operatorRuntime(signer, setNodeLicenseStatusMap, writeLog, whitelistedWallets, onAssertionMissMatch);
 			setRerender((_number) => _number + 1);
 		}
 	}


### PR DESCRIPTION
Extend the operator for the `onAssertionMissMatch()` callback.
The operator will use this callback to notify if there was a miss match between the challenge on the referee and the assertion from the public node posted to the CDN

The CLI will write a console log, the desktop client will show an alert.