### PR TITLE
Operator - fixed sentry wallet page modal and scrolling

### DIFF
--- a/apps/sentry-client-desktop/src/features/home/SentryWallet.tsx
+++ b/apps/sentry-client-desktop/src/features/home/SentryWallet.tsx
@@ -198,9 +198,6 @@ export function SentryWallet() {
 		void queryClient.invalidateQueries({queryKey: ["ownersForOperator", operatorAddress]});
 	}
 
-	console.log('funded', funded)
-	console.log('hasAssignedKeys', hasAssignedKeys)
-
 	return (
 		<>
 			{assignedWallet.show && (

--- a/apps/sentry-client-desktop/src/features/home/modals/WalletConnectedModal.tsx
+++ b/apps/sentry-client-desktop/src/features/home/modals/WalletConnectedModal.tsx
@@ -1,6 +1,7 @@
 import {FaCircleCheck} from "react-icons/fa6";
 import {AiOutlineClose} from "react-icons/ai";
 import {useProvider} from "@/hooks/useProvider";
+import {useEffect} from "react";
 
 interface WalletConnectedModalProps {
 	txHash: string;
@@ -10,26 +11,37 @@ interface WalletConnectedModalProps {
 export function WalletConnectedModal({txHash, onClose}: WalletConnectedModalProps) {
 	const {data: providerData} = useProvider();
 
+	useEffect(() => {
+
+		document.body.style.overflow = "hidden";
+
+		return () => {
+			document.body.style.overflow = "visible"
+		}
+
+	}, []);
+
 	return (
 		<div
-			className="absolute top-0 right-0 left-0 bottom-0 m-auto w-auto h-auto flex flex-col justify-start items-center z-30">
-			<div className="w-full h-full bg-white opacity-75"/>
+			className="fixed top-0 right-0 left-0 bottom-0 m-auto w-auto h-auto flex flex-col justify-start items-center z-30">
+			<div className="w-full h-full bg-black opacity-75"/>
 			<div
-				className="absolute top-0 right-0 left-0 bottom-0 m-auto flex flex-col justify-start items-center w-[506px] h-[190px] border border-gray-200 bg-white">
+				className="fixed top-0 right-0 left-0 bottom-0 m-auto flex flex-col justify-start items-center w-[692px] h-[200px] bg-black">
 				<div
 					className="absolute top-0 right-0 h-16 flex flex-row justify-between items-center text-lg px-6">
 					<div className="cursor-pointer z-10" onClick={onClose}>
-						<AiOutlineClose/>
+						<AiOutlineClose size={24} color="white"
+										className="hover:!text-hornetSting duration-300 ease-in"/>
 					</div>
 				</div>
 				<div
 					className="absolute top-0 bottom-0 left-0 right-0 m-auto flex flex-col justify-center items-center gap-4">
 					<FaCircleCheck color={"#16A34A"} size={32}/>
-					<span className="text-xl font-semibold text-center">Wallet assigned</span>
-					<span className="text-[15px] text-center">Transaction ID:
+					<span className="text-2xl font-bold text-white text-center">Wallet assigned</span>
+					<span className="text-elementalGrey text-[17px] font-medium text-center">Transaction ID:
 						<a
 							onClick={() => window.electron.openExternal(`${providerData?.blockExplorer}/tx/${txHash}`)}
-							className="text-[#F30919] ml-1 cursor-pointer"
+							className="text-[#F30919] text-[17px] font-semibold ml-1 cursor-pointer"
 						>
 							{txHash.slice(0, 10) + "..."}
 						</a>

--- a/apps/sentry-client-desktop/src/features/home/modals/WalletDisconnectedModal.tsx
+++ b/apps/sentry-client-desktop/src/features/home/modals/WalletDisconnectedModal.tsx
@@ -1,6 +1,7 @@
 import {FaCircleCheck} from "react-icons/fa6";
 import {AiOutlineClose} from "react-icons/ai";
 import {useProvider} from "@/hooks/useProvider";
+import {useEffect} from "react";
 
 interface WalletConnectedModalProps {
 	txHash: string;
@@ -10,23 +11,34 @@ interface WalletConnectedModalProps {
 export function WalletDisconnectedModal({txHash, onClose}: WalletConnectedModalProps) {
 	const {data: providerData} = useProvider();
 
+	useEffect(() => {
+
+		document.body.style.overflow = "hidden";
+
+		return () => {
+			document.body.style.overflow = "visible"
+		}
+
+	}, []);
+
 	return (
 		<div
-			className="absolute top-0 right-0 left-0 bottom-0 m-auto w-auto h-auto flex flex-col justify-start items-center z-30">
-			<div className="w-full h-full bg-white opacity-75"/>
+			className="fixed top-0 right-0 left-0 bottom-0 m-auto w-auto h-auto flex flex-col justify-start items-center z-30">
+			<div className="w-full h-full bg-black opacity-75"/>
 			<div
-				className="absolute top-0 right-0 left-0 bottom-0 m-auto flex flex-col justify-start items-center w-[506px] h-[190px] border border-gray-200 bg-white">
+				className="fixed top-0 right-0 left-0 bottom-0 m-auto flex flex-col justify-start items-center w-[692px] h-[200px] bg-black">
 				<div
 					className="absolute top-0 right-0 h-16 flex flex-row justify-between items-center text-lg px-6">
 					<div className="cursor-pointer z-10" onClick={onClose}>
-						<AiOutlineClose/>
+						<AiOutlineClose size={24} color="white"
+										className="hover:!text-hornetSting duration-300 ease-in"/>
 					</div>
 				</div>
 				<div
 					className="absolute top-0 bottom-0 left-0 right-0 m-auto flex flex-col justify-center items-center gap-4">
 					<FaCircleCheck color={"#16A34A"} size={32}/>
-					<span className="text-xl font-semibold text-center">Wallet un-assigned</span>
-					<span className="text-[15px] text-center">Transaction ID:
+					<span className="text-2xl font-bold text-white text--center">Wallet un-assigned</span>
+					<span className="text-elementalGrey text-[17px] font-medium text-center">Transaction ID:
 						<a
 							onClick={() => window.electron.openExternal(`${providerData?.blockExplorer}/tx/${txHash}`)}
 							className="text-[#F30919] ml-1 cursor-pointer"


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/188108663

- added new styles for assigned wallet modal
- added new styles for un-assigned wallet modal
- added `fixed` position for modals to fix scrolling before modal appears
- added `document.body.style.overflow = "hidden"` for modals to prevent scrolling after modal appears
- removed useless console logs which were added for debugging by me
