### PR TITLE
Added Failed KYC Requirements

### DIFF
--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -7,14 +7,13 @@ import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/Base64Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "../../upgrades/referee/Referee9.sol";
 
 interface IAggregatorV3Interface {
     function latestAnswer() external view returns (int256);
 }
 
-contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable, ReentrancyGuard  {
+contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  {
     using StringsUpgradeable for uint256;
     using CountersUpgradeable for CountersUpgradeable.Counter;
     CountersUpgradeable.Counter private _tokenIds;
@@ -491,7 +490,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable, 
      * @dev The function checks if claiming is enabled and if the caller has a reward to claim.
      * If both conditions are met, the reward is transferred to the caller and their reward balance is reset.
      */
-    function claimReferralReward() external nonReentrant {
+    function claimReferralReward() external {
         require(claimable, "Claiming of referral rewards is currently disabled");
         uint256 reward = _referralRewards[msg.sender];
         // Pay Xai & esXAI rewards if they exist

--- a/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
@@ -53,6 +53,7 @@ import "../../staking-v2/PoolBeacon.sol";
 // 35: Invalid submission; pool needs to have been created via the PoolFactory
 // 36: Invalid submission; user needs to be owner, delegate or staker to submit
 // 37: Invalid auth: msg.sender must be kyc approved to create a pool
+// 38: Address failed kyc
 
 contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
     using EnumerableSetUpgradeable for EnumerableSetUpgradeable.AddressSet;
@@ -100,16 +101,18 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
     // Period (in seconds) to update reward breakdown changes
     uint256 public updateRewardBreakdownDelayPeriod;
 
+    // Mapping to track if an address failed kyc
+    mapping(address => bool) public failedKyc; // Default is false
+
     // Role definition for stake keys admin
-    bytes32 public constant STAKE_KEYS_ADMIN_ROLE =
-        keccak256("STAKE_KEYS_ADMIN_ROLE");
+    bytes32 public constant STAKE_KEYS_ADMIN_ROLE = keccak256("STAKE_KEYS_ADMIN_ROLE");
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[500] private __gap;
+    uint256[499] private __gap;
 
     // Events for various actions within the contract
     event StakingEnabled();
@@ -237,6 +240,10 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
 
         Referee9 referee = Referee9(refereeAddress);
         require(referee.isKycApproved(msg.sender), "37"); // Owner must be kyc approved
+        
+        // This is redundant, but being added in case the approved kyc requirement is ever removed
+        // this would still prevent a user from creating a pool if they failed kyc
+        require(failedKyc[msg.sender] == false, "38"); // Owner must not have failed kyc
 
         (
             address poolProxy,
@@ -431,6 +438,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         require(pool != address(0), "10"); // Invalid pool address
         require(keyIds.length > 0, "11"); // At least 1 key required
         require(poolsCreatedViaFactory[pool], "12"); // Pool must be created via factory
+        require(failedKyc[msg.sender] == false, "38"); // Owner must not have failed kyc
 
         _stakeKeys(pool, keyIds, msg.sender, false);
     }
@@ -567,6 +575,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
      */
     function stakeEsXai(address pool, uint256 amount) external {
         require(poolsCreatedViaFactory[pool], "27"); // Pool must be created via factory
+        require(failedKyc[msg.sender] == false, "38"); // Owner must not have failed kyc
 
         Referee9(refereeAddress).stakeEsXai(pool, amount);
         esXai(esXaiAddress).transferFrom(msg.sender, address(this), amount);
@@ -800,5 +809,15 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         }
 
         return true;
+    }
+    
+    /**
+    * @notice Allows the admin to set the failed kyc status of a user
+    * @param user The address of the user
+    * @param failed Boolean indicating if the user failed kyc
+    */
+
+    function setFailedKyc(address user, bool failed) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        failedKyc[user] = failed;
     }
 }

--- a/infrastructure/smart-contracts/test/Fixture.mjs
+++ b/infrastructure/smart-contracts/test/Fixture.mjs
@@ -392,18 +392,18 @@ describe("Fixture Tests", function () {
         };
     }
 
-    //describe("CNY 2024", CNYAirDropTests.bind(this));
-    //describe("Xai Gasless Claim", XaiGaslessClaimTests(deployInfrastructure).bind(this));
-    //describe("Xai", XaiTests(deployInfrastructure).bind(this));
-    //describe("EsXai", esXaiTests(deployInfrastructure).bind(this));
-    //describe("Node License", NodeLicenseTests(deployInfrastructure).bind(this));
-    //describe("Referee", RefereeTests(deployInfrastructure).bind(this));
-    //describe("StakingV2", StakingV2(deployInfrastructure).bind(this));
-    //describe("Beacon Tests", Beacons(deployInfrastructure).bind(this));
-    //describe("Gas Subsidy", GasSubsidyTests(deployInfrastructure).bind(this));
-    //describe("Upgrade Tests", UpgradeabilityTests(deployInfrastructure).bind(this));
-    //describe("PoolSubmissions", RefereePoolSubmissions(deployInfrastructure).bind(this));
-    //describe("Node License Tiny Keys", NodeLicenseTinyKeysTest(deployInfrastructure, getBasicPoolConfiguration()).bind(this));
+    describe("CNY 2024", CNYAirDropTests.bind(this));
+    describe("Xai Gasless Claim", XaiGaslessClaimTests(deployInfrastructure).bind(this));
+    describe("Xai", XaiTests(deployInfrastructure).bind(this));
+    describe("EsXai", esXaiTests(deployInfrastructure).bind(this));
+    describe("Node License", NodeLicenseTests(deployInfrastructure).bind(this));
+    describe("Referee", RefereeTests(deployInfrastructure).bind(this));
+    describe("StakingV2", StakingV2(deployInfrastructure).bind(this));
+    describe("Beacon Tests", Beacons(deployInfrastructure).bind(this));
+    describe("Gas Subsidy", GasSubsidyTests(deployInfrastructure).bind(this));
+    describe("Upgrade Tests", UpgradeabilityTests(deployInfrastructure).bind(this));
+    describe("PoolSubmissions", RefereePoolSubmissions(deployInfrastructure).bind(this));
+    describe("Node License Tiny Keys", NodeLicenseTinyKeysTest(deployInfrastructure, getBasicPoolConfiguration()).bind(this));
     describe("Failed KYC Tests", FailedKycTests(deployInfrastructure).bind(this));
 
     // This doesn't work when running coverage

--- a/infrastructure/smart-contracts/test/Fixture.mjs
+++ b/infrastructure/smart-contracts/test/Fixture.mjs
@@ -342,9 +342,6 @@ describe("Fixture Tests", function () {
         const referee9 = await upgrades.upgradeProxy((await referee.getAddress()), Referee9, { call: { fn: "initialize", args: [await refereeCalculations.getAddress()] } });
         await referee9.waitForDeployment();
 
-        // Set Address 4 as Failed KYC
-        await poolFactory2.connect(deployer).setFailedKyc(await addr4.getAddress());
-
 
         config.esXaiAddress = await esXai.getAddress();
         config.esXaiDeployedBlockNumber = (await esXai.deploymentTransaction()).blockNumber;

--- a/infrastructure/smart-contracts/test/failed-kyc/FailedKyc.mjs
+++ b/infrastructure/smart-contracts/test/failed-kyc/FailedKyc.mjs
@@ -1,5 +1,9 @@
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
+import {findWinningStateRoot} from "../Referee.mjs";
+import {submitTestChallenge} from "../utils/submitTestChallenge.mjs";
+import {mintBatchedLicenses, mintSingleLicense} from "../utils/mintLicenses.mjs";
+import {createPool} from "../utils/createPool.mjs";
 
 /**
  * @title Failed KYC Tests
@@ -8,15 +12,72 @@ import { expect } from "chai";
 export function FailedKycTests(deployInfrastructure) {
     return function() {
     
+        it("Check that admin can add and remove kyc fail successfully.", async function() {
+            const {refereeDefaultAdmin, addr4, poolFactory} = await loadFixture(deployInfrastructure);
 
-        it("Check esXai can be minted by an address with the minter role", async function() {
-            const {esXai, esXaiMinter} = await loadFixture(deployInfrastructure);
-            const initialBalance = await esXai.balanceOf(esXaiMinter.address);
+            // Check that the address is not in the failed kyc list
+            const kycFailBefore = await poolFactory.failedKyc(await addr4.getAddress());
+            expect(kycFailBefore).to.equal(false);
+            
+            // Add the address to the failed kyc list
+            await poolFactory.connect(refereeDefaultAdmin).setFailedKyc(await addr4.getAddress(), true);
+
+            // Check that the address is now in the failed kyc list
+            const kycFailAfter = await poolFactory.failedKyc(await addr4.getAddress());
+            expect(kycFailAfter).to.equal(true);
+
+            // Remove the address from the failed kyc list
+            await poolFactory.connect(refereeDefaultAdmin).setFailedKyc(await addr4.getAddress(), false);
+
+            // Check that the address is no longer in the failed kyc list
+            const kycFailAfterRemove = await poolFactory.failedKyc(await addr4.getAddress());
+            expect(kycFailAfterRemove).to.equal(false);
+        });
+    
+        it("Check that a failed kyc wallet cannot add stake to a pool.", async function() {
+            const {refereeDefaultAdmin, addr1: poolOwner, addr4: failedKycWallet, poolFactory, nodeLicense, referee, esXai, esXaiMinter, challenger} = await loadFixture(deployInfrastructure);
+
+            // Mint Node License to pool owner
+            const poolOwnerKeyId = await mintSingleLicense(nodeLicense, poolOwner);
+
+            // Mint Node License to failed kyc wallet
+            const failedKycKeyId = await mintSingleLicense(nodeLicense, failedKycWallet);
+            
+            // Submit a challenge so that a pool can be created (required to prevent overflow subtraction error)
+            const challengeId = 0;
+            const keys = [poolOwnerKeyId];
+            const winningStateRoot = await findWinningStateRoot(referee, keys, challengeId);
+            const startingAssertion = 100;
+            await submitTestChallenge(referee, challenger, startingAssertion, winningStateRoot);
+
+            // Create a new pool
+            const stakingPoolAddress = await createPool(poolFactory, poolOwner, keys);
+            
+            // Check that the failedKycWallet is not in the failed kyc list
+            const kycFailBefore = await poolFactory.failedKyc(await failedKycWallet.getAddress());
+            expect(kycFailBefore).to.equal(false);
+            
+            // Add the failedKycWallet to the failed kyc list
+            await poolFactory.connect(refereeDefaultAdmin).setFailedKyc(await failedKycWallet.getAddress(), true);
+
+            // Check that the failedKycWallet is now in the failed kyc list
+            const kycFailAfter = await poolFactory.failedKyc(await failedKycWallet.getAddress());
+            expect(kycFailAfter).to.equal(true);
+            
+            const failedKeys = [failedKycKeyId];
+            // Check that the failed kyc wallet cannot stake keys in the pool
+            console.log("Failed Kyc Wallet1: ", failedKycWallet.address);
+            expect(poolFactory.connect(failedKycWallet).stakeKeys(stakingPoolAddress, failedKeys)).to.be.revertedWith("381");
+            console.log("Failed Kyc Wallet2: ", failedKycWallet.address);
+
+            // Mint some esXai to the failed kyc wallet
             const mintAmount = BigInt(1000);
-            await esXai.connect(esXaiMinter).mint(esXaiMinter.address, mintAmount);
-            const finalBalance = await esXai.balanceOf(esXaiMinter.address);
-            expect(finalBalance).to.equal(initialBalance + mintAmount);
-        })
+            await esXai.connect(esXaiMinter).mint(failedKycWallet.address, mintAmount);
+
+            // Check that the failed kyc wallet cannot stake esXai in the pool
+            expect(poolFactory.connect(failedKycWallet).stakeEsXai(stakingPoolAddress, mintAmount)).to.be.revertedWith("384");
+
+        });
 
         // it("Check esXai can't be minted by someone without the minter role", async function() {
         //     const {esXai, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);

--- a/infrastructure/smart-contracts/test/failed-kyc/FailedKyc.mjs
+++ b/infrastructure/smart-contracts/test/failed-kyc/FailedKyc.mjs
@@ -66,205 +66,61 @@ export function FailedKycTests(deployInfrastructure) {
             
             const failedKeys = [failedKycKeyId];
             // Check that the failed kyc wallet cannot stake keys in the pool
-            console.log("Failed Kyc Wallet1: ", failedKycWallet.address);
-            expect(poolFactory.connect(failedKycWallet).stakeKeys(stakingPoolAddress, failedKeys)).to.be.revertedWith("381");
-            console.log("Failed Kyc Wallet2: ", failedKycWallet.address);
+            await expect(poolFactory.connect(failedKycWallet).stakeKeys(stakingPoolAddress, failedKeys)).to.be.revertedWith("38");
 
             // Mint some esXai to the failed kyc wallet
             const mintAmount = BigInt(1000);
             await esXai.connect(esXaiMinter).mint(failedKycWallet.address, mintAmount);
 
             // Check that the failed kyc wallet cannot stake esXai in the pool
-            expect(poolFactory.connect(failedKycWallet).stakeEsXai(stakingPoolAddress, mintAmount)).to.be.revertedWith("384");
+            await expect(poolFactory.connect(failedKycWallet).stakeEsXai(stakingPoolAddress, mintAmount)).to.be.revertedWith("38");
 
         });
 
-        // it("Check esXai can't be minted by someone without the minter role", async function() {
-        //     const {esXai, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
-        //     const esXaiMinterRole = await esXai.MINTER_ROLE();
-        //     const mintAmount = BigInt(1000);
-        //     const expectedRevertMessage = `AccessControl: account ${esXaiDefaultAdmin.address.toLowerCase()} is missing role ${esXaiMinterRole}`;
-        //     await expect(esXai.connect(esXaiDefaultAdmin).mint(esXaiDefaultAdmin.address, mintAmount)).to.be.revertedWith(expectedRevertMessage);
-        // })
+        it("Check redemption cannot be initiated for failed kyc wallets.", async function() {
+            const {esXai, esXaiMinter, addr3, esXaiDefaultAdmin, addr4: failedKycWallet, poolFactory, refereeDefaultAdmin} = await loadFixture(deployInfrastructure);            
+            
+            // Check that the failedKycWallet is not in the failed kyc list
+            const kycFailBefore = await poolFactory.failedKyc(await failedKycWallet.getAddress());
+            expect(kycFailBefore).to.equal(false);
+            
+            // Add the failedKycWallet to the failed kyc list
+            await poolFactory.connect(refereeDefaultAdmin).setFailedKyc(await failedKycWallet.getAddress(), true);
 
-        // it("Check xai address can be changed", async function() {
-        //     const {esXai, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
-        //     const newXaiAddress = "0x0000000000000000000000000000000000000001";
-        //     await esXai.connect(esXaiDefaultAdmin).changeXaiAddress(newXaiAddress);
-        //     const currentXaiAddress = await esXai.xai();
-        //     expect(currentXaiAddress).to.equal(newXaiAddress);
-        // })
+            // Check that the failedKycWallet is now in the failed kyc list
+            const kycFailAfter = await poolFactory.failedKyc(await failedKycWallet.getAddress());
+            expect(kycFailAfter).to.equal(true);
 
-        // it("Check esXai can't be transferred unless either the recipient or the from address is in the whitelist", async function() {
-        //     const {esXai, esXaiMinter, esXaiDefaultAdmin, addr1, addr2, addr3} = await loadFixture(deployInfrastructure);
-        //     await esXai.connect(esXaiDefaultAdmin).addToWhitelist(addr2.address);
-        //     expect(await esXai.isWhitelisted(addr2.address)).to.equal(true);
-        //     const transferAmount = BigInt(1000);
-        //     await esXai.connect(esXaiMinter).mint(addr1.address, transferAmount);
-        //     await expect(esXai.connect(addr1).transfer(addr3.address, transferAmount)).to.be.revertedWith("Transfer not allowed: address not in whitelist");
-        //     await esXai.connect(addr1).transfer(addr2.address, transferAmount);
-        //     const finalBalance = await esXai.balanceOf(addr2.address);
-        //     expect(finalBalance).to.equal(transferAmount);
-        //     await esXai.connect(esXaiDefaultAdmin).addToWhitelist(addr1.address);
-        //     expect(await esXai.isWhitelisted(addr1.address)).to.equal(true);
-        //     await esXai.connect(addr2).transfer(addr3.address, transferAmount);
-        //     const finalBalanceAddr3 = await esXai.balanceOf(addr3.address);
-        //     expect(finalBalanceAddr3).to.equal(transferAmount);
-        //     await esXai.connect(esXaiDefaultAdmin).removeFromWhitelist(addr1.address);
-        //     expect(await esXai.isWhitelisted(addr1.address)).to.equal(false);
-        //     await expect(esXai.connect(addr1).transfer(addr3.address, transferAmount)).to.be.revertedWith("Transfer not allowed: address not in whitelist");
-        // })
+            await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);
+            const redemptionAmount = BigInt(1000);
+            await esXai.connect(esXaiMinter).mint(failedKycWallet.address, redemptionAmount);            
+            const duration = 15 * 24 *60 *60;
+            await expect (esXai.connect(failedKycWallet).startRedemption(redemptionAmount, duration)).to.be.revertedWith("KYC failed, cannot redeem");
+        })
 
-        // it("Check esXai can't be transferredFrom unless either the recipient or the from address is in the whitelist", async function() {
-        //     const {esXai, esXaiMinter, esXaiDefaultAdmin, addr1, addr2, addr3} = await loadFixture(deployInfrastructure);
-        //     await esXai.connect(esXaiDefaultAdmin).addToWhitelist(addr2.address);
-        //     expect(await esXai.isWhitelisted(addr2.address)).to.equal(true);
-        //     const transferAmount = BigInt(1000);
-        //     await esXai.connect(esXaiMinter).mint(addr1.address, transferAmount);
-        //     await esXai.connect(addr1).approve(esXaiMinter.address, transferAmount);
-        //     await expect(esXai.connect(esXaiMinter).transferFrom(addr1.address, addr3.address, transferAmount)).to.be.revertedWith("Transfer not allowed: address not in whitelist");
-        //     await esXai.connect(esXaiMinter).transferFrom(addr1.address, addr2.address, transferAmount);
-        //     const finalBalance = await esXai.balanceOf(addr2.address);
-        //     expect(finalBalance).to.equal(transferAmount);
-        //     await esXai.connect(esXaiDefaultAdmin).addToWhitelist(addr1.address);
-        //     expect(await esXai.isWhitelisted(addr1.address)).to.equal(true);
-        //     await esXai.connect(addr2).approve(esXaiMinter.address, transferAmount);
-        //     await esXai.connect(esXaiMinter).transferFrom(addr2.address, addr3.address, transferAmount);
-        //     const finalBalanceAddr3 = await esXai.balanceOf(addr3.address);
-        //     expect(finalBalanceAddr3).to.equal(transferAmount);
-        //     await esXai.connect(esXaiDefaultAdmin).removeFromWhitelist(addr1.address);
-        //     expect(await esXai.isWhitelisted(addr1.address)).to.equal(false);
-        //     await esXai.connect(addr1).approve(esXaiMinter.address, transferAmount);
-        //     await expect(esXai.connect(esXaiMinter).transferFrom(addr1.address, addr3.address, transferAmount)).to.be.revertedWith("Transfer not allowed: address not in whitelist");
-        // })
 
-        // it("Check redemption periods can't be claimed before time is complete", async function() {
-        //     const {esXai, esXaiMinter, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
-        //     await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);
-        //     const redemptionAmount = BigInt(1000);
-        //     await esXai.connect(esXaiMinter).mint(esXaiMinter.address, redemptionAmount * BigInt(3));
-        //     const durations = [15 * 24 * 60 * 60, 90 * 24 * 60 * 60, 180 * 24 * 60 * 60]; // 15 days, 90 days, 180 days in seconds
-        //     for (const duration of durations) {
-        //         await esXai.connect(esXaiMinter).startRedemption(redemptionAmount, duration);
-        //         const redemptionRequest = await esXai.getRedemptionRequest(esXaiMinter.address, 0);
-        //         expect(redemptionRequest.completed).to.equal(false);
-        //         await expect(esXai.connect(esXaiMinter).completeRedemption(0)).to.be.revertedWith("Redemption period not yet over");
-        //     }
-        // })
+        it("Check redemption cannot be completed for failed kyc wallets.", async function() {
+            const {esXai, esXaiMinter, addr3, esXaiDefaultAdmin, addr4: failedKycWallet, poolFactory, refereeDefaultAdmin} = await loadFixture(deployInfrastructure);            
+            
+            // Check that the failedKycWallet is not in the failed kyc list
+            const kycFailBefore = await poolFactory.failedKyc(await failedKycWallet.getAddress());
+            expect(kycFailBefore).to.equal(false);
 
-        // it("Check redemption request can be retrieved after creation", async function() {
-        //     const {esXai, esXaiMinter, addr1, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
-        //     await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);
-        //     const redemptionAmount = BigInt(1000);
-        //     await esXai.connect(esXaiMinter).mint(addr1.address, redemptionAmount);
-        //     const duration = 15 * 24 * 60 * 60; // 15 days in seconds
-        //     await esXai.connect(addr1).startRedemption(redemptionAmount, duration);
-        //     const redemptionRequest = await esXai.getRedemptionRequest(addr1.address, 0);
-        //     expect(redemptionRequest.amount).to.equal(redemptionAmount);
-        //     expect(redemptionRequest.duration).to.equal(duration);
-        //     expect(redemptionRequest.completed).to.equal(false);
-        // })
+            await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);
+            const redemptionAmount = BigInt(1000);
+            await esXai.connect(esXaiMinter).mint(failedKycWallet.address, redemptionAmount);            
+            const duration = 15 * 24 *60 *60;
+            await esXai.connect(failedKycWallet).startRedemption(redemptionAmount, duration);
+            await network.provider.send("evm_increaseTime", [duration]);
+            await network.provider.send("evm_mine");
+            
+            // Add the failedKycWallet to the failed kyc list
+            await poolFactory.connect(refereeDefaultAdmin).setFailedKyc(await failedKycWallet.getAddress(), true);
 
-        // it("Check redemption can be cancelled and esXai returned, and cannot be cancelled or completed a second time", async function() {
-        //     const {esXai, esXaiMinter, addr1, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
-        //     await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);
-        //     const redemptionAmount = BigInt(1000);
-        //     await esXai.connect(esXaiMinter).mint(addr1.address, redemptionAmount);
-        //     const duration = 15 * 24 * 60 * 60; // 15 days in seconds
-        //     await esXai.connect(addr1).startRedemption(redemptionAmount, duration);
-        //     const initialBalance = await esXai.balanceOf(addr1.address);
-        //     await esXai.connect(addr1).cancelRedemption(0);
-        //     const finalBalance = await esXai.balanceOf(addr1.address);
-        //     expect(finalBalance).to.equal(initialBalance + redemptionAmount);
-        //     await expect(esXai.connect(addr1).cancelRedemption(0)).to.be.revertedWith("Redemption already completed");
-        //     await expect(esXai.connect(addr1).completeRedemption(0)).to.be.revertedWith("Redemption already completed");
-        // })
-
-        // it("Check redemption can be completed and correct amount of xai is received, and total supply of esXai decreases", async function() {
-        //     const {esXai, xai, esXaiMinter, addr1, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
-        //     await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);
-        //     const redemptionAmount = BigInt(1000);
-        //     await esXai.connect(esXaiMinter).mint(addr1.address, redemptionAmount * BigInt(3));
-
-        //     const foundationAddr = await esXai.esXaiBurnFoundationRecipient();
-        //     const foundationBasePoints = await esXai.esXaiBurnFoundationBasePoints();
-        //     const durations = [
-        //         15 * 24 * 60 * 60,  // 15 days
-        //         90 * 24 * 60 * 60,  // 90 days
-        //         180 * 24 * 60 * 60  // 180 days
-        //     ];
-        //     const ratios = [250, 625, 1000]; // corresponding ratios for 15 days, 90 days, 180 days
-        //     for (let i = 0; i < durations.length; i++) {
-        //         const initialXaiBalance = await xai.balanceOf(addr1.address);
-        //         const initialFoundationBalance = await xai.balanceOf(foundationAddr);
-        //         const duration = durations[i];
-        //         const ratio = ratios[i];
-        //         await esXai.connect(addr1).startRedemption(redemptionAmount, duration);
-        //         const initialEsXaiSupply = await esXai.totalSupply();
-        //         await network.provider.send("evm_increaseTime", [duration]);
-        //         await network.provider.send("evm_mine");
-        //         await esXai.connect(addr1).completeRedemption(i);
-        //         const finalEsXaiSupply = await esXai.totalSupply();
-        //         expect(finalEsXaiSupply).to.equal(initialEsXaiSupply - redemptionAmount);
-        //         const xaiBalance = await xai.balanceOf(addr1.address);
-        //         expect(xaiBalance).to.equal(initialXaiBalance + (redemptionAmount * BigInt(ratio) / BigInt(1000)));
-
-        //         // check that foundation receives correct split
-        //         const foundationAmount = (redemptionAmount - (redemptionAmount * BigInt(ratio) / BigInt(1000))) * foundationBasePoints / BigInt(1000);
-        //         const finalFoundationBalance = await xai.balanceOf(foundationAddr);
-        //         expect(finalFoundationBalance).to.equal(initialFoundationBalance + foundationAmount);
-        //     }
-        //     // await xai.connect(addr1).burn((await xai.balanceOf(addr1.address))); // burn the xai for the next iteration
-
-        //     const redemptionRequestCount = await esXai.getRedemptionRequestCount(addr1.address);
-        //     expect(redemptionRequestCount).to.equal(3);
-
-        // })
-
-        // it("Check whitelist addresses are added and retrieved correctly", async function() {
-        //     const {esXai, addr1, addr2, addr3, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
-        //     const whitelistCount2 = await esXai.getWhitelistCount();
-        //     console.log("WL Count2: ", whitelistCount2);
-        //     await esXai.connect(esXaiDefaultAdmin).addToWhitelist(addr1.address);
-        //     await esXai.connect(esXaiDefaultAdmin).addToWhitelist(addr2.address);
-        //     const whitelistCount = await esXai.getWhitelistCount();
-        //     expect(whitelistCount).to.equal(4);
-        //     const whitelistedAddress1 = await esXai.getWhitelistedAddressAtIndex(2);
-        //     const whitelistedAddress2 = await esXai.getWhitelistedAddressAtIndex(3);
-        //     expect(whitelistedAddress1).to.equal(addr1.address);
-        //     expect(whitelistedAddress2).to.equal(addr2.address);
-        // })
-
-        
-        // it("Check redemption passes for kyc wallets if they hold more keys than the max allowed", async function() {
-        //     const {esXai, esXaiMinter, addr2, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
-        //     await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);            
-        //     const redemptionAmount = BigInt(1000);            
-        //     const initialBalance = await esXai.balanceOf(addr2.address);
-        //     await esXai.connect(esXaiMinter).mint(addr2.address, redemptionAmount * BigInt(3));            
-        //     const duration = 15 * 24 *60 *60;
-        //     await esXai.connect(addr2).startRedemption(redemptionAmount, duration);
-        //     await network.provider.send("evm_increaseTime", [duration]);
-        //     await network.provider.send("evm_mine");            
-
-        //     // Complete redemption    
-        //     // Assuming the redemption was successful, check the new total supply
-        //     const finalBalance = await esXai.balanceOf(addr2.address);
-        //     expect(initialBalance).to.be.below(finalBalance); // Check if the total balance increased
-
-        // })
-
-        // it("Check redemption fails for non-kyc wallets if they hold more keys than the max allowed", async function() {
-        //     const {esXai, esXaiMinter, addr3, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
-        //     await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);
-        //     const redemptionAmount = BigInt(1000);
-        //     await esXai.connect(esXaiMinter).mint(addr3.address, redemptionAmount * BigInt(3));            
-        //     const duration = 15 * 24 *60 *60;
-        //     await esXai.connect(addr3).startRedemption(redemptionAmount, duration);
-        //     await network.provider.send("evm_increaseTime", [duration]);
-        //     await network.provider.send("evm_mine");
-        //     expect (esXai.connect(addr3).completeRedemption(0)).to.be.revertedWith("You own too many keys, must be KYC approved to claim.")
-        // })
-
+            // Check that the failedKycWallet is now in the failed kyc list
+            const kycFailAfter = await poolFactory.failedKyc(await failedKycWallet.getAddress());
+            expect(kycFailAfter).to.equal(true);
+            await expect (esXai.connect(failedKycWallet).completeRedemption(0)).to.be.revertedWith("KYC failed, cannot redeem")
+        })
     }
 }

--- a/infrastructure/smart-contracts/test/failed-kyc/FailedKyc.mjs
+++ b/infrastructure/smart-contracts/test/failed-kyc/FailedKyc.mjs
@@ -1,0 +1,209 @@
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+
+/**
+ * @title Failed KYC Tests
+ * @dev Implementation of the failed KYC tests
+ */
+export function FailedKycTests(deployInfrastructure) {
+    return function() {
+    
+
+        it("Check esXai can be minted by an address with the minter role", async function() {
+            const {esXai, esXaiMinter} = await loadFixture(deployInfrastructure);
+            const initialBalance = await esXai.balanceOf(esXaiMinter.address);
+            const mintAmount = BigInt(1000);
+            await esXai.connect(esXaiMinter).mint(esXaiMinter.address, mintAmount);
+            const finalBalance = await esXai.balanceOf(esXaiMinter.address);
+            expect(finalBalance).to.equal(initialBalance + mintAmount);
+        })
+
+        // it("Check esXai can't be minted by someone without the minter role", async function() {
+        //     const {esXai, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
+        //     const esXaiMinterRole = await esXai.MINTER_ROLE();
+        //     const mintAmount = BigInt(1000);
+        //     const expectedRevertMessage = `AccessControl: account ${esXaiDefaultAdmin.address.toLowerCase()} is missing role ${esXaiMinterRole}`;
+        //     await expect(esXai.connect(esXaiDefaultAdmin).mint(esXaiDefaultAdmin.address, mintAmount)).to.be.revertedWith(expectedRevertMessage);
+        // })
+
+        // it("Check xai address can be changed", async function() {
+        //     const {esXai, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
+        //     const newXaiAddress = "0x0000000000000000000000000000000000000001";
+        //     await esXai.connect(esXaiDefaultAdmin).changeXaiAddress(newXaiAddress);
+        //     const currentXaiAddress = await esXai.xai();
+        //     expect(currentXaiAddress).to.equal(newXaiAddress);
+        // })
+
+        // it("Check esXai can't be transferred unless either the recipient or the from address is in the whitelist", async function() {
+        //     const {esXai, esXaiMinter, esXaiDefaultAdmin, addr1, addr2, addr3} = await loadFixture(deployInfrastructure);
+        //     await esXai.connect(esXaiDefaultAdmin).addToWhitelist(addr2.address);
+        //     expect(await esXai.isWhitelisted(addr2.address)).to.equal(true);
+        //     const transferAmount = BigInt(1000);
+        //     await esXai.connect(esXaiMinter).mint(addr1.address, transferAmount);
+        //     await expect(esXai.connect(addr1).transfer(addr3.address, transferAmount)).to.be.revertedWith("Transfer not allowed: address not in whitelist");
+        //     await esXai.connect(addr1).transfer(addr2.address, transferAmount);
+        //     const finalBalance = await esXai.balanceOf(addr2.address);
+        //     expect(finalBalance).to.equal(transferAmount);
+        //     await esXai.connect(esXaiDefaultAdmin).addToWhitelist(addr1.address);
+        //     expect(await esXai.isWhitelisted(addr1.address)).to.equal(true);
+        //     await esXai.connect(addr2).transfer(addr3.address, transferAmount);
+        //     const finalBalanceAddr3 = await esXai.balanceOf(addr3.address);
+        //     expect(finalBalanceAddr3).to.equal(transferAmount);
+        //     await esXai.connect(esXaiDefaultAdmin).removeFromWhitelist(addr1.address);
+        //     expect(await esXai.isWhitelisted(addr1.address)).to.equal(false);
+        //     await expect(esXai.connect(addr1).transfer(addr3.address, transferAmount)).to.be.revertedWith("Transfer not allowed: address not in whitelist");
+        // })
+
+        // it("Check esXai can't be transferredFrom unless either the recipient or the from address is in the whitelist", async function() {
+        //     const {esXai, esXaiMinter, esXaiDefaultAdmin, addr1, addr2, addr3} = await loadFixture(deployInfrastructure);
+        //     await esXai.connect(esXaiDefaultAdmin).addToWhitelist(addr2.address);
+        //     expect(await esXai.isWhitelisted(addr2.address)).to.equal(true);
+        //     const transferAmount = BigInt(1000);
+        //     await esXai.connect(esXaiMinter).mint(addr1.address, transferAmount);
+        //     await esXai.connect(addr1).approve(esXaiMinter.address, transferAmount);
+        //     await expect(esXai.connect(esXaiMinter).transferFrom(addr1.address, addr3.address, transferAmount)).to.be.revertedWith("Transfer not allowed: address not in whitelist");
+        //     await esXai.connect(esXaiMinter).transferFrom(addr1.address, addr2.address, transferAmount);
+        //     const finalBalance = await esXai.balanceOf(addr2.address);
+        //     expect(finalBalance).to.equal(transferAmount);
+        //     await esXai.connect(esXaiDefaultAdmin).addToWhitelist(addr1.address);
+        //     expect(await esXai.isWhitelisted(addr1.address)).to.equal(true);
+        //     await esXai.connect(addr2).approve(esXaiMinter.address, transferAmount);
+        //     await esXai.connect(esXaiMinter).transferFrom(addr2.address, addr3.address, transferAmount);
+        //     const finalBalanceAddr3 = await esXai.balanceOf(addr3.address);
+        //     expect(finalBalanceAddr3).to.equal(transferAmount);
+        //     await esXai.connect(esXaiDefaultAdmin).removeFromWhitelist(addr1.address);
+        //     expect(await esXai.isWhitelisted(addr1.address)).to.equal(false);
+        //     await esXai.connect(addr1).approve(esXaiMinter.address, transferAmount);
+        //     await expect(esXai.connect(esXaiMinter).transferFrom(addr1.address, addr3.address, transferAmount)).to.be.revertedWith("Transfer not allowed: address not in whitelist");
+        // })
+
+        // it("Check redemption periods can't be claimed before time is complete", async function() {
+        //     const {esXai, esXaiMinter, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
+        //     await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);
+        //     const redemptionAmount = BigInt(1000);
+        //     await esXai.connect(esXaiMinter).mint(esXaiMinter.address, redemptionAmount * BigInt(3));
+        //     const durations = [15 * 24 * 60 * 60, 90 * 24 * 60 * 60, 180 * 24 * 60 * 60]; // 15 days, 90 days, 180 days in seconds
+        //     for (const duration of durations) {
+        //         await esXai.connect(esXaiMinter).startRedemption(redemptionAmount, duration);
+        //         const redemptionRequest = await esXai.getRedemptionRequest(esXaiMinter.address, 0);
+        //         expect(redemptionRequest.completed).to.equal(false);
+        //         await expect(esXai.connect(esXaiMinter).completeRedemption(0)).to.be.revertedWith("Redemption period not yet over");
+        //     }
+        // })
+
+        // it("Check redemption request can be retrieved after creation", async function() {
+        //     const {esXai, esXaiMinter, addr1, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
+        //     await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);
+        //     const redemptionAmount = BigInt(1000);
+        //     await esXai.connect(esXaiMinter).mint(addr1.address, redemptionAmount);
+        //     const duration = 15 * 24 * 60 * 60; // 15 days in seconds
+        //     await esXai.connect(addr1).startRedemption(redemptionAmount, duration);
+        //     const redemptionRequest = await esXai.getRedemptionRequest(addr1.address, 0);
+        //     expect(redemptionRequest.amount).to.equal(redemptionAmount);
+        //     expect(redemptionRequest.duration).to.equal(duration);
+        //     expect(redemptionRequest.completed).to.equal(false);
+        // })
+
+        // it("Check redemption can be cancelled and esXai returned, and cannot be cancelled or completed a second time", async function() {
+        //     const {esXai, esXaiMinter, addr1, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
+        //     await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);
+        //     const redemptionAmount = BigInt(1000);
+        //     await esXai.connect(esXaiMinter).mint(addr1.address, redemptionAmount);
+        //     const duration = 15 * 24 * 60 * 60; // 15 days in seconds
+        //     await esXai.connect(addr1).startRedemption(redemptionAmount, duration);
+        //     const initialBalance = await esXai.balanceOf(addr1.address);
+        //     await esXai.connect(addr1).cancelRedemption(0);
+        //     const finalBalance = await esXai.balanceOf(addr1.address);
+        //     expect(finalBalance).to.equal(initialBalance + redemptionAmount);
+        //     await expect(esXai.connect(addr1).cancelRedemption(0)).to.be.revertedWith("Redemption already completed");
+        //     await expect(esXai.connect(addr1).completeRedemption(0)).to.be.revertedWith("Redemption already completed");
+        // })
+
+        // it("Check redemption can be completed and correct amount of xai is received, and total supply of esXai decreases", async function() {
+        //     const {esXai, xai, esXaiMinter, addr1, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
+        //     await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);
+        //     const redemptionAmount = BigInt(1000);
+        //     await esXai.connect(esXaiMinter).mint(addr1.address, redemptionAmount * BigInt(3));
+
+        //     const foundationAddr = await esXai.esXaiBurnFoundationRecipient();
+        //     const foundationBasePoints = await esXai.esXaiBurnFoundationBasePoints();
+        //     const durations = [
+        //         15 * 24 * 60 * 60,  // 15 days
+        //         90 * 24 * 60 * 60,  // 90 days
+        //         180 * 24 * 60 * 60  // 180 days
+        //     ];
+        //     const ratios = [250, 625, 1000]; // corresponding ratios for 15 days, 90 days, 180 days
+        //     for (let i = 0; i < durations.length; i++) {
+        //         const initialXaiBalance = await xai.balanceOf(addr1.address);
+        //         const initialFoundationBalance = await xai.balanceOf(foundationAddr);
+        //         const duration = durations[i];
+        //         const ratio = ratios[i];
+        //         await esXai.connect(addr1).startRedemption(redemptionAmount, duration);
+        //         const initialEsXaiSupply = await esXai.totalSupply();
+        //         await network.provider.send("evm_increaseTime", [duration]);
+        //         await network.provider.send("evm_mine");
+        //         await esXai.connect(addr1).completeRedemption(i);
+        //         const finalEsXaiSupply = await esXai.totalSupply();
+        //         expect(finalEsXaiSupply).to.equal(initialEsXaiSupply - redemptionAmount);
+        //         const xaiBalance = await xai.balanceOf(addr1.address);
+        //         expect(xaiBalance).to.equal(initialXaiBalance + (redemptionAmount * BigInt(ratio) / BigInt(1000)));
+
+        //         // check that foundation receives correct split
+        //         const foundationAmount = (redemptionAmount - (redemptionAmount * BigInt(ratio) / BigInt(1000))) * foundationBasePoints / BigInt(1000);
+        //         const finalFoundationBalance = await xai.balanceOf(foundationAddr);
+        //         expect(finalFoundationBalance).to.equal(initialFoundationBalance + foundationAmount);
+        //     }
+        //     // await xai.connect(addr1).burn((await xai.balanceOf(addr1.address))); // burn the xai for the next iteration
+
+        //     const redemptionRequestCount = await esXai.getRedemptionRequestCount(addr1.address);
+        //     expect(redemptionRequestCount).to.equal(3);
+
+        // })
+
+        // it("Check whitelist addresses are added and retrieved correctly", async function() {
+        //     const {esXai, addr1, addr2, addr3, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
+        //     const whitelistCount2 = await esXai.getWhitelistCount();
+        //     console.log("WL Count2: ", whitelistCount2);
+        //     await esXai.connect(esXaiDefaultAdmin).addToWhitelist(addr1.address);
+        //     await esXai.connect(esXaiDefaultAdmin).addToWhitelist(addr2.address);
+        //     const whitelistCount = await esXai.getWhitelistCount();
+        //     expect(whitelistCount).to.equal(4);
+        //     const whitelistedAddress1 = await esXai.getWhitelistedAddressAtIndex(2);
+        //     const whitelistedAddress2 = await esXai.getWhitelistedAddressAtIndex(3);
+        //     expect(whitelistedAddress1).to.equal(addr1.address);
+        //     expect(whitelistedAddress2).to.equal(addr2.address);
+        // })
+
+        
+        // it("Check redemption passes for kyc wallets if they hold more keys than the max allowed", async function() {
+        //     const {esXai, esXaiMinter, addr2, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
+        //     await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);            
+        //     const redemptionAmount = BigInt(1000);            
+        //     const initialBalance = await esXai.balanceOf(addr2.address);
+        //     await esXai.connect(esXaiMinter).mint(addr2.address, redemptionAmount * BigInt(3));            
+        //     const duration = 15 * 24 *60 *60;
+        //     await esXai.connect(addr2).startRedemption(redemptionAmount, duration);
+        //     await network.provider.send("evm_increaseTime", [duration]);
+        //     await network.provider.send("evm_mine");            
+
+        //     // Complete redemption    
+        //     // Assuming the redemption was successful, check the new total supply
+        //     const finalBalance = await esXai.balanceOf(addr2.address);
+        //     expect(initialBalance).to.be.below(finalBalance); // Check if the total balance increased
+
+        // })
+
+        // it("Check redemption fails for non-kyc wallets if they hold more keys than the max allowed", async function() {
+        //     const {esXai, esXaiMinter, addr3, esXaiDefaultAdmin} = await loadFixture(deployInfrastructure);
+        //     await esXai.connect(esXaiDefaultAdmin).changeRedemptionStatus(true);
+        //     const redemptionAmount = BigInt(1000);
+        //     await esXai.connect(esXaiMinter).mint(addr3.address, redemptionAmount * BigInt(3));            
+        //     const duration = 15 * 24 *60 *60;
+        //     await esXai.connect(addr3).startRedemption(redemptionAmount, duration);
+        //     await network.provider.send("evm_increaseTime", [duration]);
+        //     await network.provider.send("evm_mine");
+        //     expect (esXai.connect(addr3).completeRedemption(0)).to.be.revertedWith("You own too many keys, must be KYC approved to claim.")
+        // })
+
+    }
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187862702

Added failed KYC variable to pool factory.

If preferred, I can move the variable to the esXai contract and have the poolFactory check the esXai contract instead.

I chose not to include the variable in the referee due to size issues.

Note, had to remove ReentrancyGuard from NodeLicense to get tests to run. Those changes were in another PR [#301](https://github.com/xai-foundation/sentry/pull/301) but also included here