### PR TITLE
[Paused] - Redemption Vouchers Smart Contract Upgrades

### DIFF
--- a/apps/web-staking/src/app/components/redeem/History.tsx
+++ b/apps/web-staking/src/app/components/redeem/History.tsx
@@ -16,7 +16,7 @@ import { MODAL_BODY_TEXT } from "./Constants";
 import { WriteFunctions, executeContractWrite } from "@/services/web3.writes";
 import { BaseModal, PrimaryButton } from "@/app/components/ui";
 import { TextButton } from "@/app/components/ui/buttons";
-import { useBlockIp, useGetKYCApproved } from "@/app/hooks";
+import { useBlockIp, useGetEsXaiBalanceHooks, useGetKYCApproved } from "@/app/hooks";
 import { listOfCountries } from "../constants/constants";
 
 interface HistoryCardProps {
@@ -154,6 +154,7 @@ export default function History({ redemptions, reloadRedemptions }: {
     const [isOpen, setIsOpen] = useState<boolean>(false);
 	const { isApproved } = useGetKYCApproved();
 	const {blocked, loading} = useBlockIp();
+	const { esXaiBalance, refreshEsXaiBalance } = useGetEsXaiBalanceHooks();
 	
 
 	const { switchChain } = useSwitchChain();
@@ -186,7 +187,8 @@ export default function History({ redemptions, reloadRedemptions }: {
 		}
 		if (isError) {
 			updateOnError()
-		}
+		}		
+		refreshEsXaiBalance();
 	}, [isSuccess, isError, updateOnSuccess, updateOnError]);
 
 	const onClaim = async (redemption: RedemptionRequest) => {
@@ -264,7 +266,7 @@ export default function History({ redemptions, reloadRedemptions }: {
 									onClaim={() => onClaim(r)}
 									onCancel={(onClose) => onCancel(r, onClose)}
 									claimable={true}
-									claimDisabled={isLoading}
+									claimDisabled={isLoading || r.redeemAmount > esXaiBalance} // Disable button if the user has less esXAI than the redeem amount}
 									receivedAmount={r.receiveAmount}
 									redeemedAmount={r.redeemAmount}
 									receivedCurrency="XAI"

--- a/apps/web-staking/src/app/hooks/useGetEsXaiBalance.ts
+++ b/apps/web-staking/src/app/hooks/useGetEsXaiBalance.ts
@@ -1,23 +1,23 @@
 import {
-    getEsXaiBalance,
-    getNetwork
+  getEsXaiBalance,
+  getNetwork
 } from "@/services/web3.service";
 import { useEffect, useState } from "react";
 import { useAccount } from "wagmi";
 
-
 export const useGetEsXaiBalanceHooks = () => {
   const [esXaiBalance, setEsXaiBalance] = useState(0);
   const { address, chainId } = useAccount();
+  const [refresh, setRefresh] = useState(false);
 
   useEffect(() => {
     if (!address || !chainId) return;
     getEsXaiBalance(getNetwork(chainId), address).then(({ balance }) => {
       setEsXaiBalance(balance);
     });
-  }, [address, chainId]);
+  }, [address, chainId, refresh]); 
 
-  return { esXaiBalance };
+  const refreshEsXaiBalance = () => setRefresh((prevRefresh) => !prevRefresh);
+
+  return { esXaiBalance, refreshEsXaiBalance };
 };
-
-

--- a/infrastructure/smart-contracts/contracts/upgrades/esXai/esXai3.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/esXai/esXai3.sol
@@ -362,7 +362,7 @@ contract esXai3 is ERC20Upgradeable, ERC20BurnableUpgradeable, AccessControlUpgr
                 if(request.amount > 0 && !request.completed && !request.voucherIssued) {
                     request.voucherIssued = true;
                     _totalPendingRedemptions[account] += request.amount;
-                    transfer(accounts[i], request.amount);
+                    _transfer(address(this), account, request.amount);
                 }
             }
             emit VoucherIssued(account, accountIndices);

--- a/infrastructure/smart-contracts/contracts/upgrades/esXai/esXai3.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/esXai/esXai3.sol
@@ -225,7 +225,7 @@ contract esXai3 is ERC20Upgradeable, ERC20BurnableUpgradeable, AccessControlUpgr
         }else{
             // If the voucher was not issued
             // Transfer the esXai tokens back to the sender's account
-            _transfer(msg.sender, address(this), request.amount);
+            _transfer(address(this), msg.sender, request.amount);
         }
 
         emit RedemptionCancelled(msg.sender, index);

