### PR TITLE
Fb export from graph

### DIFF
--- a/apps/cli/src/commands/export-challenge-info.ts
+++ b/apps/cli/src/commands/export-challenge-info.ts
@@ -1,0 +1,85 @@
+import { getChallengesFromGraph, retry } from "@sentry/core";
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Vorpal from "vorpal";
+
+/**
+ * Function to export the following info about all challenges as csv:
+ * - challengeNumber
+ * - timestamp
+ * - amountClaimedByClaimers
+ * - numberOfEligibleClaimers
+ * - submissions claimed
+ * - submissions total
+ * @param {Vorpal} cli - The Vorpal instance to attach the command to.
+ */
+export function exportChallengeInfo(cli: Vorpal) {
+    cli
+        .command('export-challenge-info', 'Exports information about all past challenges as csv.')
+        .action(async function (this: Vorpal.CommandInstance) {
+            const cmdInstance = this;
+
+            process.on('SIGINT', async () => {
+                cmdInstance.log(`The export has been terminated manually.`);
+                process.exit();
+            });
+
+            let offset = 0;
+            const tableRows = [];
+
+            let totalAmountForChallenges = 0n;
+            let totalAmountClaimedFromChallenges = 0n;
+            let totalAmountForSubsidy = 0n;
+
+            while (true) {
+                const challenges = await retry(() => getChallengesFromGraph(10, 10 * offset), 3);
+
+                if (challenges.length == 0) {
+                    this.log("Finished query from graph");
+                    break;
+                }
+
+                this.log(`Processing challenge ${challenges[0].challengeNumber} - ${(BigInt(challenges[0].challengeNumber) - BigInt(challenges.length)).toString()}...`);
+
+                for (let i = 0; i < challenges.length; i++) {
+                    const challenge = challenges[i];
+
+                    const tableRow = {
+                        challengeNumber: challenge.challengeNumber,
+                        timeStamp: `"${new Date(challenge.createdTimestamp * 1000).toLocaleString()}"`,
+                        amountClaimedByClaimers: BigInt(challenge.amountClaimedByClaimers) / BigInt(10 ** 18),
+                        rewardAmountForClaimers: BigInt(challenge.rewardAmountForClaimers) / BigInt(10 ** 18),
+                        amountForGasSubsidy: BigInt(challenge.amountForGasSubsidy) / BigInt(10 ** 18),
+                        numberOfEligibleClaimers: challenge.numberOfEligibleClaimers,
+                        submissionsClaimed: challenge.submissions.filter(s => s.claimed).length,
+                        submissionsTotal: challenge.submissions.length,
+                        numberOfUnclaimedSubmissions: challenge.submissions.filter(s => s.submittedFrom == "unclaimed").length,
+                        submissionsFromSingle: challenge.submissions.filter(s => s.submittedFrom == "submitAssertion").length,
+                        submissionsFromMultiple: challenge.submissions.filter(s => s.submittedFrom == "submitMultipleAssertions").length,
+                        claimFromSingle: challenge.submissions.filter(s => s.claimedFrom == "claimRewards").length,
+                        claimFromMultiple: challenge.submissions.filter(s => s.claimedFrom == "claimMultipleRewards").length
+                    }
+
+                    totalAmountForChallenges += BigInt(challenge.amountClaimedByClaimers) + BigInt(challenge.amountForGasSubsidy)
+                    totalAmountClaimedFromChallenges += BigInt(challenge.amountClaimedByClaimers)
+                    totalAmountForSubsidy += BigInt(challenge.amountForGasSubsidy)
+
+                    tableRows.push(tableRow);
+                }
+                offset++
+            }
+
+            const headers = Object.keys(tableRows[0]).join(',');
+            const rows = tableRows.map(obj => {
+                return Object.values(obj).join(',');
+            });
+            const csv = [headers, ...rows].join('\n');
+
+            const destination = path.join(os.homedir(), `challengesInfo-${Date.now()}.csv`);
+
+            fs.writeFileSync(destination, csv);
+
+            this.log(`CSV export has been saved to "${destination}"`);
+        });
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -46,7 +46,7 @@ import { startKycProcess } from './commands/kyc/start-kyc-process.js';
 import { generateRevenueReport } from './commands/licenses/generate-revenue-report.js';
 import { displayNodeAgreement } from './commands/display-node-agreement.js';
 import { startCentralizationRuntime } from './commands/start-centralization-runtime.js';
-
+import { exportChallengeInfo } from './commands/export-challenge-info.js';
 
 import {version} from "@sentry/core";
 
@@ -100,6 +100,7 @@ startKycProcess(cli);
 generateRevenueReport(cli);
 displayNodeAgreement(cli);
 startCentralizationRuntime(cli);
+exportChallengeInfo(cli);
 
 console.log(`Starting Sentry cli version ${version}`);
 console.log(`Stake and redeem esXAI at https://app.xai.games`);

--- a/infrastructure/sentry-subgraph/generated/schema.ts
+++ b/infrastructure/sentry-subgraph/generated/schema.ts
@@ -1054,6 +1054,32 @@ export class Submission extends Entity {
   set challenge(value: string) {
     this.set("challenge", Value.fromString(value));
   }
+
+  get submittedFrom(): string {
+    let value = this.get("submittedFrom");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toString();
+    }
+  }
+
+  set submittedFrom(value: string) {
+    this.set("submittedFrom", Value.fromString(value));
+  }
+
+  get claimedFrom(): string {
+    let value = this.get("claimedFrom");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toString();
+    }
+  }
+
+  set claimedFrom(value: string) {
+    this.set("claimedFrom", Value.fromString(value));
+  }
 }
 
 export class SentryWallet extends Entity {

--- a/infrastructure/sentry-subgraph/schema.graphql
+++ b/infrastructure/sentry-subgraph/schema.graphql
@@ -107,6 +107,18 @@ type Challenge @entity(immutable: false) {
   submissions: [Submission!]! @derivedFrom(field: "challenge")
 }
 
+enum SubmittedFrom {
+  submitAssertion
+  submitMultipleAssertions
+  unknown
+}
+
+enum ClaimedFrom {
+  claimRewards
+  claimMultipleRewards
+  unclaimed
+}
+
 type Submission @entity(immutable: false) {
   id: String!
   challengeNumber: BigInt!
@@ -121,6 +133,8 @@ type Submission @entity(immutable: false) {
   claimTxHash: Bytes!
   sentryKey: SentryKey!
   challenge: Challenge!
+  submittedFrom: SubmittedFrom!
+  claimedFrom: ClaimedFrom!
 }
 
 type SentryWallet @entity(immutable: false) {

--- a/infrastructure/sentry-subgraph/schema/events/Referee.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/Referee.graphql
@@ -23,6 +23,18 @@ type Challenge @entity(immutable: false) {
   submissions: [Submission!]! @derivedFrom(field: "challenge")
 }
 
+enum SubmittedFrom {
+  submitAssertion
+  submitMultipleAssertions
+  unknown
+}
+
+enum ClaimedFrom {
+  claimRewards
+  claimMultipleRewards
+  unclaimed
+}
+
 type Submission @entity(immutable: false) {
   id: String!
   challengeNumber: BigInt!
@@ -37,6 +49,8 @@ type Submission @entity(immutable: false) {
   claimTxHash: Bytes!
   sentryKey: SentryKey!
   challenge: Challenge!
+  submittedFrom: SubmittedFrom!
+  claimedFrom: ClaimedFrom!
 }
 
 type SentryWallet @entity(immutable: false) {

--- a/packages/core/src/subgraph/getChallengesFromGraph.ts
+++ b/packages/core/src/subgraph/getChallengesFromGraph.ts
@@ -1,0 +1,38 @@
+import { Challenge } from "@sentry/sentry-subgraph-client";
+import { GraphQLClient, gql } from 'graphql-request'
+import { config } from "../config.js";
+
+/**
+ * @returns The challenge entity from the graph.
+ */
+export async function getChallengesFromGraph(
+  first: number = 1,
+  skip: number = 0
+): Promise<Challenge[]> {
+
+  const client = new GraphQLClient(config.subgraphEndpoint);
+  const query = gql`
+    query Challenges {
+      challenges(first: ${first}, skip: ${skip}, orderBy: challengeNumber, orderDirection: desc) {
+        amountClaimedByClaimers
+        challengeNumber
+        numberOfEligibleClaimers
+        createdTimestamp
+        amountForGasSubsidy
+        rewardAmountForClaimers
+        submissions(first: 5000, orderBy: nodeLicenseId, orderDirection: asc) {
+          claimed
+          eligibleForPayout
+          createdTxHash
+          claimTxHash
+          nodeLicenseId
+          submittedFrom
+          claimedFrom
+        }
+      }
+    }
+  `
+
+  const result = await client.request(query) as any;
+  return result.challenges;
+}

--- a/packages/core/src/subgraph/index.ts
+++ b/packages/core/src/subgraph/index.ts
@@ -3,3 +3,4 @@ export * from "./getSentryKeysFromGraph.js";
 export * from "./getLatestChallengeFromGraph.js";
 export * from "./getPoolInfosFromGraph.js";
 export * from "./getSubgraphHealthStatus.js";
+export * from "./getChallengesFromGraph.js";


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/187606168

This has the udpated subgraph syncing script with the submittedFrom and claimedFrom fields to every submission.

Subgraph is currently syncing (v 1.1.10)
https://subgraphs.alchemy.com/subgraphs/4740/versions/19992

Once the subgraph is synced, the export script can be run with the updated subgraph endpoint for the extended challenge info