### PR TITLE
add announcement banner for staking app

### DIFF
--- a/apps/web-staking/src/app/components/AnnouncementBanner.tsx
+++ b/apps/web-staking/src/app/components/AnnouncementBanner.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from "react";
+import ExternalLinkIcon from "../../../../../packages/ui/src/rebrand/icons/ExternalLinkIcon";
+import { CloseIcon } from "./icons/IconsComponent";
+
+interface IAnnouncementBanner {
+    activateBanner: boolean; // Externally control if the banner should be shown at all. Set to false if no banner should be displayed in a release
+    bannerVersion: string; // Banner version for session storage. Used to enable setting a new announcement banner even if it previously has been closed
+    title: string;
+    text: string;
+    href: string;
+}
+
+const AnnouncementBanner = ({ title, text, href, activateBanner, bannerVersion }: IAnnouncementBanner) => {
+
+    const sessionKey = `announcement_banner_${bannerVersion}`
+
+    const [isShow, setIsShow] = useState<number>(Number(sessionStorage.getItem(sessionKey)));
+
+    useEffect(() => {
+        const value = sessionStorage.getItem(sessionKey) || Number(activateBanner);
+        setIsShow(Number(value));
+    }, []);
+
+    const closeBanner = (e: React.MouseEvent<HTMLElement>) => {
+        e.preventDefault();
+        setIsShow(0);
+        sessionStorage.setItem(sessionKey, "0");
+    };
+
+    return (
+        <>
+            {(activateBanner && isShow) && <div
+                className="w-full announcementBannerGradient flex flex-col md:flex-row md:justify-center md:items-center justify-start items-start h-[132px] md:h-[54px] text-lg relative">
+                <div
+                    className="flex flex-col md:flex-row md:justify-center md:items-center justify-start items-start md:gap-[5px] gap-0 text-lg mt-[14px] ml-[17px] md:my-0 md:mx-0">
+                    <span className="block font-bold text-nulnOil">{title}</span>
+                    <span className="block text-nulnOil max-w-[80%]">{text}</span>
+                    <span className="block font-bold text-nulnOil md:mt-0 mtb-[10px]">
+                        <a className="underline flex items-center gap-[7px]" href={href} target={"_blank"}>
+                            Learn more
+                            <ExternalLinkIcon extraClasses={{ svgClasses: "mt-[-4px]" }} />
+                        </a>
+                    </span>
+                </div>
+                <span onClick={closeBanner}
+                    className="block cursor-pointer absolute right-[23px] md:top-1/2 top-[20px] md:-translate-y-[50%]">
+                    <CloseIcon fill={"#181818"} height={13} width={13} />
+                </span>
+            </div>}
+        </>);
+};
+
+export default AnnouncementBanner;

--- a/apps/web-staking/src/app/components/navbar/WrapperComponent.tsx
+++ b/apps/web-staking/src/app/components/navbar/WrapperComponent.tsx
@@ -4,6 +4,7 @@ import { useTheme } from "next-themes";
 import NavbarComponent from "./NavbarComponent";
 import SidebarComponent from "./SidebarComponent";
 import { useEffect } from "react";
+import AnnouncementBanner from "@/app/components/AnnouncementBanner";
 
 export default function WrapperComponent({ children }: { children: React.ReactNode }) {
 
@@ -15,6 +16,13 @@ export default function WrapperComponent({ children }: { children: React.ReactNo
 
 	return (
 		<>
+			<AnnouncementBanner
+				activateBanner={true}
+				bannerVersion="tk"
+				title={"Announcement title."}
+				text={"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc non porttitor urna."}
+				href={"https://xai-foundation.gitbook.io/xai-network"}
+			/>
 			<div className="flex">
 				<div className="hidden lg:block">
 					<SidebarComponent />

--- a/apps/web-staking/src/app/globals.css
+++ b/apps/web-staking/src/app/globals.css
@@ -110,6 +110,10 @@
     padding-right: 0 !important;
     gap: 10px !important;
   }
+
+  .announcementBannerGradient {
+    background: transparent linear-gradient(92deg, #97C8EB 0%, #FFC7D2 100%) 0% 0% no-repeat padding-box;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/187849510

Adding an announcement banner to the staking app.
Can be controlled from the wrapper component.