### PR TITLE
Fb tiny keys subgraph pool submissions

### DIFF
--- a/infrastructure/sentry-subgraph/schema/events/Referee.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/Referee.graphql
@@ -81,4 +81,5 @@ type PoolSubmission @entity(immutable: false) {
   winningKeyCount: BigInt!
   claimedRewardsAmount: BigInt!
   poolAddress: Bytes!
+  claimed: Boolean!
 }

--- a/infrastructure/sentry-subgraph/schema/events/Referee.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/Referee.graphql
@@ -73,3 +73,12 @@ type RefereeConfig @entity(immutable: false) {
   stakeAmountTierThresholds: [BigInt!]!
   stakeAmountBoostFactors: [BigInt!]!
 }
+
+type PoolSubmission @entity(immutable: false) {
+  id: String!
+  challengeId: BigInt!
+  stakedKeyCount: BigInt!
+  winningKeyCount: BigInt!
+  claimedRewardsAmount: BigInt!
+  poolAddress: Bytes!
+}

--- a/infrastructure/sentry-subgraph/src/referee.ts
+++ b/infrastructure/sentry-subgraph/src/referee.ts
@@ -491,32 +491,40 @@ export function handleUnstakeV1(event: UnstakeV1): void {
   sentryWallet.save()
 }
 
