### PR TITLE
fix: fixed reedem cancel button

### DIFF
--- a/apps/web-staking/src/app/components/redeem/History.tsx
+++ b/apps/web-staking/src/app/components/redeem/History.tsx
@@ -175,7 +175,8 @@ export default function History({ redemptions, reloadRedemptions }: {
 	const updateOnSuccess = useCallback(() => {
 		updateNotification(isCancel ? 'Cancel successful' : `Claim successful`, toastId.current as Id, false, receipt, chainId);
 		reloadRedemptions();
-	}, [isCancel, receipt, chainId, reloadRedemptions])
+		isCancel && setIsCancel(false);
+	}, [receipt, chainId, reloadRedemptions])
 
 	const updateOnError = useCallback(() => {
 		const error = mapWeb3Error(status);


### PR DESCRIPTION
Copy from https://github.com/CryptITAustria/sentry/pull/53

Added clearing of isCancel state after useWaitForTransactionReceipt returns new isSuccess state. Also removed isCancel state from updateOnSuccess dependecies array to avoid incorrect notifications.
task: https://www.pivotaltracker.com/story/show/187790660