### PR TITLE
fix bug save swapped pool index on removeUserFromPool

### DIFF
--- a/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
+++ b/infrastructure/smart-contracts/contracts/staking-v2/PoolFactory.sol
@@ -456,9 +456,13 @@ contract PoolFactory is Initializable, AccessControlEnumerableUpgradeable {
     function removeUserFromPool(address user, address pool) internal {
         uint256 indexOfPool = userToInteractedPoolIds[user][pool];
         uint256 userLength = interactedPoolsOfUser[user].length;
-        interactedPoolsOfUser[user][indexOfPool] = interactedPoolsOfUser[user][
+        address lastPool = interactedPoolsOfUser[user][
             userLength - 1
         ];
+        
+        interactedPoolsOfUser[user][indexOfPool] = lastPool;
+        userToInteractedPoolIds[user][lastPool] = indexOfPool;
+
         interactedPoolsOfUser[user].pop();
     }
 


### PR DESCRIPTION
Fixed Bug array out of bounds

For example:
Alice stakes into pool A and B:
userToInteractedPoolIds[Alice][A] = 0;
userToInteractedPoolIds[Alice][B] = 1;
interactedPoolsOfUser[Alice] = [A, B];
When Alice exits from A:
userToInteractedPoolIds[Alice][A] = 0;
userToInteractedPoolIds[Alice][B] = 1; (* this is not correct)
interactedPoolsOfUser[Alice] = [B];
Now, Alice cannot exit from B due to the out-of-index issue.