### PR TITLE
Move Key Stake Functions to Pool Factory

### DIFF
--- a/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
@@ -562,7 +562,6 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
             referee.unstakeKey(pool, msg.sender, keyId, keyHasSubmitted, poolHasSubmitted);
         }
 
-        Referee9A(refereeAddress).unstakeKeys(pool, msg.sender, keyIds);
         StakingPool stakingPool = StakingPool(pool);
         stakingPool.unstakeKeys(msg.sender, unstakeRequestIndex, keyIds);
 

--- a/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
@@ -7,9 +7,10 @@ import "@openzeppelin/contracts-upgradeable/utils/structs/EnumerableSetUpgradeab
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
-import "../../upgrades/referee/Referee9.sol";
+import "../../upgrades/referee/Referee9A.sol";
 import "../../Xai.sol";
 import "../../upgrades/esXai/esXai2.sol";
+import "../../upgrades/node-license/NodeLicense8.sol";
 import "../../staking-v2/StakingPool.sol";
 import "../../staking-v2/PoolProxyDeployer.sol";
 import "../../staking-v2/PoolBeacon.sol";
@@ -396,7 +397,23 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         address staker,
         bool _asAdmin
     ) internal {
-        Referee9(refereeAddress).stakeKeys(pool, staker, keyIds, _asAdmin);
+        Referee9A referee = Referee9A(refereeAddress);
+        NodeLicense8 nodeLicenseContract = NodeLicense8(nodeLicenseAddress);
+        require(_asAdmin || referee.stakingEnabled(), "52");        
+        uint256 keysLength = keyIds.length;
+        uint256 currentStakedKeyCount = referee.assignedKeysToPoolCount(pool);
+        require(currentStakedKeyCount + keysLength <= referee.maxKeysPerPool(), "43");
+
+        for (uint256 i = 0; i < keysLength; i++) {
+            uint256 keyId = keyIds[i];
+            require(referee.assignedKeyToPool(keyId) == address(0), "44");
+            require(nodeLicenseContract.ownerOf(keyId) == staker, "45");
+            (bool keyHasSubmitted, , , , ) = referee.submissions(referee.challengeCounter(), keyId);
+            (bool poolHasSubmitted, , , , , ) = referee.poolSubmissions(referee.challengeCounter(), pool);
+            referee.stakeKey(pool, staker, keyId, keyHasSubmitted, poolHasSubmitted);
+        }
+
+
         StakingPool stakingPool = StakingPool(pool);
         stakingPool.stakeKeys(staker, keyIds);
 
@@ -529,9 +546,23 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         uint256 unstakeRequestIndex,
         uint256[] memory keyIds
     ) external {
+        NodeLicense8 nodeLicenseContract = NodeLicense8(nodeLicenseAddress);
+        Referee9A referee = Referee9A(refereeAddress);
+
         require(poolsCreatedViaFactory[pool], "23"); // Pool must be created via factory
 
-        Referee9(refereeAddress).unstakeKeys(pool, msg.sender, keyIds);
+        uint256 keysLength = keyIds.length;
+
+        for (uint256 i = 0; i < keysLength; i++) {
+            uint256 keyId = keyIds[i];
+            require(referee.assignedKeyToPool(keyId) == pool, "47");
+            require(nodeLicenseContract.ownerOf(keyId) == msg.sender, "45");
+            (bool keyHasSubmitted, , , , ) = referee.submissions(referee.challengeCounter(), keyId);
+            (bool poolHasSubmitted, , , , , ) = referee.poolSubmissions(referee.challengeCounter(), pool);
+            referee.unstakeKey(pool, msg.sender, keyId, keyHasSubmitted, poolHasSubmitted);
+        }
+
+        Referee9A(refereeAddress).unstakeKeys(pool, msg.sender, keyIds);
         StakingPool stakingPool = StakingPool(pool);
         stakingPool.unstakeKeys(msg.sender, unstakeRequestIndex, keyIds);
 
@@ -556,7 +587,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
     function stakeEsXai(address pool, uint256 amount) external {
         require(poolsCreatedViaFactory[pool], "27"); // Pool must be created via factory
 
-        Referee9(refereeAddress).stakeEsXai(pool, amount);
+        Referee9A(refereeAddress).stakeEsXai(pool, amount);
         esXai(esXaiAddress).transferFrom(msg.sender, address(this), amount);
         StakingPool stakingPool = StakingPool(pool);
         stakingPool.stakeEsXai(msg.sender, amount);
@@ -568,7 +599,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
             pool,
             amount,
             stakingPool.getStakedAmounts(msg.sender),
-            Referee9(refereeAddress).stakedAmounts(pool)
+            Referee9A(refereeAddress).stakedAmounts(pool)
         );
     }
 
@@ -586,7 +617,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         require(poolsCreatedViaFactory[pool], "28"); // Pool must be created via factory
 
         esXai(esXaiAddress).transfer(msg.sender, amount);
-        Referee9(refereeAddress).unstakeEsXai(pool, amount);
+        Referee9A(refereeAddress).unstakeEsXai(pool, amount);
         StakingPool stakingPool = StakingPool(pool);
         stakingPool.unstakeEsXai(msg.sender, unstakeRequestIndex, amount);
 
@@ -599,7 +630,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
             pool,
             amount,
             stakingPool.getStakedAmounts(msg.sender),
-            Referee9(refereeAddress).stakedAmounts(pool)
+            Referee9A(refereeAddress).stakedAmounts(pool)
         );
     }
 
@@ -752,7 +783,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
                 i
             );
             if (
-                Referee9(refereeAddress).assignedKeyToPool(keyId) == address(0)
+                Referee9A(refereeAddress).assignedKeyToPool(keyId) == address(0)
             ) {
                 unstakedKeyIds[currentIndexUnstaked] = keyId;
                 currentIndexUnstaked++;
@@ -771,7 +802,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         isStaked = new bool[](keyIds.length);
         for (uint256 i; i < keyIds.length; i++) {
             isStaked[i] =
-                Referee9(refereeAddress).assignedKeyToPool(keyIds[i]) !=
+                Referee9A(refereeAddress).assignedKeyToPool(keyIds[i]) !=
                 address(0);
         }
     }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187900838
https://www.pivotaltracker.com/story/show/187900825

Moved key staking logic from Referee to Pool Factory. 

Note, I did not move the stake/unstake esXai to Pool Factory as they are only 2 line functions.