### PR TITLE
Fb fallback rpc

### DIFF
--- a/apps/cli/src/commands/operator-control/operator-runtime.ts
+++ b/apps/cli/src/commands/operator-control/operator-runtime.ts
@@ -41,7 +41,7 @@ export function bootOperator(cli: Vorpal) {
             if (useWhitelist) {
 
                 const operatorAddress = await signer.getAddress();
-                const { wallets, pools } = await getSentryWalletsForOperator(null, operatorAddress);
+                const { wallets, pools } = await getSentryWalletsForOperator(operatorAddress);
 
                 const choices: Array<{ name: string, value: string }> = [];
 

--- a/packages/core/src/data-centralization/updatePoolInDB.ts
+++ b/packages/core/src/data-centralization/updatePoolInDB.ts
@@ -26,7 +26,7 @@ export async function updatePoolInDB(
     //Timeout to wait for subgraph sync to updates for pools
     await new Promise(resolve => setTimeout(resolve, 2000));
     //Load poolInfo from subgraph
-    const { pools, refereeConfig } = await getPoolInfosFromGraph(graphClient, [poolAddress], true, true);
+    const { pools, refereeConfig } = await getPoolInfosFromGraph([poolAddress], true, true);
     if (!pools.length || !pools[0]) {
         throw new Error(`Pool ${poolAddress} could not be found on subgraph - event: ${eventName}`);
     }

--- a/packages/core/src/operator/operatorRuntime.ts
+++ b/packages/core/src/operator/operatorRuntime.ts
@@ -71,7 +71,7 @@ const KEYS_PER_BATCH = 100;
 
 // Cache for rpc fallback
 // const keyToOwner: { [keyId: string]: string } = {};
-let cachedOperatorWallets: string[] = [];
+let cachedOperatorWallets: string[];
 const mintTimestamps: { [nodeLicenseId: string]: bigint } = {};
 let cachedKeysOfOwner: { [keyId: string]: SentryKey } = {};
 

--- a/packages/core/src/operator/operatorRuntime.ts
+++ b/packages/core/src/operator/operatorRuntime.ts
@@ -26,7 +26,6 @@ import {
 } from "../index.js";
 import axios from "axios";
 import { PoolInfo, RefereeConfig, SentryKey, SentryWallet, Submission } from "@sentry/sentry-subgraph-client";
-import { GraphQLClient } from 'graphql-request'
 import { getSubgraphHealthStatus } from "../subgraph/getSubgraphHealthStatus.js";
 
 export enum NodeLicenseStatus {
@@ -74,8 +73,6 @@ const KEYS_PER_BATCH = 100;
 let cachedOperatorWallets: string[];
 const mintTimestamps: { [nodeLicenseId: string]: bigint } = {};
 let cachedKeysOfOwner: { [keyId: string]: SentryKey };
-
-const graphClient = new GraphQLClient(config.subgraphEndpoint);
 
 // SUBGRAPH EDIT
 let nodeLicenseStatusMap: NodeLicenseStatusMap = new Map();
@@ -619,7 +616,7 @@ const loadOperatorKeysFromGraph = async (
 
     // Load all operator addresses and pool addresses, pass in the whitelist to get them filtered
     // refereeConfig will be used to locally calculate the boos factor (hold tier thresholds and boostFactors as well as max staking capacity per key)
-    const { wallets, pools, refereeConfig } = await retry(() => getSentryWalletsForOperator(graphClient, operator, passedInOwnersAndPools));
+    const { wallets, pools, refereeConfig } = await retry(() => getSentryWalletsForOperator(operator, passedInOwnersAndPools));
 
     const mappedPools: { [poolAddress: string]: PoolInfo } = {};
 
@@ -631,7 +628,6 @@ const loadOperatorKeysFromGraph = async (
 
     // Load SentryKey objects from the subgraph
     const sentryKeys = await retry(() => getSentryKeysFromGraph(
-        graphClient,
         wallets.map(w => w.address),
         pools.map(p => p.address),
         true,
@@ -696,7 +692,7 @@ const loadOperatorKeysFromGraph = async (
 
     // If we have keys from pools we would not operate from the owners map the pool metadata for 
     if (keyPools.size) {
-        const keyPoolsData = await retry(() => getPoolInfosFromGraph(graphClient, [...keyPools]));
+        const keyPoolsData = await retry(() => getPoolInfosFromGraph([...keyPools]));
         keyPoolsData.pools.forEach(p => {
             mappedPools[p.address] = p;
         })
@@ -917,7 +913,7 @@ export async function operatorRuntime(
     if (graphStatus.healthy) {
         closeChallengeListener = listenForChallenges(listenForChallengesCallback)
 
-        const openChallenge = await retry(() => getLatestChallengeFromGraph(graphClient));
+        const openChallenge = await retry(() => getLatestChallengeFromGraph());
         // Calculate the latest challenge we should load from the graph
         const latestClaimableChallenge = Number(openChallenge.challengeNumber) <= MAX_CHALLENGE_CLAIM_AMOUNT ? 1 : Number(openChallenge.challengeNumber) - MAX_CHALLENGE_CLAIM_AMOUNT;
 

--- a/packages/core/src/operator/operatorRuntime.ts
+++ b/packages/core/src/operator/operatorRuntime.ts
@@ -462,6 +462,13 @@ async function listenForChallengesCallback(challengeNumber: bigint, challenge: C
     }
 
     cachedLogger(`Received new challenge with number: ${challengeNumber}.`);
+    cachedLogger(`Processing challenge...`);
+
+    // Add a delay of 1 -300 seconds to the new challenge process so not all operators request the subgraph at the same time
+    const delay = Math.floor(Math.random() * 301);
+    await new Promise((resolve) => {
+        setTimeout(resolve, delay * 1000);
+    })
 
     try {
         const graphStatus = await getSubgraphHealthStatus();
@@ -663,9 +670,9 @@ const loadOperatorKeysFromGraph = async (
             keyOfOwnerCount++;
         } else {
             keyPools.add(s.assignedPool);
-            if(cachedOperatorWallets.includes(s.owner.toLowerCase())){
+            if (cachedOperatorWallets.includes(s.owner.toLowerCase())) {
                 keyOfOwnerCount++;
-            }else{
+            } else {
                 keyOfPoolsCount++;
             }
         }
@@ -805,7 +812,7 @@ const loadOperatorKeysFromRPC = async (
     }
 
     safeStatusCallback();
-    
+
     cachedLogger(`Total Sentry Keys fetched: ${nodeLicenseIds.length}.`);
     cachedLogger(`Fetched ${keysOfOwnersCount} keys of owners.`);
     cachedLogger(`Fetched ${Object.keys(sentryKeysMap).length - keysOfOwnersCount} keys of pools.`);
@@ -947,9 +954,9 @@ export async function operatorRuntime(
 
         const [latestChallengeNumber, latestChallenge] = await getLatestChallenge();
         await processNewChallenge(latestChallengeNumber, latestChallenge, nodeLicenseIds, sentryKeysMap);
-        
+
         closeChallengeListener = listenForChallenges(listenForChallengesCallback)
-        
+
         logFunction(`The operator has finished booting. The operator is running successfully. esXAI will accrue every few days.`);
     }
 

--- a/packages/core/src/operator/operatorRuntime.ts
+++ b/packages/core/src/operator/operatorRuntime.ts
@@ -73,7 +73,7 @@ const KEYS_PER_BATCH = 100;
 // const keyToOwner: { [keyId: string]: string } = {};
 let cachedOperatorWallets: string[];
 const mintTimestamps: { [nodeLicenseId: string]: bigint } = {};
-let cachedKeysOfOwner: { [keyId: string]: SentryKey } = {};
+let cachedKeysOfOwner: { [keyId: string]: SentryKey };
 
 const graphClient = new GraphQLClient(config.subgraphEndpoint);
 
@@ -603,7 +603,7 @@ const loadOperatorKeysFromGraph = async (
     mappedPools: { [poolAddress: string]: PoolInfo },
     refereeConfig: RefereeConfig
 }> => {
-    cachedLogger(`Getting all wallets assigned to the operator.`);
+    cachedLogger(`Loading all wallets assigned to the operator.`);
     if (passedInOwnersAndPools && passedInOwnersAndPools.length) {
         cachedLogger(`Operator owners were passed in.`);
     } else {
@@ -646,6 +646,7 @@ const loadOperatorKeysFromGraph = async (
     let keyOfPoolsCount = 0;
 
     const keyPools: Set<string> = new Set();
+    cachedKeysOfOwner = {}
 
     //Map the sentryKeys for use in operator
     //Create the updated nodeLicenseIds array
@@ -662,7 +663,11 @@ const loadOperatorKeysFromGraph = async (
             keyOfOwnerCount++;
         } else {
             keyPools.add(s.assignedPool);
-            keyOfPoolsCount++;
+            if(cachedOperatorWallets.includes(s.owner.toLowerCase())){
+                keyOfOwnerCount++;
+            }else{
+                keyOfPoolsCount++;
+            }
         }
         nodeLicenseStatusMap.set(BigInt(s.keyId), {
             ownerPublicKey: s.owner,
@@ -691,8 +696,10 @@ const loadOperatorKeysFromGraph = async (
     }
 
     safeStatusCallback();
+
     cachedLogger(`Total Sentry Keys fetched: ${nodeLicenseIds.length}.`);
-    cachedLogger(`Fetched ${keyOfOwnerCount} keys of owners and ${keyOfPoolsCount} keys staked in pools.`);
+    cachedLogger(`Fetched ${keyOfOwnerCount} keys of owners.`);
+    cachedLogger(`Fetched ${keyOfPoolsCount} keys of pools.`);
 
     return { wallets, sentryKeys, sentryWalletMap, sentryKeysMap, nodeLicenseIds, mappedPools, refereeConfig };
 }
@@ -716,20 +723,23 @@ const loadOperatorKeysFromRPC = async (
 
     //If we don't have the owners we fetch them from the RPC
     if (!cachedOperatorWallets) {
-        cachedLogger(`Getting all wallets assigned to the operator.`);
+        cachedLogger(`Loading all wallets assigned to the operator.`);
         //We need to get all approved owners so we can filter against pools
         const ownersForOperator = (await retry(async () => await listOwnersForOperator(operator))).map(o => o.toLowerCase());
+        cachedLogger(`Found associated owners: ${ownersForOperator.join(', ')}`);
+        cachedOperatorWallets = [operator.toLowerCase(), ...ownersForOperator];
         // get a list of all the owners that are added to this operator
         if (passedInOwnersAndPools && passedInOwnersAndPools.length) {
-            cachedLogger(`Operator owners were passed in.`);
-            cachedOperatorWallets = ownersForOperator.filter(o => passedInOwnersAndPools?.includes(o));
+            cachedLogger(`Operator owners were passed in. ${passedInOwnersAndPools.join(', ')}`);
+            cachedOperatorWallets = cachedOperatorWallets.filter(o => passedInOwnersAndPools?.includes(o));
         } else {
             cachedLogger(`No operator owners were passed in.`);
-            cachedOperatorWallets = [operator.toLowerCase(), ...ownersForOperator];
         }
     }
 
     owners = [...cachedOperatorWallets]
+    cachedLogger(`Found ${owners.length} operatorWallets. The addresses are: ${owners.join(', ')}`);
+
 
     const nodeLicenseIds: bigint[] = [];
     let sentryKeysMap: { [keyId: string]: SentryKey } = {}
@@ -740,7 +750,9 @@ const loadOperatorKeysFromRPC = async (
 
         for (const owner of owners) {
             cachedLogger(`Fetching node licenses for owner ${owner}.`);
-            const licensesOfOwner = await listNodeLicenses(owner);
+            const licensesOfOwner = await listNodeLicenses(owner, (keyId) => {
+                cachedLogger(`Fetched node licenses key ${keyId.toString()}.`);
+            });
 
             for (const licenseId of licensesOfOwner) {
 
@@ -769,6 +781,7 @@ const loadOperatorKeysFromRPC = async (
         sentryKeysMap = { ...cachedKeysOfOwner }
     }
 
+    const keysOfOwnersCount = Object.keys(sentryKeysMap).length;
     // Map the keys from pools our operator should operate, filter pools if passedInOwnersAndPools whitelist is enabled
     sentryKeysMap = await reloadPoolKeysForRPC(operator, sentryKeysMap, passedInOwnersAndPools);
 
@@ -792,6 +805,10 @@ const loadOperatorKeysFromRPC = async (
     }
 
     safeStatusCallback();
+    
+    cachedLogger(`Total Sentry Keys fetched: ${nodeLicenseIds.length}.`);
+    cachedLogger(`Fetched ${keysOfOwnersCount} keys of owners.`);
+    cachedLogger(`Fetched ${Object.keys(sentryKeysMap).length - keysOfOwnersCount} keys of pools.`);
 
     return { sentryKeysMap, nodeLicenseIds }
 }
@@ -886,11 +903,12 @@ export async function operatorRuntime(
     operatorAddress = await signer.getAddress();
     logFunction(`Fetched address of operator ${operatorAddress}.`);
 
-    const closeChallengeListener = listenForChallenges(listenForChallengesCallback);
+    let closeChallengeListener: () => void;
     logFunction(`Started listener for new challenges.`);
 
     const graphStatus = await getSubgraphHealthStatus();
     if (graphStatus.healthy) {
+        closeChallengeListener = listenForChallenges(listenForChallengesCallback)
 
         const openChallenge = await retry(() => getLatestChallengeFromGraph(graphClient));
         // Calculate the latest challenge we should load from the graph
@@ -924,11 +942,15 @@ export async function operatorRuntime(
 
     } else {
         cachedLogger(`Revert to RPC call instead of using subgraph. Subgraph status error: ${graphStatus.error}`)
-        const [latestChallengeNumber, latestChallenge] = await getLatestChallenge();
 
         const { sentryKeysMap, nodeLicenseIds } = await loadOperatorKeysFromRPC(operatorAddress);
 
+        const [latestChallengeNumber, latestChallenge] = await getLatestChallenge();
         await processNewChallenge(latestChallengeNumber, latestChallenge, nodeLicenseIds, sentryKeysMap);
+        
+        closeChallengeListener = listenForChallenges(listenForChallengesCallback)
+        
+        logFunction(`The operator has finished booting. The operator is running successfully. esXAI will accrue every few days.`);
     }
 
     const fetchBlockNumber = async () => {

--- a/packages/core/src/subgraph/getLatestChallengeFromGraph.ts
+++ b/packages/core/src/subgraph/getLatestChallengeFromGraph.ts
@@ -1,12 +1,13 @@
 import { Challenge } from "@sentry/sentry-subgraph-client";
 import { GraphQLClient, gql } from 'graphql-request'
+import { config } from "../config.js";
 
 /**
  * @returns The challenge entity from the graph.
  */
-export async function getLatestChallengeFromGraph(
-  client: GraphQLClient
-): Promise<Challenge> {
+export async function getLatestChallengeFromGraph(): Promise<Challenge> {
+
+  const client = new GraphQLClient(config.subgraphEndpoint);
 
   const query = gql`
       query ChallengeQuery {

--- a/packages/core/src/subgraph/getPoolInfosFromGraph.ts
+++ b/packages/core/src/subgraph/getPoolInfosFromGraph.ts
@@ -1,5 +1,6 @@
 import { PoolInfo, RefereeConfig } from "@sentry/sentry-subgraph-client";
 import { GraphQLClient, gql } from 'graphql-request'
+import { config } from "../config.js";
 
 /**
  * 
@@ -9,11 +10,12 @@ import { GraphQLClient, gql } from 'graphql-request'
  * @returns List of sentry key objects with metadata.
  */
 export async function getPoolInfosFromGraph(
-  client: GraphQLClient,
   poolAddresses: string[],
   extendPoolInfo?: boolean,
   fetchRefereeConfig?: boolean
 ): Promise<{ pools: PoolInfo[], refereeConfig?: RefereeConfig }> {
+
+  const client = new GraphQLClient(config.subgraphEndpoint);
 
   let extendedInfo = ""
   if (extendPoolInfo) {

--- a/packages/core/src/subgraph/getSentryKeysFromGraph.ts
+++ b/packages/core/src/subgraph/getSentryKeysFromGraph.ts
@@ -1,5 +1,6 @@
 import { SentryKey } from "@sentry/sentry-subgraph-client";
 import { GraphQLClient, gql } from 'graphql-request'
+import { config } from "../config.js";
 
 /**
  * 
@@ -10,13 +11,14 @@ import { GraphQLClient, gql } from 'graphql-request'
  * @returns List of sentry key objects with metadata.
  */
 export async function getSentryKeysFromGraph(
-  client: GraphQLClient,
   owners: string[],
   stakingPools: string[],
   includeSubmissions: boolean,
   submissionsFilter: { eligibleForPayout?: boolean, claimed?: boolean, latestChallengeNumber?: bigint }
 ): Promise<SentryKey[]> {
 
+  const client = new GraphQLClient(config.subgraphEndpoint);
+  
   let submissionQuery = ``;
   if (includeSubmissions) {
 

--- a/packages/core/src/subgraph/getSentryWalletsForOperator.ts
+++ b/packages/core/src/subgraph/getSentryWalletsForOperator.ts
@@ -8,14 +8,11 @@ import { config } from "../config.js";
  * @returns The SentryWallet entity from the graph
  */
 export async function getSentryWalletsForOperator(
-  client: GraphQLClient | null,
   operator: string,
   whitelist?: string[]
 ): Promise<{ wallets: SentryWallet[], pools: PoolInfo[], refereeConfig: RefereeConfig }> {
 
-  if (client == null) {
-    client = new GraphQLClient(config.subgraphEndpoint);
-  }
+  const client = new GraphQLClient(config.subgraphEndpoint);
 
   const query = gql`
     query OperatorAddresses {

--- a/packages/core/src/subgraph/getSubgraphHealthStatus.ts
+++ b/packages/core/src/subgraph/getSubgraphHealthStatus.ts
@@ -1,0 +1,39 @@
+import axios from "axios"
+
+/**
+ * 
+ * @returns Status and possible error from the graph version
+ */
+export async function getSubgraphHealthStatus(): Promise<{ healthy: boolean, error?: string }> {
+
+    try {
+        const url = `https://subgraph.satsuma-prod.com/f37507ea64fb/xai/sentry/status`;
+        const response = await axios.get(url);
+        if (response.status === 200) {
+            const status = response.data.data.indexingStatusForCurrentVersion.health;
+            if (status != "healthy") {
+                return {
+                    healthy: false,
+                    error: `Subgraph in invalid state (${status})`
+                }
+            }
+
+            return {
+                healthy: true
+            }
+
+
+        } else {
+            return {
+                healthy: false,
+                error: `Request for graph status failed with response status ${response.status}`
+            }
+        }
+    } catch (ex: any) {
+
+        return {
+            healthy: false,
+            error: `Something went wrong reading the graph status: ${ex && ex.message ? ex.message : ex}`
+        }
+    }
+}

--- a/packages/core/src/subgraph/index.ts
+++ b/packages/core/src/subgraph/index.ts
@@ -2,3 +2,4 @@ export * from "./getSentryWalletsForOperator.js";
 export * from "./getSentryKeysFromGraph.js";
 export * from "./getLatestChallengeFromGraph.js";
 export * from "./getPoolInfosFromGraph.js";
+export * from "./getSubgraphHealthStatus.js";


### PR DESCRIPTION
This will make the oeprator fallback to the RPC should the graph status not be healthy anymore.
This will also add a delay so that not all oeprators query the graph exactly at the same time when the challenge event gets emitted.