-export function handleNewPoolSubmission(event: NewPoolSubmission): void {
+export function handleNewPoolSubmission(event: NewPoolSubmissionEvent): void {
   let poolSubmission = new PoolSubmission(event.params.challengeId.toHexString() + event.params.poolAddress.toHexString())
   poolSubmission.challengeId = event.params.challengeId
   poolSubmission.stakedKeyCount = event.params.stakedKeys
   poolSubmission.winningKeyCount = event.params.winningKeys
-  poolSubmission.claimedRewardsAmount = 0
+  poolSubmission.claimedRewardsAmount = BigInt.fromI32(0)
   poolSubmission.poolAddress = event.params.poolAddress
+  poolSubmission.save()
 }
 
-export function handleUpdatePoolSubmission(event: UpdatePoolSubmission): void {
+export function handleUpdatePoolSubmission(event: UpdatePoolSubmissionEvent): void {
   let poolSubmission = PoolSubmission.load(event.params.challengeId.toHexString() + event.params.poolAddress.toHexString())
   if (!poolSubmission) {
     poolSubmission = new PoolSubmission(event.params.challengeId.toHexString() + event.params.poolAddress.toHexString())
     poolSubmission.challengeId = event.params.challengeId
     poolSubmission.stakedKeyCount = event.params.stakedKeys
     poolSubmission.winningKeyCount = event.params.winningKeys
-    poolSubmission.claimedRewardsAmount = 0
+    poolSubmission.claimedRewardsAmount = BigInt.fromI32(0)
     poolSubmission.poolAddress = event.params.poolAddress
+  } else {
+    poolSubmission.stakedKeyCount = event.params.stakedKeys
+    poolSubmission.winningKeyCount = event.params.winningKeys
   }
+  poolSubmission.save()
+
+
 }
 
-export function handlePoolRewardsClaimed(event: PoolRewardsClaimed): void {
+export function handlePoolRewardsClaimed(event: PoolRewardsClaimedEvent): void {
   let poolSubmission = PoolSubmission.load(event.params.challengeId.toHexString() + event.params.poolAddress.toHexString())
   if (!poolSubmission) {
     log.warning("Failed to find poolSubmission on PoolRewardsClaimed TX: " + event.transaction.hash.toHexString(), [])
     return
   }
   poolSubmission.claimedRewardsAmount = event.params.totalReward
+  poolSubmission.save()
 }

--- a/infrastructure/sentry-subgraph/src/referee.ts
+++ b/infrastructure/sentry-subgraph/src/referee.ts
@@ -490,3 +490,33 @@ export function handleUnstakeV1(event: UnstakeV1): void {
   sentryWallet.v1EsXaiStakeAmount = event.params.totalStaked
   sentryWallet.save()
 }
+
+export function handleNewPoolSubmission(event: NewPoolSubmission): void {
+  let poolSubmission = new PoolSubmission(event.params.challengeId.toHexString() + event.params.poolAddress.toHexString())
+  poolSubmission.challengeId = event.params.challengeId
+  poolSubmission.stakedKeyCount = event.params.stakedKeys
+  poolSubmission.winningKeyCount = event.params.winningKeys
+  poolSubmission.claimedRewardsAmount = 0
+  poolSubmission.poolAddress = event.params.poolAddress
+}
+
+export function handleUpdatePoolSubmission(event: UpdatePoolSubmission): void {
+  let poolSubmission = PoolSubmission.load(event.params.challengeId.toHexString() + event.params.poolAddress.toHexString())
+  if (!poolSubmission) {
+    poolSubmission = new PoolSubmission(event.params.challengeId.toHexString() + event.params.poolAddress.toHexString())
+    poolSubmission.challengeId = event.params.challengeId
+    poolSubmission.stakedKeyCount = event.params.stakedKeys
+    poolSubmission.winningKeyCount = event.params.winningKeys
+    poolSubmission.claimedRewardsAmount = 0
+    poolSubmission.poolAddress = event.params.poolAddress
+  }
+}
+
+export function handlePoolRewardsClaimed(event: PoolRewardsClaimed): void {
+  let poolSubmission = PoolSubmission.load(event.params.challengeId.toHexString() + event.params.poolAddress.toHexString())
+  if (!poolSubmission) {
+    log.warning("Failed to find poolSubmission on PoolRewardsClaimed TX: " + event.transaction.hash.toHexString(), [])
+    return
+  }
+  poolSubmission.claimedRewardsAmount = event.params.totalReward
+}

--- a/infrastructure/sentry-subgraph/src/referee.ts
+++ b/infrastructure/sentry-subgraph/src/referee.ts
@@ -498,6 +498,7 @@ export function handleNewPoolSubmission(event: NewPoolSubmissionEvent): void {
   poolSubmission.winningKeyCount = event.params.winningKeys
   poolSubmission.claimedRewardsAmount = BigInt.fromI32(0)
   poolSubmission.poolAddress = event.params.poolAddress
+  poolSubmission.claimed = false
   poolSubmission.save()
 }
 
@@ -510,13 +511,12 @@ export function handleUpdatePoolSubmission(event: UpdatePoolSubmissionEvent): vo
     poolSubmission.winningKeyCount = event.params.winningKeys
     poolSubmission.claimedRewardsAmount = BigInt.fromI32(0)
     poolSubmission.poolAddress = event.params.poolAddress
+    poolSubmission.claimed = false
   } else {
     poolSubmission.stakedKeyCount = event.params.stakedKeys
     poolSubmission.winningKeyCount = event.params.winningKeys
   }
   poolSubmission.save()
-
-
 }
 
 export function handlePoolRewardsClaimed(event: PoolRewardsClaimedEvent): void {
@@ -526,5 +526,6 @@ export function handlePoolRewardsClaimed(event: PoolRewardsClaimedEvent): void {
     return
   }
   poolSubmission.claimedRewardsAmount = event.params.totalReward
+  poolSubmission.claimed = true
   poolSubmission.save()
 }


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/n/projects/2671427/stories/187869828
- Add new entity for poolSubmission
- Add new events UpdatePoolSubmissionEvent, NewPoolSubmissionEvent, PoolRewardsClaimedEvent
- Did not update existing events: As in updated contract assigned keys do not trigger the events
- [Blocker] upgrade referee not deployable as to big, cannot get event signature

Answered Questions from task:
additional fields: claimed, createdTimestamp, claimTimestamp, createdTxHash, claimTxHash, sentryKey, challenge
Would consider an additional task for the queries, as currently there is no synced graph to test