--- a/infrastructure/smart-contracts/contracts/upgrades/esXai/esXai3.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/esXai/esXai3.sol
@@ -351,7 +351,6 @@ contract esXai3 is ERC20Upgradeable, ERC20BurnableUpgradeable, AccessControlUpgr
     * @dev Only callable by an account with the `DEFAULT_ADMIN_ROLE`.
     */
     function convertRedemptionsInProcess(address[] calldata accounts, uint256[][] calldata indices) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(!_redemptionActive, "Redemptions must be paused to convert");
         require(accounts.length == indices.length, "Invalid input");
         for(uint256 i = 0; i < accounts.length; i++) {
             address account = accounts[i];

--- a/infrastructure/smart-contracts/contracts/upgrades/esXai/esXai3.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/esXai/esXai3.sol
@@ -272,8 +272,8 @@ contract esXai3 is ERC20Upgradeable, ERC20BurnableUpgradeable, AccessControlUpgr
         request.completed = true;
         request.endTime = block.timestamp;
 
-        // Adding this just in case a conversion was some how missed.
-        // This would allow the user to still redeem the esXai while keeping the state correct.
+        // If the voucher was issued decrement the totalPendingRedemptions
+        // and transfer the esXai tokens from the sender's account to this contract
         if(request.voucherIssued) {     
 
             // Update the user's totalPendingRedemptions

--- a/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
@@ -106,12 +106,20 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
     // Role definition for stake keys admin
     bytes32 public constant STAKE_KEYS_ADMIN_ROLE = keccak256("STAKE_KEYS_ADMIN_ROLE");
 
+    mapping(address => bool) public totalStakeCalculated;
+
+    // =================> VERY IMPORTANT <============================================
+    // Making this variable private as it SHOULD NOT BE USED as the source of truth for total stake
+    // The getTotalesXaiStakedByUser function should be used instead
+    // This mapping will only be accurate AFTER a user has interacted with a pool
+    mapping(address => uint256) private _totalEsXaiStakeByUser;
+
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[499] private __gap;
+    uint256[497] private __gap;
 
     // Events for various actions within the contract
     event StakingEnabled();
@@ -585,6 +593,14 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
 
         associateUserWithPool(msg.sender, pool);
 
+        // Update total stake
+        if(!totalStakeCalculated[msg.sender]) {
+            _totalEsXaiStakeByUser[msg.sender] = getTotalesXaiStakedByUser(msg.sender);
+            totalStakeCalculated[msg.sender] = true;
+        } else {
+            _totalEsXaiStakeByUser[msg.sender] += amount;
+        }
+
         emit StakeEsXai(
             msg.sender,
             pool,
@@ -614,6 +630,20 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
 
         if (!stakingPool.isUserEngagedWithPool(msg.sender)) {
             removeUserFromPool(msg.sender, pool);
+        }
+
+        // Update total stake
+        if(!totalStakeCalculated[msg.sender]) {
+            uint256 totalPools = interactedPoolsOfUser[msg.sender].length;
+            // We check the total pools interacted with by the user to avoid running out of gas
+            // This ensures we do not run this one time calculation until we are sure that it will not run out of gas
+            // This ensures a user can always unstake their esXai
+            if(totalPools < 150) {
+                _totalEsXaiStakeByUser[msg.sender] = getTotalesXaiStakedByUser(msg.sender);
+                totalStakeCalculated[msg.sender] = true;
+            }
+        } else {
+            _totalEsXaiStakeByUser[msg.sender] -= amount;
         }
 
         emit UnstakeEsXai(
@@ -820,5 +850,49 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
 
     function setFailedKyc(address user, bool failed) external onlyRole(DEFAULT_ADMIN_ROLE) {
         failedKyc[user] = failed;
+    }
+
+    /**
+    * @notice Retrieves the total amount of esXAI staked by a specific user across all interacted staking pools.
+    * @dev If the user's total stake has already been calculated and cached, the cached value is returned.
+    *      Otherwise, it calculates the total staked amount by iterating over all staking pools the user has interacted with.
+    * @param user The address of the user whose total staked amount is to be retrieved.
+    * @return The total amount of esXAI staked by the user across all pools.
+    */
+    function getTotalesXaiStakedByUser(address user) public view returns (uint256) {
+        if (totalStakeCalculated[user]) {
+            return _totalEsXaiStakeByUser[user];
+        }
+
+        uint256 totalStakeAmount = 0;
+        address[] memory userPools = interactedPoolsOfUser[user];
+        for (uint256 i = 0; i < userPools.length; i++) {
+            totalStakeAmount += StakingPool(userPools[i]).getStakedAmounts(user);
+        }
+        return totalStakeAmount;
+    }
+
+    /**
+    * @notice Calculates the total stake amount for a list of users across all pools they have interacted with.
+    * @dev Iterates over each user provided in the `users` calldata array. For each user, it checks if the total stake has already been calculated.
+    *      If not, it sums the staked amounts from all staking pools the user has interacted with and stores the result.
+    *      Uses storage for interacting pools array to optimize gas usage. Only processes users whose total stake hasn't been calculated yet.
+    * @param users An array of user addresses for which the total stake needs to be calculated.
+    */
+    function calculateUserTotalStake(address[] calldata users) external {
+        for (uint256 i = 0; i < users.length; i++) {
+            address user = users[i];
+            if(totalStakeCalculated[user]) {
+                continue;
+            }
+            uint256 totalStakeAmount = 0;
+            address[] storage userPools = interactedPoolsOfUser[user]; // Use storage instead of memory
+            uint256 poolCount = userPools.length; // Cache length for gas optimization
+            for (uint256 j = 0; j < poolCount; j++) {
+                totalStakeAmount += StakingPool(userPools[j]).getStakedAmounts(user);
+            }
+            _totalEsXaiStakeByUser[user] = totalStakeAmount;
+            totalStakeCalculated[user] = true;
+        }
     }
 }

--- a/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
@@ -881,18 +881,17 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
     */
     function calculateUserTotalStake(address[] calldata users) external {
         for (uint256 i = 0; i < users.length; i++) {
-            address user = users[i];
-            if(totalStakeCalculated[user]) {
+            if(totalStakeCalculated[users[i]]) {
                 continue;
             }
             uint256 totalStakeAmount = 0;
-            address[] storage userPools = interactedPoolsOfUser[user]; // Use storage instead of memory
+            address[] storage userPools = interactedPoolsOfUser[users[i]]; // Use storage instead of memory
             uint256 poolCount = userPools.length; // Cache length for gas optimization
             for (uint256 j = 0; j < poolCount; j++) {
-                totalStakeAmount += StakingPool(userPools[j]).getStakedAmounts(user);
+                totalStakeAmount += StakingPool(userPools[j]).getStakedAmounts(users[i]);
             }
-            _totalEsXaiStakeByUser[user] = totalStakeAmount;
-            totalStakeCalculated[user] = true;
+            _totalEsXaiStakeByUser[users[i]] = totalStakeAmount;
+            totalStakeCalculated[users[i]] = true;
         }
     }
 }


### PR DESCRIPTION
[Ticket - Initiate Redemption](https://www.pivotaltracker.com/story/show/188093494)
[Ticket - Pool Factory Total Staked EsXai](https://www.pivotaltracker.com/story/show/188164723)
[Ticket - Claim Redemptions](https://www.pivotaltracker.com/story/show/188093497)
[Ticket - Convert Existing Redemptions](https://www.pivotaltracker.com/story/show/188093540)

Continuation of previous closed [PR #387](https://github.com/xai-foundation/sentry/pull/387)

1. Updated esXai contract to handle vouchers
2. Updated claim button in U/I to disable if user does not have enough esXai
3. Updated Pool Factory to manage total staked esXai in the state of the contract.
4. The current implementation already displays an error message in the toast upon error. Per Mark, this is a rare edge case and doesn't need additional attention. It only applies if a user has 2 browser tabs open, the potential second claim could fail which would trigger the error toast.

Testing Smart Contracts: => [Ticket](https://www.pivotaltracker.com/story/show/188163662)
Testing Button Disable: ran locally, hardcoded a balance to test that button state changes. Console logged the balance returned from the hook to confirm it was accurate.




