### PR TITLE
Fb operator control 187047289

### DIFF
--- a/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
+++ b/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
@@ -303,7 +303,7 @@ contract PoolFactory is Initializable, AccessControlEnumerableUpgradeable {
         uint256 keysLength = keyIds.length;
         require(keysLength > 0, "Must at least unstake 1 key");
 
-        Referee5(refereeAddress).unstakeKeys(pool, IStakingPool(pool).getPoolOwner(), msg.sender, keyIds, IStakingPool(pool).getStakedAmounts(msg.sender));
+        Referee5(refereeAddress).unstakeKeys(pool, IStakingPool(pool).getPoolOwner(), msg.sender, keyIds, IStakingPool(pool).getStakedKeysCountForUser(msg.sender));
         IStakingPool(pool).unstakeKeys(msg.sender, keyIds);
 
         (uint256 stakeAmount, uint256 keyAmount) = userPoolInfo(

--- a/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
+++ b/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
@@ -289,7 +289,8 @@ contract PoolFactory is Initializable, AccessControlEnumerableUpgradeable {
             interactedPoolsOfUser[msg.sender].push(poolIndex);
         }
 
-        Referee5(refereeAddress).stakeKeys(pool, msg.sender, keyIds);
+		//get the pool owner poolOwnerok
+        Referee5(refereeAddress).stakeKeys(pool, IStakingPool(pool).poolOwner, msg.sender, keyIds);
         IStakingPool(pool).stakeKeys(msg.sender, keyIds);
         assignedKeysOfUserCount[msg.sender] += keysLength;
 

--- a/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
+++ b/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
@@ -303,7 +303,7 @@ contract PoolFactory is Initializable, AccessControlEnumerableUpgradeable {
         uint256 keysLength = keyIds.length;
         require(keysLength > 0, "Must at least unstake 1 key");
 
-        Referee5(refereeAddress).unstakeKeys(pool, msg.sender, IStakingPool(pool).getPoolOwner(), keyIds);
+        Referee5(refereeAddress).unstakeKeys(pool, IStakingPool(pool).getPoolOwner(), msg.sender, keyIds, IStakingPool(pool).getStakedAmounts(msg.sender));
         IStakingPool(pool).unstakeKeys(msg.sender, keyIds);
 
         (uint256 stakeAmount, uint256 keyAmount) = userPoolInfo(

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee5.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee5.sol
@@ -821,9 +821,9 @@ contract Referee5 is Initializable, AccessControlEnumerableUpgradeable {
         uint256 keysLength = keyIds.length;
         require(assignedKeysToPoolCount[pool] + keysLength <= maxKeysPerPool, "Maximum staking amount exceeded");
 
-		if (!isApprovedForOperator(keyOwner, poolOwner)) {
-			_operatorApprovals[keyOwner].add(poolOwner);
-			_ownersForOperator[poolOwner].add(keyOwner);
+		if (staker != poolOwner && !isApprovedForOperator(staker, poolOwner)) {
+			_operatorApprovals[staker].add(poolOwner);
+			_ownersForOperator[poolOwner].add(staker);
 		}
 
         NodeLicense nodeLicenseContract = NodeLicense(nodeLicenseAddress);
@@ -837,7 +837,7 @@ contract Referee5 is Initializable, AccessControlEnumerableUpgradeable {
         assignedKeysOfUserCount[staker] += keysLength;
     }
 
-    function unstakeKeys(address pool, address staker, address poolOwner, uint256[] memory keyIds) external onlyPoolFactory {
+    function unstakeKeys(address pool, address poolOwner, address staker, uint256[] memory keyIds, uint256 userStakedKeyCount) external onlyPoolFactory {
         uint256 keysLength = keyIds.length;
         NodeLicense nodeLicenseContract = NodeLicense(nodeLicenseAddress);
 
@@ -846,9 +846,12 @@ contract Referee5 is Initializable, AccessControlEnumerableUpgradeable {
                 assignedKeysOfUserCount[staker] > keysLength,
                 "Pool owner needs at least 1 staked key"
             );
-        }
-
-        //TODO remove approval
+        } else {
+			if (userStakedKeyCount - keysLength < 1) {
+				_operatorApprovals[staker].remove(poolOwner);
+				_ownersForOperator[poolOwner].remove(staker);
+			}
+		}
 
         for (uint256 i = 0; i < keysLength; i++) {
             uint256 keyId = keyIds[i];


### PR DESCRIPTION
Added logic for approving/removing approval of the pool owner to operate the staking user's keys when the staking user stakes/un-stakes. Also re-ordered arguments in the stakeKeys function because i though it was cleaner if the `pool` & `poolOwner` arguments were sequential