### PR TITLE
Subgraph ConfirmData

### DIFF
--- a/infrastructure/sentry-subgraph/abis/Rollup.json
+++ b/infrastructure/sentry-subgraph/abis/Rollup.json
@@ -1,0 +1,1055 @@
+[
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint64",
+          "name": "nodeNum",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "blockHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "sendRoot",
+          "type": "bytes32"
+        }
+      ],
+      "name": "NodeConfirmed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint64",
+          "name": "nodeNum",
+          "type": "uint64"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "parentNodeHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "nodeHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "executionHash",
+          "type": "bytes32"
+        },
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "components": [
+                    {
+                      "internalType": "bytes32[2]",
+                      "name": "bytes32Vals",
+                      "type": "bytes32[2]"
+                    },
+                    {
+                      "internalType": "uint64[2]",
+                      "name": "u64Vals",
+                      "type": "uint64[2]"
+                    }
+                  ],
+                  "internalType": "struct GlobalState",
+                  "name": "globalState",
+                  "type": "tuple"
+                },
+                {
+                  "internalType": "enum MachineStatus",
+                  "name": "machineStatus",
+                  "type": "uint8"
+                }
+              ],
+              "internalType": "struct ExecutionState",
+              "name": "beforeState",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "components": [
+                    {
+                      "internalType": "bytes32[2]",
+                      "name": "bytes32Vals",
+                      "type": "bytes32[2]"
+                    },
+                    {
+                      "internalType": "uint64[2]",
+                      "name": "u64Vals",
+                      "type": "uint64[2]"
+                    }
+                  ],
+                  "internalType": "struct GlobalState",
+                  "name": "globalState",
+                  "type": "tuple"
+                },
+                {
+                  "internalType": "enum MachineStatus",
+                  "name": "machineStatus",
+                  "type": "uint8"
+                }
+              ],
+              "internalType": "struct ExecutionState",
+              "name": "afterState",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint64",
+              "name": "numBlocks",
+              "type": "uint64"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct Assertion",
+          "name": "assertion",
+          "type": "tuple"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "afterInboxBatchAcc",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "wasmModuleRoot",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "inboxMaxCount",
+          "type": "uint256"
+        }
+      ],
+      "name": "NodeCreated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint64",
+          "name": "nodeNum",
+          "type": "uint64"
+        }
+      ],
+      "name": "NodeRejected",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Paused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint64",
+          "name": "challengeIndex",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "asserter",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "challenger",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "challengedNode",
+          "type": "uint64"
+        }
+      ],
+      "name": "RollupChallengeStarted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "machineHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        }
+      ],
+      "name": "RollupInitialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Unpaused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "initialBalance",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "finalBalance",
+          "type": "uint256"
+        }
+      ],
+      "name": "UserStakeUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "initialBalance",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "finalBalance",
+          "type": "uint256"
+        }
+      ],
+      "name": "UserWithdrawableFundsUpdated",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "_stakerMap",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountStaked",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint64",
+          "name": "index",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "latestStakedNode",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "currentChallenge",
+          "type": "uint64"
+        },
+        {
+          "internalType": "bool",
+          "name": "isStaked",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "staker",
+          "type": "address"
+        }
+      ],
+      "name": "amountStaked",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "baseStake",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "bridge",
+      "outputs": [
+        {
+          "internalType": "contract IBridge",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "chainId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "challengeManager",
+      "outputs": [
+        {
+          "internalType": "contract IChallengeManager",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "confirmPeriodBlocks",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "staker",
+          "type": "address"
+        }
+      ],
+      "name": "currentChallenge",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "extraChallengeTimeBlocks",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "firstUnresolvedNode",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "nodeNum",
+          "type": "uint64"
+        }
+      ],
+      "name": "getNode",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "stateHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "challengeHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "confirmData",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "prevNum",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "deadlineBlock",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "noChildConfirmedBeforeBlock",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "stakerCount",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "childStakerCount",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "firstChildBlock",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "latestChildNumber",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "createdAtBlock",
+              "type": "uint64"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "nodeHash",
+              "type": "bytes32"
+            }
+          ],
+          "internalType": "struct Node",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "nodeNum",
+          "type": "uint64"
+        }
+      ],
+      "name": "getNodeCreationBlockForLogLookup",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "staker",
+          "type": "address"
+        }
+      ],
+      "name": "getStaker",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountStaked",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint64",
+              "name": "index",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "latestStakedNode",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "currentChallenge",
+              "type": "uint64"
+            },
+            {
+              "internalType": "bool",
+              "name": "isStaked",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct IRollupCore.Staker",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "stakerNum",
+          "type": "uint64"
+        }
+      ],
+      "name": "getStakerAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "inbox",
+      "outputs": [
+        {
+          "internalType": "contract IInbox",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "staker",
+          "type": "address"
+        }
+      ],
+      "name": "isStaked",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "staker",
+          "type": "address"
+        }
+      ],
+      "name": "isStakedOnLatestConfirmed",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "isValidator",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "staker",
+          "type": "address"
+        }
+      ],
+      "name": "isZombie",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "lastStakeBlock",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "latestConfirmed",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "latestNodeCreated",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "staker",
+          "type": "address"
+        }
+      ],
+      "name": "latestStakedNode",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "loserStakeEscrow",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minimumAssertionPeriod",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "nodeNum",
+          "type": "uint64"
+        },
+        {
+          "internalType": "address",
+          "name": "staker",
+          "type": "address"
+        }
+      ],
+      "name": "nodeHasStaker",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "outbox",
+      "outputs": [
+        {
+          "internalType": "contract IOutbox",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "paused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rollupDeploymentBlock",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rollupEventInbox",
+      "outputs": [
+        {
+          "internalType": "contract IRollupEventInbox",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sequencerInbox",
+      "outputs": [
+        {
+          "internalType": "contract ISequencerInbox",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "stakeToken",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "stakerCount",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalWithdrawableFunds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "validatorUtils",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "validatorWalletCreator",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "validatorWhitelistDisabled",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "wasmModuleRoot",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "withdrawableFunds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "zombieNum",
+          "type": "uint256"
+        }
+      ],
+      "name": "zombieAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "zombieCount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "zombieNum",
+          "type": "uint256"
+        }
+      ],
+      "name": "zombieLatestStakedNode",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+]

--- a/infrastructure/sentry-subgraph/schema.graphql
+++ b/infrastructure/sentry-subgraph/schema.graphql
@@ -127,6 +127,7 @@ type Challenge @entity(immutable: false) {
   amountClaimedByClaimers: BigInt! # uint256
   submissions: [Submission!]! @derivedFrom(field: "challenge")
   bulkSubmissions: [BulkSubmission!]! @derivedFrom(field: "challenge")
+  nodeConfirmed: [NodeConfirmed!]!
 }
 
 enum SubmittedFrom {
@@ -199,6 +200,14 @@ type BulkSubmission @entity(immutable: false) {
   claimed: Boolean! @index
   sentryWallet: SentryWallet
   isPool: Boolean! @index
+}
+
+type NodeConfirmed @entity(immutable: false) {
+  id: String!
+  nodeNum: BigInt # aka assertionId
+  blockHash: Bytes
+  sendRoot: Bytes
+  confirmData: String
 }
 
 

--- a/infrastructure/sentry-subgraph/schema.graphql
+++ b/infrastructure/sentry-subgraph/schema.graphql
@@ -127,7 +127,7 @@ type Challenge @entity(immutable: false) {
   amountClaimedByClaimers: BigInt! # uint256
   submissions: [Submission!]! @derivedFrom(field: "challenge")
   bulkSubmissions: [BulkSubmission!]! @derivedFrom(field: "challenge")
-  nodeConfirmed: [NodeConfirmed!]!
+  nodeConfirmations: [NodeConfirmation!]! @derivedFrom(field: "challenge")
 }
 
 enum SubmittedFrom {
@@ -202,12 +202,13 @@ type BulkSubmission @entity(immutable: false) {
   isPool: Boolean! @index
 }
 
-type NodeConfirmed @entity(immutable: false) {
+type NodeConfirmation @entity(immutable: false) {
   id: String!
-  nodeNum: BigInt # aka assertionId
+  nodeNum: BigInt! # aka assertionId
   blockHash: Bytes
   sendRoot: Bytes
   confirmData: String
+  challenge: Challenge
 }
 
 

--- a/infrastructure/sentry-subgraph/schema.graphql
+++ b/infrastructure/sentry-subgraph/schema.graphql
@@ -204,7 +204,7 @@ type BulkSubmission @entity(immutable: false) {
 
 type NodeConfirmation @entity(immutable: false) {
   id: String!
-  nodeNum: BigInt! # aka assertionId
+  nodeNum: BigInt! @index # aka assertionId
   blockHash: Bytes!
   sendRoot: Bytes!
   confirmData: String!

--- a/infrastructure/sentry-subgraph/schema.graphql
+++ b/infrastructure/sentry-subgraph/schema.graphql
@@ -205,9 +205,9 @@ type BulkSubmission @entity(immutable: false) {
 type NodeConfirmation @entity(immutable: false) {
   id: String!
   nodeNum: BigInt! # aka assertionId
-  blockHash: Bytes
-  sendRoot: Bytes
-  confirmData: String
+  blockHash: Bytes!
+  sendRoot: Bytes!
+  confirmData: String!
   challenge: Challenge
 }
 

--- a/infrastructure/sentry-subgraph/schema/events/Referee.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/Referee.graphql
@@ -22,6 +22,7 @@ type Challenge @entity(immutable: false) {
   amountClaimedByClaimers: BigInt! # uint256
   submissions: [Submission!]! @derivedFrom(field: "challenge")
   bulkSubmissions: [BulkSubmission!]! @derivedFrom(field: "challenge")
+  nodeConfirmed: [NodeConfirmed!]!
 }
 
 enum SubmittedFrom {
@@ -94,4 +95,12 @@ type BulkSubmission @entity(immutable: false) {
   claimed: Boolean! @index
   sentryWallet: SentryWallet
   isPool: Boolean! @index
+}
+
+type NodeConfirmed @entity(immutable: false) {
+  id: String!
+  nodeNum: BigInt # aka assertionId
+  blockHash: Bytes
+  sendRoot: Bytes
+  confirmData: String
 }

--- a/infrastructure/sentry-subgraph/schema/events/Referee.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/Referee.graphql
@@ -22,7 +22,7 @@ type Challenge @entity(immutable: false) {
   amountClaimedByClaimers: BigInt! # uint256
   submissions: [Submission!]! @derivedFrom(field: "challenge")
   bulkSubmissions: [BulkSubmission!]! @derivedFrom(field: "challenge")
-  nodeConfirmations: [NodeConfirmed!]!
+  nodeConfirmations: [NodeConfirmation!]!
 }
 
 enum SubmittedFrom {
@@ -97,7 +97,7 @@ type BulkSubmission @entity(immutable: false) {
   isPool: Boolean! @index
 }
 
-type NodeConfirmed @entity(immutable: false) { # TODO: rename to NodeConfirmation
+type NodeConfirmation @entity(immutable: false) {
   id: String!
   nodeNum: BigInt! # aka assertionId
   blockHash: Bytes

--- a/infrastructure/sentry-subgraph/schema/events/Referee.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/Referee.graphql
@@ -22,7 +22,7 @@ type Challenge @entity(immutable: false) {
   amountClaimedByClaimers: BigInt! # uint256
   submissions: [Submission!]! @derivedFrom(field: "challenge")
   bulkSubmissions: [BulkSubmission!]! @derivedFrom(field: "challenge")
-  nodeConfirmed: [NodeConfirmed!]!
+  nodeConfirmations: [NodeConfirmed!]!
 }
 
 enum SubmittedFrom {
@@ -97,9 +97,9 @@ type BulkSubmission @entity(immutable: false) {
   isPool: Boolean! @index
 }
 
-type NodeConfirmed @entity(immutable: false) {
+type NodeConfirmed @entity(immutable: false) { # TODO: rename to NodeConfirmation
   id: String!
-  nodeNum: BigInt # aka assertionId
+  nodeNum: BigInt! # aka assertionId
   blockHash: Bytes
   sendRoot: Bytes
   confirmData: String

--- a/infrastructure/sentry-subgraph/schema/events/Referee.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/Referee.graphql
@@ -99,7 +99,7 @@ type BulkSubmission @entity(immutable: false) {
 
 type NodeConfirmation @entity(immutable: false) {
   id: String!
-  nodeNum: BigInt! # aka assertionId
+  nodeNum: BigInt! @index # aka assertionId
   blockHash: Bytes!
   sendRoot: Bytes!
   confirmData: String!

--- a/infrastructure/sentry-subgraph/schema/events/Referee.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/Referee.graphql
@@ -100,8 +100,8 @@ type BulkSubmission @entity(immutable: false) {
 type NodeConfirmation @entity(immutable: false) {
   id: String!
   nodeNum: BigInt! # aka assertionId
-  blockHash: Bytes
-  sendRoot: Bytes
-  confirmData: String
+  blockHash: Bytes!
+  sendRoot: Bytes!
+  confirmData: String!
   challenge: Challenge
 }

--- a/infrastructure/sentry-subgraph/schema/events/Referee.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/Referee.graphql
@@ -22,7 +22,7 @@ type Challenge @entity(immutable: false) {
   amountClaimedByClaimers: BigInt! # uint256
   submissions: [Submission!]! @derivedFrom(field: "challenge")
   bulkSubmissions: [BulkSubmission!]! @derivedFrom(field: "challenge")
-  nodeConfirmations: [NodeConfirmation!]!
+  nodeConfirmations: [NodeConfirmation!]! @derivedFrom(field: "challenge")
 }
 
 enum SubmittedFrom {
@@ -103,4 +103,5 @@ type NodeConfirmation @entity(immutable: false) {
   blockHash: Bytes
   sendRoot: Bytes
   confirmData: String
+  challenge: Challenge
 }

--- a/infrastructure/sentry-subgraph/sepolia.subgraph.yaml
+++ b/infrastructure/sentry-subgraph/sepolia.subgraph.yaml
@@ -136,6 +136,26 @@ dataSources:
           handler: handleConvertedToEsXai
       file: ./src/xai.ts
   - kind: ethereum
+    name: Rollup
+    network: arbitrum-sepolia
+    source:
+      address: "0xC47DacFbAa80Bd9D8112F4e8069482c2A3221336" #TODO: change to sepolia rollup address when deployed in a later ticket
+      abi: Rollup
+      startBlock: 169689813 #TODO: change to deploy block number when rollup contract is deployed in a later ticket
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - NodeConfirmation
+      abis:
+        - name: Rollup
+          file: ./abis/Rollup.json
+      eventHandlers:
+        - event: NodeConfirmed(indexed uint64,bytes32,bytes32)
+          handler: handleNodeConfirmed
+      file: ./src/referee.ts
+  - kind: ethereum
     name: TinyKeysAirdrop
     network: arbitrum-sepolia
     source:

--- a/infrastructure/sentry-subgraph/src/referee.ts
+++ b/infrastructure/sentry-subgraph/src/referee.ts
@@ -85,7 +85,6 @@ export function handleInitialized(event: Initialized): void {
   refereeConfig.save();
 }
 
-
 export function handleAssertionSubmitted(event: AssertionSubmittedEvent): void {
   // Load current referee config from the graph
   const refereeConfig = RefereeConfig.load("RefereeConfig");
@@ -675,17 +674,15 @@ export function handleBulkRewardsClaimed(event: BulkRewardsClaimedEvent): void {
 }
 
 export function handleNodeConfirmed(event: NodeConfirmedEvent): void {
-  
+  //subgraph entity id is nodeNum since its already unique
   const nodeConfirmedEvent = new NodeConfirmed(
-    event.params.nodeNum.toString() + "_" + event.params.blockHash.toHexString()
+    event.params.nodeNum.toString()
   )
-  nodeConfirmedEvent.nodeNum = event.params.nodeNum
-  nodeConfirmedEvent.blockHash = event.params.blockHash
-  nodeConfirmedEvent.sendRoot = event.params.sendRoot
+  nodeConfirmedEvent.nodeNum = event.params.nodeNum;
+  nodeConfirmedEvent.blockHash = event.params.blockHash;
+  nodeConfirmedEvent.sendRoot = event.params.sendRoot;
 
   //constructing confirmHash exactly how its built in the smart contract (RollupLib.confirmHash)
-
-  // Concatenate the two bytes32 values
   let blockHashBytes = nodeConfirmedEvent.blockHash;
   let sendRootBytes = nodeConfirmedEvent.sendRoot;
 
@@ -694,15 +691,14 @@ export function handleNodeConfirmed(event: NodeConfirmedEvent): void {
     return;
   }
 
-  // Compute and return the Keccak-256 hash
+  //confirmData = keccak256(blockHash + sendRoot)
   let concatenatedHexStr = blockHashBytes.concat(sendRootBytes).toHexString();
   let concatenatedByteArray = ByteArray.fromHexString(concatenatedHexStr);
   let confirmHashByteArray = crypto.keccak256(concatenatedByteArray);
   let confirmHashHexStr = confirmHashByteArray.toHexString();
 
+  //assign confirm data
   nodeConfirmedEvent.confirmData = confirmHashHexStr;
   
-  log.debug("confirmHash: ", [confirmHashHexStr]);
-
-  nodeConfirmedEvent.save()
+  nodeConfirmedEvent.save();
 }

--- a/infrastructure/sentry-subgraph/src/referee.ts
+++ b/infrastructure/sentry-subgraph/src/referee.ts
@@ -251,7 +251,7 @@ export function handleChallengeSubmitted(event: ChallengeSubmittedEvent): void {
   challenge.challengeNumber = event.params.challengeNumber
   challenge.status = "OpenForSubmissions"
 
-  challenge = updateChallenge(contract, challenge)
+  challenge = updateChallenge(contract, challenge, event)
 
   challenge.save()
 }

--- a/infrastructure/sentry-subgraph/src/referee.ts
+++ b/infrastructure/sentry-subgraph/src/referee.ts
@@ -27,7 +27,7 @@ import {
   PoolInfo,
   PoolChallenge,
   BulkSubmission,
-  NodeConfirmed
+  NodeConfirmation
 } from "../generated/schema"
 import { checkIfSubmissionEligible } from "./utils/checkIfSubmissionEligible"
 import { getBoostFactor } from "./utils/getBoostFactor"
@@ -675,7 +675,7 @@ export function handleBulkRewardsClaimed(event: BulkRewardsClaimedEvent): void {
 
 export function handleNodeConfirmed(event: NodeConfirmedEvent): void {
   //subgraph entity id is nodeNum since its already unique
-  const nodeConfirmedEvent = new NodeConfirmed(
+  const nodeConfirmedEvent = new NodeConfirmation(
     event.params.nodeNum.toString()
   )
   nodeConfirmedEvent.nodeNum = event.params.nodeNum;

--- a/infrastructure/sentry-subgraph/src/referee.ts
+++ b/infrastructure/sentry-subgraph/src/referee.ts
@@ -699,6 +699,9 @@ export function handleNodeConfirmed(event: NodeConfirmedEvent): void {
 
   //assign confirm data
   nodeConfirmedEvent.confirmData = confirmHashHexStr;
+
+  //temporarily set challenge to placeholder value, set correct value in challenge handler
+  nodeConfirmedEvent.challenge = null;
   
   nodeConfirmedEvent.save();
 }

--- a/infrastructure/sentry-subgraph/src/utils/updateChallenge.ts
+++ b/infrastructure/sentry-subgraph/src/utils/updateChallenge.ts
@@ -51,6 +51,7 @@ export function updateChallenge(referee: Referee, challenge: Challenge, event: C
     const previousChallenge = Challenge.load(previousChallengeId.toString());
 
     //previous challenge not found, therefore on the first challenge
+    //also doubles as a null guard
     if (!previousChallenge) {
         //set challenge field in NodeConfirmed event to challenge id and save
         let nodeConfirmation = NodeConfirmation.load(challenge.assertionId.toString());
@@ -87,7 +88,7 @@ export function updateChallenge(referee: Referee, challenge: Challenge, event: C
             nodeConfirmation.save();
             return challenge;
         }
-        if (refereeConfig.version.gt(BigInt.fromI32(6))) {
+        if (refereeConfig.version.lt(BigInt.fromI32(6))) {
             let nodeConfirmation = NodeConfirmation.load(challenge.assertionId.toString());
             if (!nodeConfirmation) {
                 log.warning(`Failed to load nodeConfirmation entity with id: ${challenge.assertionId}`, []);

--- a/infrastructure/sentry-subgraph/src/utils/updateChallenge.ts
+++ b/infrastructure/sentry-subgraph/src/utils/updateChallenge.ts
@@ -1,4 +1,4 @@
-import { Challenge, NodeConfirmed } from "../../generated/schema";
+import { Challenge, NodeConfirmation } from "../../generated/schema";
 import { Referee } from "../../generated/Referee/Referee"
 import { BigInt, log } from "@graphprotocol/graph-ts";
 

--- a/infrastructure/sentry-subgraph/src/utils/updateChallenge.ts
+++ b/infrastructure/sentry-subgraph/src/utils/updateChallenge.ts
@@ -53,64 +53,62 @@ export function updateChallenge(referee: Referee, challenge: Challenge, event: C
     //previous challenge not found, therefore on the first challenge
     if (!previousChallenge) {
         //set challenge field in NodeConfirmed event to challenge id and save
-        setNodeConfirmedChallengeId(challenge.assertionId, challenge.id);
-        // let nodeConfirmation = NodeConfirmation.load(challenge.assertionId.toString());
-        // if (!nodeConfirmation) {
-        //     log.warning(`Failed to load nodeConfirmation entity with id: ${challenge.assertionId}`, []);
-        //     return challenge;
-        // }
-        // nodeConfirmation.challenge = challenge.id;
-        // nodeConfirmation.save();
+        let nodeConfirmation = NodeConfirmation.load(challenge.assertionId.toString());
+        if (!nodeConfirmation) {
+            log.warning(`Failed to load nodeConfirmation entity with id: ${challenge.assertionId}`, []);
+            return challenge;
+        }
+        nodeConfirmation.challenge = challenge.id;
+        nodeConfirmation.save();
         return challenge;
     }
 
     //execute based on gap between previous and current assertion id
     const assertionIdGapSize = challenge.assertionId.minus(previousChallenge.assertionId);
     if (assertionIdGapSize.equals(BigInt.fromI32(1))) { //gap size == 1 (no gap)
-        log.warning(`******** gap size: ${assertionIdGapSize}`, []);
-        setNodeConfirmedChallengeId(challenge.assertionId, challenge.id);
         //set challenge field in this NodeConfirmation entity
-        // let nodeConfirmation = NodeConfirmation.load(challenge.assertionId.toString());
-        // if (!nodeConfirmation) {
-        //     log.warning(`Failed to load nodeConfirmation entity with id: ${challenge.assertionId}`, []);
-        //     return challenge;
-        // }
-        // nodeConfirmation.challenge = challenge.id;
-        // nodeConfirmation.save();
+        let nodeConfirmation = NodeConfirmation.load(challenge.assertionId.toString());
+        if (!nodeConfirmation) {
+            log.warning(`Failed to load nodeConfirmation entity with id: ${challenge.assertionId}`, []);
+            return challenge;
+        }
+        nodeConfirmation.challenge = challenge.id;
+        nodeConfirmation.save();
     } else if (assertionIdGapSize.gt(BigInt.fromI32(1))) { //gap size > 1
         const refereeConfig = RefereeConfig.load("RefereeConfig");
         if (!refereeConfig) {
             log.warning("Failed to find refereeConfig", [])
-            setNodeConfirmedChallengeId(challenge.assertionId, challenge.id);
+            let nodeConfirmation = NodeConfirmation.load(challenge.assertionId.toString());
+            if (!nodeConfirmation) {
+                log.warning(`Failed to load nodeConfirmation entity with id: ${challenge.assertionId}`, []);
+                return challenge;
+            }
+            nodeConfirmation.challenge = challenge.id;
+            nodeConfirmation.save();
             return challenge;
         }
         if (refereeConfig.version.gt(BigInt.fromI32(6))) {
-            setNodeConfirmedChallengeId(challenge.assertionId, challenge.id);
+            let nodeConfirmation = NodeConfirmation.load(challenge.assertionId.toString());
+            if (!nodeConfirmation) {
+                log.warning(`Failed to load nodeConfirmation entity with id: ${challenge.assertionId}`, []);
+                return challenge;
+            }
+            nodeConfirmation.challenge = challenge.id;
+            nodeConfirmation.save();
             return challenge;
         }
         //set challenge field in each NodeConfirmed event in gap
-        log.warning(`>>>>>>>> gap size: ${assertionIdGapSize}`, []);
         for (let i = previousChallenge.assertionId; i < challenge.assertionId; i = i.plus(BigInt.fromI32(1))) {
-            setNodeConfirmedChallengeId(i, challenge.id);
-            // let nodeConfirmation = NodeConfirmation.load(i.toString());
-            // if (!nodeConfirmation) {
-            //     log.warning(`Failed to load nodeConfirmation entity with id: ${i.toString()}`, []);
-            //     continue;
-            // }
-            // nodeConfirmation.challenge = challenge.id;
-            // nodeConfirmation.save();
+            // setNodeConfirmedChallengeId(i, challenge.id);
+            let nodeConfirmation = NodeConfirmation.load(i.toString());
+            if (!nodeConfirmation) {
+                log.warning(`Failed to load nodeConfirmation entity with id: ${i.toString()}`, []);
+                continue;
+            }
+            nodeConfirmation.challenge = challenge.id;
+            nodeConfirmation.save();
         }
     }
 
     return challenge;
-}
-
-function setNodeConfirmedChallengeId(challengeAssertionId: BigInt, challengeId: string): void {
-    let nodeConfirmation = NodeConfirmation.load(challengeAssertionId.toString());
-    if (!nodeConfirmation) {
-        log.warning(`Failed to load nodeConfirmation entity with id: ${challengeAssertionId}`, []);
-        return;
-    }
-    nodeConfirmation.challenge = challengeId;
-    nodeConfirmation.save();
 }

--- a/infrastructure/sentry-subgraph/subgraph.yaml
+++ b/infrastructure/sentry-subgraph/subgraph.yaml
@@ -135,6 +135,26 @@ dataSources:
         - event: ConvertedToEsXai(indexed address,uint256)
           handler: handleConvertedToEsXai
       file: ./src/xai.ts
+  - kind: ethereum
+    name: Rollup
+    network: arbitrum-one
+    source:
+      address: "0xC47DacFbAa80Bd9D8112F4e8069482c2A3221336"
+      abi: Rollup
+      startBlock: 169689813
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - NodeConfirmation
+      abis:
+        - name: Rollup
+          file: ./abis/Rollup.json
+      eventHandlers:
+        - event: NodeConfirmed(indexed uint64,bytes32,bytes32)
+          handler: handleNodeConfirmed
+      file: ./src/referee.ts #TODO: refactor this into a separate rollup.ts file later
   # - kind: ethereum
   #   name: TinyKeysAirdrop
   #   network: arbitrum-one

--- a/infrastructure/sentry-subgraph/subgraph.yaml
+++ b/infrastructure/sentry-subgraph/subgraph.yaml
@@ -154,7 +154,7 @@ dataSources:
       eventHandlers:
         - event: NodeConfirmed(indexed uint64,bytes32,bytes32)
           handler: handleNodeConfirmed
-      file: ./src/referee.ts #TODO: refactor this into a separate rollup.ts file later
+      file: ./src/referee.ts
   # - kind: ethereum
   #   name: TinyKeysAirdrop
   #   network: arbitrum-one


### PR DESCRIPTION
[Ticket](https://www.pivotaltracker.com/story/show/187992525)

* Added `NodeConfirmation` entity to subgraph schema.
* Updated Challenge entity to reference one or more `NodeConfirmation` entities.
* Added event handler for `NodeConfirmed` events.
* Updated Challenge handler to populate the new `nodeConfirmations` field with one or more `NodeConfirmation` entities.

Tested by querying for both the Challenge and NodeConfirmation entities in the subgraph [here](https://subgraph.satsuma-prod.com/xai/sentry/version/1.1.21/playground)

Test Queries:

NodeConfirmations
```
query MyQuery {
  nodeConfirmations(first: 5) {
    id
    nodeNum
    confirmData
  }
}
```
Challenges
NOTE: we skip early challenges because they won't have an associated nodeConfirmation
```
query MyQuery {
  challenges(orderBy: challengeNumber, orderDirection: asc, skip: 1297) {
    id
    challengeNumber
    assertionId
    nodeConfirmations {
      id
      confirmData
    }
  }
}
```

The onchain `confirmData` can be queried [here](https://arbiscan.io/address/0xC47DacFbAa80Bd9D8112F4e8069482c2A3221336#readProxyContract) for comparing against the hash calculated in the `handleNodeConfirmed` function. Input a `nodeNum` in the `getNode` read function to get the onchain `confirmData` (it is the third field in the returned tuple) and compare to the `confirmData` returned by a subgraph query. 