### PR TITLE
Update boostfactor to support 4 decimals, update base chance to 0.01%

### DIFF
--- a/infrastructure/smart-contracts/contracts/RefereeCalculations.sol
+++ b/infrastructure/smart-contracts/contracts/RefereeCalculations.sol
@@ -92,7 +92,7 @@ contract RefereeCalculations is Initializable, AccessControlUpgradeable {
         uint256 seed = uint256(seedHash);
 
         // First, we calculate the expected number of winning keys based on the (key count) and boost factor (probability).
-        uint256 expectedWinningKeys = (_keyCount * probability) / 10_000;
+        uint256 expectedWinningKeys = (_keyCount * probability) / 1_000_000;
 
         if (expectedWinningKeys == 0) {
             // We use a large number (1,000,000) to help us calculate very small probabilities accurately.
@@ -100,7 +100,7 @@ contract RefereeCalculations is Initializable, AccessControlUpgradeable {
 
             // We scale the probability by multiplying it with scaleFactor and then dividing by 10,000.
             // This helps in handling small decimal values accurately without losing precision.
-            uint256 scaledProbability = (probability * scaleFactor) / 10_000;
+            uint256 scaledProbability = (probability * scaleFactor) / 1_000_000;
 
             // We calculate the expected number of winning keys, but we scale it up by multiplying with scaledProbability.
             // This scaling helps in better accuracy while dealing with very small probabilities.

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
@@ -235,9 +235,14 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
     function initialize(address _refereeCalculationsAddress) public reinitializer(7) {
         refereeCalculationsAddress = _refereeCalculationsAddress;
 
-        //TODO update with correct values on deploy
-        // maxStakeAmountPerLicense = 2_000_000 * 10 ** 18;
-        // maxKeysPerPool = 100_000;
+        maxStakeAmountPerLicense = 200 * 10 ** 18;
+        maxKeysPerPool = 100_000;
+
+        // Updated base chance to 0.01
+        stakeAmountBoostFactors[0] = 150; // 0.015
+        stakeAmountBoostFactors[1] = 200; // 0.02
+        stakeAmountBoostFactors[2] = 300; // 0.03
+        stakeAmountBoostFactors[3] = 700; // 0.07
     }
 
     modifier onlyPoolFactory() {
@@ -632,9 +637,15 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
     }
 
     /**
-     * @dev Looks up payout boostFactor based on the staking tier.
+     * @dev Looks up payout boostFactor based on the staking tier. 
+     * Boostfactor is based with 4 decimals:
+     *      1     => 0.0001%
+     *      100   => 0.01%
+     *      10000 => 1%
+     *      20000 => 2%
+     * The current base chance for no stae is 100 => 0.01%
      * @param stakedAmount The staked amount.
-     * @return The payout chance boostFactor. 200 for double the chance.
+     * @return The payout chance boostFactor.
      */
     function _getBoostFactor(uint256 stakedAmount) internal view returns (uint256) {
         if (stakedAmount < stakeAmountTierThresholds[0]) {
@@ -829,7 +840,7 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
 
         require(numberOfKeys > 0, "57");
 
-        // Set the boost factor intially to 100
+        // Set the boost factor intially to 100 (0.01%)
         uint256 boostFactor = 100;
 
         // If the bulk address is a pool, determine the boost factor
@@ -942,7 +953,7 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
         // Confirm not already submitted
         require(!bulkSubmissions[_challengeId][_bulkAddress].submitted, "54");
 
-        // Set the boost factor intially to 100
+        // Set the boost factor intially to 100 (0.01%)
         uint256 boostFactor = 100;
 
         // If the bulk address is a pool, determine the boost factor

--- a/infrastructure/smart-contracts/test/tinykeys/RefereeBulkSubmissions.mjs
+++ b/infrastructure/smart-contracts/test/tinykeys/RefereeBulkSubmissions.mjs
@@ -567,7 +567,7 @@ function BulkSubmissionsRewardRate(deployInfrastructure) {
 
     it("Confirm the amount of winning keys for pools falls within acceptable tolerances for simulated runs.", async function () {
         const { refereeCalculations, addr1 } = await loadFixture(deployInfrastructure);
-        const stakingBoostFactors = [100, 200, 300];
+        const stakingBoostFactors = [100, 150, 200, 300, 700];
         const keyAmountTests = [100, 200, 300, 1000]; // Test cases for staked key amounts
         const iterations = 1000;  // Number of times to run each test case
 

--- a/infrastructure/smart-contracts/test/utils/getWinningKeyCountLocal.mjs
+++ b/infrastructure/smart-contracts/test/utils/getWinningKeyCountLocal.mjs
@@ -16,11 +16,11 @@ export function getWinningKeyCountLocal(keyCount, boostFactor, bulkAddress, chal
     );
     const seed = BigInt(seedHash);
 
-    const expectedWinningKeys = Math.floor((keyCount * probability) / 10000);
+    const expectedWinningKeys = Math.floor((keyCount * probability) / 1_000_000);
 
     if (expectedWinningKeys === 0) {
-        const scaleFactor = 1000000;
-        const scaledProbability = Math.floor((probability * scaleFactor) / 10000);
+        const scaleFactor = 1_000_000;
+        const scaledProbability = Math.floor((probability * scaleFactor) / 1_000_000);
         const scaledExpectedWinningKeys = BigInt(keyCount) * BigInt(scaledProbability);
 
         const randomThreshold = generateRandomNumber(seed, "threshold") % BigInt(scaleFactor);

--- a/packages/core/src/operator/operator-runtime/getWinningKeyCount.ts
+++ b/packages/core/src/operator/operator-runtime/getWinningKeyCount.ts
@@ -26,11 +26,11 @@ export const getWinningKeyCount = (keyCount: number, boostFactor: number, bulkAd
     );
     const seed = BigInt(seedHash);
 
-    const expectedWinningKeys = Math.floor((keyCount * probability) / 10000);
+    const expectedWinningKeys = Math.floor((keyCount * probability) / 1_000_000);
 
     if (expectedWinningKeys === 0) {
-        const scaleFactor = 1000000;
-        const scaledProbability = Math.floor((probability * scaleFactor) / 10000);
+        const scaleFactor = 1_000_000;
+        const scaledProbability = Math.floor((probability * scaleFactor) / 1_000_000);
         const scaledExpectedWinningKeys = BigInt(keyCount) * BigInt(scaledProbability);
 
         const randomThreshold = generateRandomNumber(seed, "threshold") % BigInt(scaleFactor);


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/188108692

Add the mainnet configs to the Referee initialize.

Update the boostFactor to support 4 decimals, setting the base chance to 0.01 % (Silver tier => 0.015%)