### PR TITLE
Updated Operator Logs and Health Check Frequency

### DIFF
--- a/packages/core/src/operator/operator-runtime/bootOperatorRuntime.ts
+++ b/packages/core/src/operator/operator-runtime/bootOperatorRuntime.ts
@@ -38,7 +38,7 @@ export const bootOperatorRuntime = async (
         
         await processNewChallenge(openChallenge.challengeNumber, openChallenge, bulkOwnersAndPools, refereeConfig);
 
-        logFunction(`Processing open challenges.`);
+        logFunction(`Processing open challenges. Challenges should occur roughly once per hour. Rewards will still accrue even if challenges are delayed.`);
 
         //Remove submissions for current challenge so we don't process it again
         bulkOwnersAndPools.forEach(b => {

--- a/packages/core/src/operator/operator-runtime/listenForChallengesCallback.ts
+++ b/packages/core/src/operator/operator-runtime/listenForChallengesCallback.ts
@@ -29,7 +29,7 @@ export async function listenForChallengesCallback(challengeNumber: bigint, chall
             });
     }
 
-    operatorState.cachedLogger(`Received new challenge with number: ${challengeNumber}.`);
+    operatorState.cachedLogger(`Received new challenge with number: ${challengeNumber}. Delayed challenges will still accrue rewards.`);
     operatorState.cachedLogger(`Processing challenge...`);
 
     // Add a delay of 1 -300 seconds to the new challenge process so not all operators request the subgraph at the same time

--- a/packages/core/src/operator/operator-runtime/operator-v1/bootOperatorRuntime.ts
+++ b/packages/core/src/operator/operator-runtime/operator-v1/bootOperatorRuntime.ts
@@ -28,7 +28,7 @@ export const bootOperatorRuntime_V1 = async (
             await retry(() => loadOperatorKeysFromGraph_V1(operatorState.operatorAddress, BigInt(latestClaimableChallenge)));
 
         await processNewChallenge_V1(BigInt(openChallenge.challengeNumber), openChallenge, nodeLicenseIds, sentryKeysMap, sentryWalletMap, mappedPools, refereeConfig);
-        logFunction(`Processing open challenges.`);
+        logFunction(`Processing open challenges. Challenges should occur roughly once per hour. Rewards will still accrue even if challenges are delayed.`);
 
         //Remove submissions for current challenge so we don't process it again
         nodeLicenseIds.forEach(n => {

--- a/packages/core/src/operator/operatorRuntime.ts
+++ b/packages/core/src/operator/operatorRuntime.ts
@@ -117,7 +117,7 @@ export async function operatorRuntime(
         }
     };
     fetchBlockNumber();
-    const intervalId = setInterval(fetchBlockNumber, 300000); // 300,000 milliseconds = 5 minutes
+    const intervalId = setInterval(fetchBlockNumber, 900000); // 900,000 milliseconds = 15 minutes
 
     async function stop() {
         clearInterval(intervalId);

--- a/packages/core/src/utils/resilientEventListener.ts
+++ b/packages/core/src/utils/resilientEventListener.ts
@@ -16,7 +16,7 @@ export interface EventListenerError {
 }
 
 const EXPECTED_PONG_BACK = 15000;
-const KEEP_ALIVE_CHECK_INTERVAL = 60 * 1000; //7500;
+const KEEP_ALIVE_CHECK_INTERVAL = 60 * 15 * 1000; //every 15 mins
 
 /**
  * This function creates a resilient event listener for a given contract on an EVM-based network.

--- a/packages/core/src/utils/resilientEventListener.ts
+++ b/packages/core/src/utils/resilientEventListener.ts
@@ -16,7 +16,7 @@ export interface EventListenerError {
 }
 
 const EXPECTED_PONG_BACK = 15000;
-const KEEP_ALIVE_CHECK_INTERVAL = 60 * 15 * 1000; //every 15 mins
+const KEEP_ALIVE_CHECK_INTERVAL = 60 * 1000; //every 1 min
 
 /**
  * This function creates a resilient event listener for a given contract on an EVM-based network.


### PR DESCRIPTION
[Ticket](https://www.pivotaltracker.com/story/show/187985681)

* Updated Websocket and JSON RPC health check frequency to every 15 minutes.
* Updated language in the operator runtime logs to explain that challenges should occur roughly once per hour, but delayed challenges will not fail to accrue rewards.

Tested by running the `boot-operator` in the cli and observing the updated logs and health check frequency.