### PR TITLE
Remove KYC From Operator & Sub-graph on claim

### DIFF
--- a/infrastructure/sentry-subgraph/schema.graphql
+++ b/infrastructure/sentry-subgraph/schema.graphql
@@ -37,10 +37,10 @@ type SentryKey @entity(immutable: false) {
 ######################################################################
 type PoolInfo @entity(immutable: false) {
   id: String!
-  address: Bytes!
+  address: Bytes! @index
   owner: Bytes!
   delegateAddress: Bytes!
-  totalStakedEsXaiAmount: BigInt!
+  totalStakedEsXaiAmount: BigInt! @index
   totalStakedKeyAmount: BigInt!
   ownerShare: BigInt!
   keyBucketShare: BigInt!
@@ -81,7 +81,7 @@ type PoolFactoryConfig @entity(immutable: false) {
 type PoolChallenge @entity(immutable: false) {
   id: String!
   pool: PoolInfo!
-  challenge: Challenge!
+  challenge: Challenge! @index
   submittedKeyCount: BigInt!
   claimKeyCount: BigInt!
   totalStakedEsXaiAmount: BigInt!
@@ -102,11 +102,11 @@ enum ChallengeStatus {
 
 type Challenge @entity(immutable: false) {
   id: String!
-  challengeNumber: BigInt! # uint256
+  challengeNumber: BigInt! @index # uint256
   status: ChallengeStatus!
   assertionId: BigInt! # uint256
   assertionStateRootOrConfirmData: Bytes! # bytes
-  assertionTimestamp: BigInt! # uint64
+  assertionTimestamp: BigInt! @index # uint64
   challengerSignedHash: Bytes! # bytes
   activeChallengerPublicKey: Bytes! # bytes
   rollupUsed: Bytes! # address
@@ -136,7 +136,7 @@ type Submission @entity(immutable: false) {
   challengeNumber: BigInt!
   claimed: Boolean!
   eligibleForPayout: Boolean!
-  nodeLicenseId: BigInt! 
+  nodeLicenseId: BigInt!
   assertionsStateRootOrConfirmData: String!
   claimAmount: BigInt!
   createdTimestamp: BigInt!
@@ -152,7 +152,7 @@ type Submission @entity(immutable: false) {
 type SentryWallet @entity(immutable: false) {
   id: String!
   isKYCApproved: Boolean!
-  address: Bytes!
+  address: Bytes! @index
   approvedOperators: [Bytes!]!
   v1EsXaiStakeAmount: BigInt!
   esXaiStakeAmount: BigInt!

--- a/infrastructure/sentry-subgraph/schema/events/PoolFactory.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/PoolFactory.graphql
@@ -1,9 +1,9 @@
 type PoolInfo @entity(immutable: false) {
   id: String!
-  address: Bytes!
+  address: Bytes! @index
   owner: Bytes!
   delegateAddress: Bytes!
-  totalStakedEsXaiAmount: BigInt!
+  totalStakedEsXaiAmount: BigInt! @index
   totalStakedKeyAmount: BigInt!
   ownerShare: BigInt!
   keyBucketShare: BigInt!
@@ -44,7 +44,7 @@ type PoolFactoryConfig @entity(immutable: false) {
 type PoolChallenge @entity(immutable: false) {
   id: String!
   pool: PoolInfo!
-  challenge: Challenge!
+  challenge: Challenge! @index
   submittedKeyCount: BigInt!
   claimKeyCount: BigInt!
   totalStakedEsXaiAmount: BigInt!

--- a/infrastructure/sentry-subgraph/schema/events/Referee.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/Referee.graphql
@@ -6,11 +6,11 @@ enum ChallengeStatus {
 
 type Challenge @entity(immutable: false) {
   id: String!
-  challengeNumber: BigInt! # uint256
+  challengeNumber: BigInt! @index # uint256
   status: ChallengeStatus!
   assertionId: BigInt! # uint256
   assertionStateRootOrConfirmData: Bytes! # bytes
-  assertionTimestamp: BigInt! # uint64
+  assertionTimestamp: BigInt! @index # uint64
   challengerSignedHash: Bytes! # bytes
   activeChallengerPublicKey: Bytes! # bytes
   rollupUsed: Bytes! # address
@@ -56,7 +56,7 @@ type Submission @entity(immutable: false) {
 type SentryWallet @entity(immutable: false) {
   id: String!
   isKYCApproved: Boolean!
-  address: Bytes!
+  address: Bytes! @index
   approvedOperators: [Bytes!]!
   v1EsXaiStakeAmount: BigInt!
   esXaiStakeAmount: BigInt!

--- a/packages/core/src/operator/operatorRuntime.ts
+++ b/packages/core/src/operator/operatorRuntime.ts
@@ -373,44 +373,15 @@ async function processClosedChallenges(
             }
 
             updateNodeLicenseStatus(nodeLicenseId, `Checking KYC Status`);
-            safeStatusCallback();
+            safeStatusCallback();  
 
-            let isKYC: boolean = false;
-            if (sentryWalletMap) {
-                isKYC = sentryWalletMap[sentryKey.owner].isKYCApproved;
-            } else {
-                //If we are running on RPC we should not check every single pool key that did not come from an owner for KYC. 
-                //The Referee will let the transaction go through but won't claim
-                if (sentryKey.assignedPool != "0x") {
-                    isKYC = true;
-                } else {
-                    //Cache KYC status on owner basis for each challenge
-                    if (ownerKYCStatus[sentryKey.owner] === undefined) {
-                        const [{ isKycApproved }] = await retry(async () => await checkKycStatus([sentryKey.owner]));
-                        ownerKYCStatus[sentryKey.owner] = isKycApproved
-                    }
-                    isKYC = ownerKYCStatus[sentryKey.owner];
-                }
+            if (!challengeToEligibleNodeLicensesMap.has(challengeId)) {
+                challengeToEligibleNodeLicensesMap.set(challengeId, []);
             }
+            challengeToEligibleNodeLicensesMap.get(challengeId)?.push(BigInt(nodeLicenseId));
 
-            if (isKYC) {
-                if (!challengeToEligibleNodeLicensesMap.has(challengeId)) {
-                    challengeToEligibleNodeLicensesMap.set(challengeId, []);
-                }
-                challengeToEligibleNodeLicensesMap.get(challengeId)?.push(BigInt(nodeLicenseId));
-
-                updateNodeLicenseStatus(nodeLicenseId, `Claiming esXAI...`);
-                safeStatusCallback();
-            } else {
-
-                if (!nonKYCWallets[sentryKey.owner]) {
-                    nonKYCWallets[sentryKey.owner] = 0;
-                }
-                nonKYCWallets[sentryKey.owner]++;
-
-                updateNodeLicenseStatus(nodeLicenseId, `Cannot Claim, Failed KYC`);
-                safeStatusCallback();
-            }
+            updateNodeLicenseStatus(nodeLicenseId, `Claiming esXAI...`);
+            safeStatusCallback();  
 
         } catch (error: any) {
             cachedLogger(`Error processing submissions for Sentry Key ${nodeLicenseId} - ${error && error.message ? error.message : error}`);

--- a/packages/core/src/operator/operatorRuntime.ts
+++ b/packages/core/src/operator/operatorRuntime.ts
@@ -372,9 +372,6 @@ async function processClosedChallenges(
                 continue;
             }
 
-            updateNodeLicenseStatus(nodeLicenseId, `Checking KYC Status`);
-            safeStatusCallback();  
-
             if (!challengeToEligibleNodeLicensesMap.has(challengeId)) {
                 challengeToEligibleNodeLicensesMap.set(challengeId, []);
             }

--- a/packages/core/src/operator/operatorRuntime.ts
+++ b/packages/core/src/operator/operatorRuntime.ts
@@ -385,13 +385,15 @@ async function processClosedChallenges(
         }
     }
 
-    const nonKYC = Object.keys(nonKYCWallets);
-    if (nonKYC.length) {
-        cachedLogger(`Failed KYC check for ${nonKYC.length} owners: `);
-        nonKYC.forEach(w => {
-            cachedLogger(`${w} (${nonKYCWallets[w]} keys)`);
-        })
-    }
+    // Leaving temporarily in case we decide to handle failed KYC wallets differently
+    //  Story ID: 187790951
+    // const nonKYC = Object.keys(nonKYCWallets);
+    // if (nonKYC.length) {
+    //     cachedLogger(`Failed KYC check for ${nonKYC.length} owners: `);
+    //     nonKYC.forEach(w => {
+    //         cachedLogger(`${w} (${nonKYCWallets[w]} keys)`);
+    //     })
+    // }
 
     // Iterate over the map and call processClaimForChallenge for each challenge with its unique list of eligible nodeLicenseIds
     for (const [challengeId, nodeLicenseIds] of challengeToEligibleNodeLicensesMap) {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187742159

Remove KYC check on claim from Operator Runtime(Core) and sub-graph.

Notes:
Subgraph removal required referee version checking.
Added the https://github.com/Index param to a few graphQL fields to improve query speeds.

New subgraph deployed and syncing here: https://subgraph.satsuma-prod.com/xai/sentry/version/v1.1.14/api