### PR TITLE
fix challenger overwrite lastAssertionTime when rollup missed NodeCon…

### DIFF
--- a/apps/cli/src/commands/boot-challenger.ts
+++ b/apps/cli/src/commands/boot-challenger.ts
@@ -169,7 +169,7 @@ const checkTimeSinceLastAssertion = async (lastAssertionTime: number, commandIns
 const sendNotification = async (message: string, commandInstance: Vorpal.CommandInstance) => {
     if (cachedWebhookUrl) {
         try {
-            await axios.post(cachedWebhookUrl, { text: `<!channel> [Instance ${CHALLENGER_INSTANCE}]: ${message}` });
+            await axios.post(cachedWebhookUrl, { text: `<!channel> [Instance ${CHALLENGER_INSTANCE}]: ${message}`, unfurl_links: false, });
         } catch (error) {
             commandInstance.log(`[${new Date().toISOString()}] Failed to send notification request ${error && (error as Error).message ? (error as Error).message : error}`);
         }


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/187933933

Remove overwrite lastAssertionTime in healthcheck
Updated notification message to include if assertion was missed on the rollup

Currently running local instance on mainnet for testing.