### PR TITLE
fix position and formatting of restriced IP text

### DIFF
--- a/apps/web-staking/src/app/IpLocationChecker.tsx
+++ b/apps/web-staking/src/app/IpLocationChecker.tsx
@@ -18,7 +18,9 @@ export function IpLocationChecker({ children }: PropsWithChildren) {
 
 	if (blocked) {
 		return (
-			<pre className="p-2 text-sm">You are in a country restricted from using this application.</pre>
+			<div className="w-full h-screen flex justify-center items-center">
+				<h3 className="md:text-3xl text-2xl text-white font-bold text-center">You are in a country restricted from using this application.</h3>
+			</div>
 		);
 	}
 


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/188143506

Update the formatting of the `IpLocationChecker` when blocked.

Tested locally by manually setting `setBlocked(true)` to trigger the IP block.
Checked position and formatting on desktop & mobile