### PR TITLE
fix tier out of bounds error on calculate emission and tier

### DIFF
--- a/infrastructure/smart-contracts/test/Referee.mjs
+++ b/infrastructure/smart-contracts/test/Referee.mjs
@@ -199,12 +199,12 @@ export function RefereeTests(deployInfrastructure) {
 			const maxSupply = await xai.MAX_SUPPLY();
 
 			let tokensToMint = [ethers.parseEther('1250000000')];
-			for (let i = 0; i < 23; i++) {
+			for (let i = 0; i < 22; i++) {
 				tokensToMint.push(tokensToMint[i] / BigInt(2));
 			}
 
 			let challengeAllocations = [BigInt('71347031963470319634703')];
-			for (let i = 0; i < 23; i++) {
+			for (let i = 0; i < 22; i++) {
 				challengeAllocations.push(challengeAllocations[i] / BigInt(2));
 			}
 
@@ -241,12 +241,12 @@ export function RefereeTests(deployInfrastructure) {
 			const maxSupply = await xai.MAX_SUPPLY();
 
 			let tokensToMint = [ethers.parseEther('1250000000')];
-			for (let i = 0; i < 23; i++) {
+			for (let i = 0; i < 22; i++) {
 				tokensToMint.push(tokensToMint[i] / BigInt(2));
 			}
 
 			let challengeAllocations = [BigInt('71347031963470319634703')];
-			for (let i = 0; i < 23; i++) {
+			for (let i = 0; i < 22; i++) {
 				challengeAllocations.push(challengeAllocations[i] / BigInt(2));
 			}
 


### PR DESCRIPTION
The testcase failed because we pushed 24 tiers to the test tiers to check, probably because the first initial value was added later on.

Making the for loop only pushing 22 tiers and one initial tier will make the testcase pass.