### PR TITLE
fix operator not loading keys form RPC in v1

### DIFF
--- a/infrastructure/sentry-subgraph/src/referee.ts
+++ b/infrastructure/sentry-subgraph/src/referee.ts
@@ -91,11 +91,6 @@ export function handleAssertionSubmitted(event: AssertionSubmittedEvent): void {
     log.warning("Failed to find refereeConfig handleAssertionSubmitted TX: " + event.transaction.hash.toHexString(), [])
     return;
   }
-  if (refereeConfig.version.gt(BigInt.fromI32(6))) {
-    // Event replaced in newer versions of the Referee for simpler event handlers
-    return;
-  }
-
 
   const challenge = Challenge.load(event.params.challengeId.toString())
   if (!challenge) {
@@ -255,16 +250,17 @@ export function handleChallengeSubmitted(event: ChallengeSubmittedEvent): void {
 
 export function handleRewardsClaimed(event: RewardsClaimedEvent): void {
 
+  if (getTxSignatureFromEvent(event) == "0xb4d6b7df") {
+    //If this event was triggered from calling "claimMultipleRewards" we don't need to process as it will be handled in the batchClaim handler
+    return;
+  }
+
   // Load current referee config from the graph
   const refereeConfig = RefereeConfig.load("RefereeConfig");
 
   // If the referee config is not found, log a warning and skip the claim
   if (!refereeConfig) {
     log.warning("Failed to find refereeConfig handleRewardsClaimed TX: " + event.transaction.hash.toHexString(), [])
-    return;
-  }
-  if (refereeConfig.version.gt(BigInt.fromI32(6))) {
-    // Event replaced in newer versions of the Referee for simpler event handlers
     return;
   }
 
@@ -367,16 +363,18 @@ export function handleRewardsClaimed(event: RewardsClaimedEvent): void {
 }
 
 export function handleBatchRewardsClaimed(event: BatchRewardsClaimedEvent): void {
+
+  if (getTxSignatureFromEvent(event) == "0x86bb8f37") {
+    //If this event was triggered from calling "claimReward" we don't need to process as it will be handled in the claim handler
+    return;
+  }
+
   // Load current referee config from the graph
   const refereeConfig = RefereeConfig.load("RefereeConfig");
 
   // If the referee config is not found, log a warning and skip the claim
   if (!refereeConfig) {
     log.warning("Failed to find refereeConfig handleBatchRewardsClaimed TX: " + event.transaction.hash.toHexString(), [])
-    return;
-  }
-  if (refereeConfig.version.gt(BigInt.fromI32(6))) {
-    // Event replaced in newer versions of the Referee for simpler event handlers
     return;
   }
 

--- a/packages/core/src/operator/operator-runtime/operator-v1/loadOperatorKeysFromRPC.ts
+++ b/packages/core/src/operator/operator-runtime/operator-v1/loadOperatorKeysFromRPC.ts
@@ -43,8 +43,7 @@ export const loadOperatorKeysFromRPC_V1 = async (
     let sentryKeysMap: { [keyId: string]: SentryKey } = {}
 
     //If we don't have cached keys from owner we fetch them and the metadata from the RPC
-    if (!operatorState.cachedKeysOfOwner) {
-        operatorState.cachedKeysOfOwner = {};
+    if (Object.keys(operatorState.cachedKeysOfOwner).length == 0) {
 
         for (const owner of owners) {
             operatorState.cachedLogger(`Fetching node licenses for owner ${owner}.`);
@@ -106,7 +105,7 @@ export const loadOperatorKeysFromRPC_V1 = async (
 
     operatorState.cachedLogger(`Total Sentry Keys fetched: ${nodeLicenseIds.length}.`);
     operatorState.cachedLogger(`Fetched ${keysOfOwnersCount} keys of owners.`);
-    operatorState.cachedLogger(`Fetched ${Object.keys(sentryKeysMap).length - keysOfOwnersCount} keys of pools.`);
+    operatorState.cachedLogger(`Fetched ${Object.keys(sentryKeysMap).length - keysOfOwnersCount} additional keys of pools.`);
 
     return { sentryKeysMap, nodeLicenseIds }
 }


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/188182015

Fixed the check for operatorSate cache in loadOperatorKeys V1 on RPC.
Removed the subgraph returns on referee version > 6, these are from the previous solution design, moving to bulk submissions we don't need to return.

Additionally I added returns to avoid duplicate process of reward claimed events on the subgraph.

This bug followed from testing the operator with version switch for [https://www.pivotaltracker.com/story/show/188116176](#188116176)

New subgraph deployed for further demo: https://subgraphs.alchemy.com/subgraphs/6221/versions/25934
New operator dev release deployed for further testing: https://github.com/xai-foundation/sentry-development/releases/tag/1.1.15-sepolia-116