### PR TITLE
Minor merge / update fixes

### DIFF
--- a/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
+++ b/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
@@ -277,7 +277,7 @@ contract PoolFactory is Initializable, AccessControlEnumerableUpgradeable {
 
     function validateShareValues(
         uint32[3] memory _shareConfig
-    ) internal returns (bool) {
+    ) internal view returns (bool) {
         return
             _shareConfig[0] <= bucketshareMaxValues[0] &&
             _shareConfig[1] <= bucketshareMaxValues[1] &&

--- a/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
+++ b/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
@@ -312,14 +312,6 @@ contract PoolFactory is Initializable, AccessControlEnumerableUpgradeable {
 		emit UpdatePoolDelegate(delegate, pool);
 	}
 
-    function userPoolInfo(
-        address pool,
-        address user
-    ) internal view returns (uint256 stakeAmount, uint256 keyAmount) {
-        stakeAmount = StakingPool(pool).getStakedAmounts(user);
-        keyAmount = StakingPool(pool).getStakedKeysCountForUser(user);
-    }
-
     function _stakeKeys(address pool, uint256[] memory keyIds) internal {
         Referee5(refereeAddress).stakeKeys(pool, msg.sender, keyIds);
         StakingPool stakingPool = StakingPool(pool);

--- a/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
+++ b/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
@@ -325,9 +325,7 @@ contract PoolFactory is Initializable, AccessControlEnumerableUpgradeable {
         StakingPool stakingPool = StakingPool(pool);
         stakingPool.stakeKeys(msg.sender, keyIds);
 
-        if (stakingPool.isUserEngagedWithPool(msg.sender)) {
-            associateUserWithPool(msg.sender, pool);
-        }
+        associateUserWithPool(msg.sender, pool);
 
         emit StakeKeys(
             msg.sender,
@@ -419,9 +417,7 @@ contract PoolFactory is Initializable, AccessControlEnumerableUpgradeable {
         StakingPool stakingPool = StakingPool(pool);
         stakingPool.stakeEsXai(msg.sender, amount);
 
-        if (stakingPool.isUserEngagedWithPool(msg.sender)) {
-            associateUserWithPool(msg.sender, pool);
-        }
+        associateUserWithPool(msg.sender, pool);
 
         emit StakeEsXai(
             msg.sender,

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee5.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee5.sol
@@ -526,7 +526,12 @@ contract Referee5 is Initializable, AccessControlEnumerableUpgradeable {
             return;
         }
 
-        _submitAssertion(_nodeLicenseId, _challengeId, _confirmData);
+        address licenseOwner = NodeLicense(nodeLicenseAddress).ownerOf(_nodeLicenseId);
+        address assignedPool = assignedKeyToPool[_nodeLicenseId];
+        
+        require(isValidOperator(licenseOwner, assignedPool), "17");
+
+        _submitAssertion(_nodeLicenseId, _challengeId, _confirmData, licenseOwner, assignedPool);
     }
 
 	function submitMultipleAssertions(
@@ -547,26 +552,28 @@ contract Referee5 is Initializable, AccessControlEnumerableUpgradeable {
 		for (uint256 i = 0; i < keyLength; i++) {
             uint256 _nodeLicenseId = _nodeLicenseIds[i];
             if (!submissions[_challengeId][_nodeLicenseId].submitted) {
-                _submitAssertion(_nodeLicenseId, _challengeId, _confirmData);
+                
+                address licenseOwner = NodeLicense(nodeLicenseAddress).ownerOf(_nodeLicenseId);
+                address assignedPool = assignedKeyToPool[_nodeLicenseId];
+
+                if(isValidOperator(licenseOwner, assignedPool)){
+                    _submitAssertion(_nodeLicenseId, _challengeId, _confirmData, licenseOwner, assignedPool);
+                }
             }
 		}
 	}
-    
-    function _submitAssertion(uint256 _nodeLicenseId, uint256 _challengeId, bytes memory _confirmData) internal {
-        
-        address licenseOwner = NodeLicense(nodeLicenseAddress).ownerOf(_nodeLicenseId);
-        address assignedPool = assignedKeyToPool[_nodeLicenseId];
 
-        require(
-            licenseOwner == msg.sender ||
+    function isValidOperator(address licenseOwner, address assignedPool) internal view returns (bool) {
+        return licenseOwner == msg.sender ||
             isApprovedForOperator(licenseOwner, msg.sender) ||
-			(
-				assignedPool != address(0) &&
-				PoolFactory(poolFactoryAddress).isDelegateOfPoolOrOwner(msg.sender, assignedPool)
-			),
-            "17"
-        );
-
+            (
+                assignedPool != address(0) &&
+                PoolFactory(poolFactoryAddress).isDelegateOfPoolOrOwner(msg.sender, assignedPool)
+            );
+    }
+    
+    function _submitAssertion(uint256 _nodeLicenseId, uint256 _challengeId, bytes memory _confirmData, address licenseOwner, address assignedPool) internal {
+        
         // Support v1 (no pools) & v2 (pools)
 		uint256 stakedAmount = stakedAmounts[assignedPool];
 		if (assignedPool == address(0)) {


### PR DESCRIPTION
- Remove redundant check stakingPool.isUserEngagedWithPool
  - This would always be true after doing pool.stake
- Add view to validateShareValues
- Remove unused userPoolInfo internal function
- Move valid operator check outside _submitAssertion for skipping on batch submit

All testcases and size cmd ran without errors