### PR TITLE
fix operator runtime bug loading all pools on start

### DIFF
--- a/apps/cli/src/commands/operator-control/operator-runtime.ts
+++ b/apps/cli/src/commands/operator-control/operator-runtime.ts
@@ -66,13 +66,17 @@ export function bootOperator(cli: Vorpal) {
                     choices,
                 };
 
-                const result = await this.prompt(ownerPrompt);
-                selectedOwners = result.selectedOwners;
+                if (!choices.length) {
+                    throw new Error(`No operatorWallets found for publicKey: ${operatorAddress}, approve your wallet for operating keys or delegate it to a staking pool to operate for it.`)
+                } else {
+                    const result = await this.prompt(ownerPrompt);
+                    selectedOwners = result.selectedOwners;
 
-                Logger.log("selectedOwners", selectedOwners);
+                    Logger.log("selectedOwners", selectedOwners);
 
-                if (!selectedOwners || selectedOwners.length < 1) {
-                    throw new Error("No owners selected. Please select at least one owner.")
+                    if (!selectedOwners || selectedOwners.length < 1) {
+                        throw new Error("No owners selected. Please select at least one owner.")
+                    }
                 }
             }
 

--- a/packages/core/src/operator/operatorRuntime.ts
+++ b/packages/core/src/operator/operatorRuntime.ts
@@ -618,9 +618,17 @@ const loadOperatorKeysFromGraph = async (
     // refereeConfig will be used to locally calculate the boos factor (hold tier thresholds and boostFactors as well as max staking capacity per key)
     const { wallets, pools, refereeConfig } = await retry(() => getSentryWalletsForOperator(operator, passedInOwnersAndPools));
 
+    if (wallets.length == 0 && pools.length == 0) {
+        cachedLogger(`No operatorWallets found, approve your wallet for operating keys or delegate it to a staking pool to operate for it.`);
+        return { wallets: [], sentryKeys: [], sentryWalletMap: {}, sentryKeysMap: {}, nodeLicenseIds: [], mappedPools: {}, refereeConfig };
+    }
+
+    if (wallets.length > 0) {
+        cachedLogger(`Found ${wallets.length} operatorWallets. The addresses are: ${wallets.map(w => w.address).join(', ')}`);
+    }
+
     const mappedPools: { [poolAddress: string]: PoolInfo } = {};
 
-    cachedLogger(`Found ${wallets.length} operatorWallets. The addresses are: ${wallets.map(w => w.address).join(', ')}`);
     if (pools.length) {
         pools.forEach(p => { mappedPools[p.address] = p });
         cachedLogger(`Found ${pools.length} pools. The addresses are: ${Object.keys(mappedPools).join(', ')}`);


### PR DESCRIPTION
For https://www.pivotaltracker.com/n/projects/2671427/stories/187837196

If the operator wallet does not have any reference on the subgraph we would currently load all the keys from all pools we get in one subgraph query. This resulted in the desktop app running for 8K keys by default on a fresh install.

Also fixes the whitelist feature in the cli for the same reasons.