### PR TITLE
Fb tiny keys subgraph update submissions

### DIFF
--- a/infrastructure/sentry-subgraph/schema.graphql
+++ b/infrastructure/sentry-subgraph/schema.graphql
@@ -136,7 +136,7 @@ type Submission @entity(immutable: false) {
   challengeNumber: BigInt!
   claimed: Boolean!
   eligibleForPayout: Boolean!
-  nodeLicenseId: BigInt!
+  nodeLicenseId: BigInt! 
   assertionsStateRootOrConfirmData: String!
   claimAmount: BigInt!
   createdTimestamp: BigInt!
@@ -168,6 +168,23 @@ type RefereeConfig @entity(immutable: false) {
   maxKeysPerPool: BigInt!
   stakeAmountTierThresholds: [BigInt!]!
   stakeAmountBoostFactors: [BigInt!]!
+}
+
+type PoolSubmission @entity(immutable: false) {
+  id: String!
+  challengeId: BigInt!
+  poolAddress: Bytes!
+  challenge: Challenge!
+  poolInfo: PoolInfo!
+  stakedKeyCount: BigInt!
+  winningKeyCount: BigInt!
+  claimedRewardsAmount: BigInt!
+  assertionsStateRootOrConfirmData: String!
+  createdTimestamp: BigInt!
+  createdTxHash: Bytes!
+  claimTimestamp: BigInt!
+  claimTxHash: Bytes!
+  claimed: Boolean!
 }
 
 ######################################################

--- a/infrastructure/sentry-subgraph/schema/events/Referee.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/Referee.graphql
@@ -77,9 +77,16 @@ type RefereeConfig @entity(immutable: false) {
 type PoolSubmission @entity(immutable: false) {
   id: String!
   challengeId: BigInt!
+  poolAddress: Bytes!
+  challenge: Challenge!
+  poolInfo: PoolInfo!
   stakedKeyCount: BigInt!
   winningKeyCount: BigInt!
   claimedRewardsAmount: BigInt!
-  poolAddress: Bytes!
+  assertionsStateRootOrConfirmData: String!
+  createdTimestamp: BigInt!
+  createdTxHash: Bytes!
+  claimTimestamp: BigInt!
+  claimTxHash: Bytes!
   claimed: Boolean!
 }

--- a/infrastructure/sentry-subgraph/sepolia.subgraph.yaml
+++ b/infrastructure/sentry-subgraph/sepolia.subgraph.yaml
@@ -45,11 +45,11 @@ dataSources:
           handler: handleStakedV1
         - event: UnstakeV1(indexed address,uint256,uint256)
           handler: handleUnstakeV1
-        - event: NewPoolSubmission(indexed uint256, indexed address, uint256, uint256)
+        - event: NewPoolSubmission(indexed uint256,indexed address,uint256,uint256)
           handler: handleNewPoolSubmission
-        - event: UpdatePoolSubmission(indexed uint256, indexed address, uint256, uint256, uint256, uint256)
+        - event: UpdatePoolSubmission(indexed uint256,indexed address,uint256,uint256,uint256,uint256)
           handler: handleUpdatePoolSubmission
-        - event: PoolRewardsClaimed(indexed uint256, indexed address, uint256, uint256)
+        - event: PoolRewardsClaimed(indexed uint256,indexed address,uint256,uint256)
           handler: handlePoolRewardsClaimed
       file: ./src/referee.ts
   - kind: ethereum

--- a/infrastructure/sentry-subgraph/sepolia.subgraph.yaml
+++ b/infrastructure/sentry-subgraph/sepolia.subgraph.yaml
@@ -45,6 +45,12 @@ dataSources:
           handler: handleStakedV1
         - event: UnstakeV1(indexed address,uint256,uint256)
           handler: handleUnstakeV1
+        - event: NewPoolSubmission(indexed uint256, indexed address, uint256, uint256)
+          handler: handleNewPoolSubmission
+        - event: UpdatePoolSubmission(indexed uint256, indexed address, uint256, uint256, uint256, uint256)
+          handler: handleUpdatePoolSubmission
+        - event: PoolRewardsClaimed(indexed uint256, indexed address, uint256, uint256)
+          handler: handlePoolRewardsClaimed
       file: ./src/referee.ts
   - kind: ethereum
     name: NodeLicense

--- a/infrastructure/sentry-subgraph/subgraph.yaml
+++ b/infrastructure/sentry-subgraph/subgraph.yaml
@@ -51,6 +51,14 @@ dataSources:
           handler: handleUpdatePoolSubmission
         - event: PoolRewardsClaimed(indexed uint256,indexed address,uint256,uint256)
           handler: handlePoolRewardsClaimed
+
+        - event: AssertionSubmittedV2(indexed uint256,indexed uint256,bytes)
+          handler: handleAssertionSubmittedV2
+        - event: RewardsClaimedV2(indexed uint256,indexed uint256,uint256)
+          handler: handleRewardsClaimedV2
+        - event: AssertionCancelled(indexed uint256,indexed uint256)
+          handler: handleAssertionCancelled
+          
       file: ./src/referee.ts
   - kind: ethereum
     name: NodeLicense

--- a/infrastructure/sentry-subgraph/subgraph.yaml
+++ b/infrastructure/sentry-subgraph/subgraph.yaml
@@ -45,11 +45,11 @@ dataSources:
           handler: handleStakedV1
         - event: UnstakeV1(indexed address,uint256,uint256)
           handler: handleUnstakeV1
-        - event: NewPoolSubmission(indexed uint256, indexed address, uint256, uint256)
+        - event: NewPoolSubmission(indexed uint256,indexed address,uint256,uint256)
           handler: handleNewPoolSubmission
-        - event: UpdatePoolSubmission(indexed uint256, indexed address, uint256, uint256, uint256, uint256)
+        - event: UpdatePoolSubmission(indexed uint256,indexed address,uint256,uint256,uint256,uint256)
           handler: handleUpdatePoolSubmission
-        - event: PoolRewardsClaimed(indexed uint256, indexed address, uint256, uint256)
+        - event: PoolRewardsClaimed(indexed uint256,indexed address,uint256,uint256)
           handler: handlePoolRewardsClaimed
       file: ./src/referee.ts
   - kind: ethereum

--- a/infrastructure/sentry-subgraph/subgraph.yaml
+++ b/infrastructure/sentry-subgraph/subgraph.yaml
@@ -45,6 +45,12 @@ dataSources:
           handler: handleStakedV1
         - event: UnstakeV1(indexed address,uint256,uint256)
           handler: handleUnstakeV1
+        - event: NewPoolSubmission(indexed uint256, indexed address, uint256, uint256)
+          handler: handleNewPoolSubmission
+        - event: UpdatePoolSubmission(indexed uint256, indexed address, uint256, uint256, uint256, uint256)
+          handler: handleUpdatePoolSubmission
+        - event: PoolRewardsClaimed(indexed uint256, indexed address, uint256, uint256)
+          handler: handlePoolRewardsClaimed
       file: ./src/referee.ts
   - kind: ethereum
     name: NodeLicense


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/n/projects/2671427/stories/187869828

- we will update the events in the contract so that the old events will not be called anymore, this means the old events in the subgraph are not updated
- added additional fields in poolSubmission entity
- added new events into yaml file for referee
[Blocker] Need to deploy contract to sync subgraph