### PR TITLE
Fix challenger double submit #187505766

### DIFF
--- a/apps/cli/src/commands/boot-challenger.ts
+++ b/apps/cli/src/commands/boot-challenger.ts
@@ -124,6 +124,11 @@ const onAssertionConfirmedCb = async (nodeNum: any, commandInstance: Vorpal.Comm
         commandInstance.log(`[${new Date().toISOString()}] Submitted assertion: ${nodeNum}`);
         lastAssertionTime = Date.now();
     } catch (error) {
+        if(error && (error as Error).message && (error as Error).message.includes('execution reverted: "9"')){
+            commandInstance.log(`[${new Date().toISOString()}] Could not submit challenge because it was already submitted`);
+            lastAssertionTime = Date.now();
+            return;
+        }
         commandInstance.log(`[${new Date().toISOString()}] Submit Assertion Error: ${(error as Error).message}`);
         sendNotification(`Submit Assertion Error: ${(error as Error).message}`, commandInstance);
         throw error;
@@ -233,6 +238,10 @@ async function processMissedAssertions(commandInstance: Vorpal.CommandInstance) 
             );
             commandInstance.log(`[${new Date().toISOString()}] Submitted assertion: ${missedAssertionNodeNum}`);
         } catch (error) {
+            if(error && (error as Error).message && (error as Error).message.includes('execution reverted: "9"')){
+                commandInstance.log(`[${new Date().toISOString()}] Could not submit challenge because it was already submitted`);
+                return;
+            }
             sendNotification(`Submit missed assertion Error: ${(error as Error).message}`, commandInstance);
             throw error;
         }

--- a/apps/cli/src/commands/boot-challenger.ts
+++ b/apps/cli/src/commands/boot-challenger.ts
@@ -169,7 +169,7 @@ const checkTimeSinceLastAssertion = async (lastAssertionTime: number, commandIns
 const sendNotification = async (message: string, commandInstance: Vorpal.CommandInstance) => {
     if (cachedWebhookUrl) {
         try {
-            await axios.post(cachedWebhookUrl, { text: `@channel [Instance ${CHALLENGER_INSTANCE}]: ${message}` });
+            await axios.post(cachedWebhookUrl, { text: `<!channel> [Instance ${CHALLENGER_INSTANCE}]: ${message}` });
         } catch (error) {
             commandInstance.log(`[${new Date().toISOString()}] Failed to send notification request ${error && (error as Error).message ? (error as Error).message : error}`);
         }


### PR DESCRIPTION
Fixing the double submit followed by Referee Error 9.

When the websocket closes and automatically reconnects, we only get the error event on close once in the runtime.
Then if the websocket ran successfully until the next node event we would first look for a missed assertion, post that and then try to submit again with the regular `onAssertionConfirmedCb`.

We actually need the challenger to catch missed assertions in between websocket reconnects. The websocket will wait 1 second to automatically reconnect, so we should wait 1 second and then call `processMissedAssertions()`.
We want to do this on any error callback from the websocket, so we make sure we don't miss an assertion from in between errors.

To not stack multiple processMissedAssertions calls we added a lock making sure it runs only once and never in paralell and reduce the load should the websocket return many errors consecutively.


