### PR TITLE
Add dev deploy CICD

### DIFF
--- a/.dev-deploy/docker-compose.yml
+++ b/.dev-deploy/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  web-connect:
+    build:
+      context: ..
+      dockerfile: .dev-deploy/web-connect.Dockerfile
+      # args: //TODO make it so the webconnect app builds so it suppots testnet and testnet config
+      #   VITE_PUBLIC_ENVIRONMENT: development
+    container_name: ${WEB_CONNECT_CONTAINER_NAME}
+    restart: always
+    networks:
+      - cicd_github_deploy_network
+
+  web-staking:
+    build:
+      context: ..
+      dockerfile: .dev-deploy/web-staking.Dockerfile
+    container_name: ${WEB_STAKING_CONTAINER_NAME}
+    restart: always
+    environment:
+      NEXT_PUBLIC_APP_ENV: development
+      MONGODB_URL: ${MONGODB_URL}
+    networks:
+      - cicd_github_deploy_network
+
+
+networks:
+  cicd_github_deploy_network:
+    external: true

--- a/.dev-deploy/web-connect.Dockerfile
+++ b/.dev-deploy/web-connect.Dockerfile
@@ -1,0 +1,36 @@
+# Stage 1: Build Stage
+FROM node:20.11.0 AS build
+
+# Install pnpm globally
+RUN npm i -g pnpm@9.7.0 nx@18.3.3
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the entire monorepo to the container, excluding node_modules and other ignored files
+COPY . .
+
+# Install all dependencies for the monorepo
+RUN pnpm install
+
+# Build the web-staking application
+RUN npx nx build @sentry/web-connect
+
+
+# Stage 2: Release Stage (Production)
+FROM node:20.11.0-alpine AS release
+
+# Install the 'serve' package globally to serve static files
+RUN npm install -g serve
+
+# Set the working directory inside the release container
+WORKDIR /app
+
+# Copy only the build artifacts from the 'build' stage
+COPY --from=build /app/apps/web-connect/dist ./dist
+
+# Expose port 3000
+EXPOSE 3000
+
+# Start the app using "serve" on port 3000
+CMD ["serve", "-s", "dist", "-l", "3000"]

--- a/.dev-deploy/web-connect.Dockerfile
+++ b/.dev-deploy/web-connect.Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Stage
-FROM node:20.11.0 AS build
+FROM node:20.11.0-alpine AS build
 
 # Install pnpm globally
 RUN npm i -g pnpm@9.7.0 nx@18.3.3

--- a/.dev-deploy/web-staking.Dockerfile
+++ b/.dev-deploy/web-staking.Dockerfile
@@ -1,0 +1,28 @@
+# Dockerfile
+# ---- Base Node ----
+FROM node:20.11.0 AS base
+ENV NEXT_TELEMETRY_DISABLED 1
+WORKDIR /app
+COPY apps/web-staking/package.json ./apps/web-staking/
+COPY apps/web-staking/package-lock.json ./apps/web-staking/
+RUN npm install --loglevel verbose -dd --prefix ./apps/web-staking
+
+# ---- Build ----
+FROM base AS build
+ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_PUBLIC_APP_ENV=development
+WORKDIR /app
+COPY . .
+RUN npm run build --prefix ./apps/web-staking
+
+# --- Release ----
+FROM gcr.io/distroless/nodejs20-debian11 AS release
+ENV NEXT_TELEMETRY_DISABLED 1
+WORKDIR /app
+COPY --from=build /app/apps/web-staking/.next ./.next
+COPY --from=build /app/apps/web-staking/public ./public
+COPY --from=base /app/apps/web-staking/node_modules ./node_modules
+COPY apps/web-staking/package.json .
+COPY apps/web-staking/package-lock.json .
+EXPOSE 3000
+CMD ["./node_modules/next/dist/bin/next", "start"]

--- a/.dev-deploy/web-staking.Dockerfile
+++ b/.dev-deploy/web-staking.Dockerfile
@@ -1,28 +1,30 @@
-# Dockerfile
-# ---- Base Node ----
-FROM node:20.11.0 AS base
-ENV NEXT_TELEMETRY_DISABLED 1
-WORKDIR /app
-COPY apps/web-staking/package.json ./apps/web-staking/
-COPY apps/web-staking/package-lock.json ./apps/web-staking/
-RUN npm install --loglevel verbose -dd --prefix ./apps/web-staking
+ARG NEXT_PUBLIC_APP_ENV=development
 
-# ---- Build ----
-FROM base AS build
-ENV NEXT_TELEMETRY_DISABLED 1
+# Base stage
+FROM node:20.11.0 AS release
+ARG NEXT_PUBLIC_APP_ENV
+
+# Set environment variables
+ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_PUBLIC_APP_ENV=development
-WORKDIR /app
-COPY . .
-RUN npm run build --prefix ./apps/web-staking
 
-# --- Release ----
-FROM gcr.io/distroless/nodejs20-debian11 AS release
-ENV NEXT_TELEMETRY_DISABLED 1
+# Install pnpm globally
+RUN npm i -g pnpm@9.7.0 nx@18.3.3
+
+# Set the working directory inside the container
 WORKDIR /app
-COPY --from=build /app/apps/web-staking/.next ./.next
-COPY --from=build /app/apps/web-staking/public ./public
-COPY --from=base /app/apps/web-staking/node_modules ./node_modules
-COPY apps/web-staking/package.json .
-COPY apps/web-staking/package-lock.json .
+
+# Copy the entire monorepo to the container, excluding node_modules and other ignored files
+COPY . .
+
+# Install all dependencies
+RUN pnpm i --filter=@sentry/web-staking --config.dedupe-peer-dependents=false
+
+# Build the web-staking application
+RUN npx nx build @sentry/web-staking
+
+# Dev expose default port 3000 - should be handled by deployment
 EXPOSE 3000
-CMD ["./node_modules/next/dist/bin/next", "start"]
+
+# Dev CMD to run the staking app - handled by deployment
+CMD ["npx", "nx", "start", "@sentry/web-staking"]

--- a/.github/workflows/pr-close.yaml
+++ b/.github/workflows/pr-close.yaml
@@ -1,0 +1,29 @@
+name: PR close cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  build:
+    runs-on: self-hosted
+
+    steps:
+      - name: Set container names
+        run: |
+          echo "WEB_CONNECT_CONTAINER_NAME=web-connect-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          echo "WEB_STAKING_CONTAINER_NAME=web-staking-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          
+      - name: Check if containers exist and remove them
+        run: |
+          # Check if the web-connect container exists, and remove it if it does
+          if [ "$(docker ps -a -q -f name=${{ env.WEB_CONNECT_CONTAINER_NAME }})" ]; then
+            docker stop ${{ env.WEB_CONNECT_CONTAINER_NAME }} || true
+            docker rm ${{ env.WEB_CONNECT_CONTAINER_NAME }} || true
+          fi
+
+          # Check if the web-staking container exists, and remove it if it does
+          if [ "$(docker ps -a -q -f name=${{ env.WEB_STAKING_CONTAINER_NAME }})" ]; then
+            docker stop ${{ env.WEB_STAKING_CONTAINER_NAME }} || true
+            docker rm ${{ env.WEB_STAKING_CONTAINER_NAME }} || true
+          fi

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -1,0 +1,58 @@
+name: PR deploy
+
+on:
+  pull_request:
+    types: [review_requested]
+    branches:
+      - "*"
+
+  pull_request_review:
+    types: [submitted]
+    branches:
+        - '*'
+
+jobs:
+  build:
+    if: github.event_name == 'pull_request' || github.event.review.state == 'approved'
+    runs-on: self-hosted
+
+    steps:
+      # Step 1: Checkout the code from the PR branch
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Step 2: Set up environment variables for container names
+      - name: Set container names
+        run: |
+          echo "WEB_CONNECT_CONTAINER_NAME=web-connect-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          echo "WEB_STAKING_CONTAINER_NAME=web-staking-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          
+      # Step 3: Build web-connect and web-staking services using docker compose
+      - name: Build Docker services
+        run: |
+          docker compose -f .dev-deploy/docker-compose.yml build
+
+      - name: Check if containers exist and remove them
+        run: |
+          # Check if the web-connect container exists, and remove it if it does
+          if [ "$(docker ps -a -q -f name=${{ env.WEB_CONNECT_CONTAINER_NAME }})" ]; then
+            docker stop ${{ env.WEB_CONNECT_CONTAINER_NAME }} || true
+            docker rm ${{ env.WEB_CONNECT_CONTAINER_NAME }} || true
+          fi
+
+          # Check if the web-staking container exists, and remove it if it does
+          if [ "$(docker ps -a -q -f name=${{ env.WEB_STAKING_CONTAINER_NAME }})" ]; then
+            docker stop ${{ env.WEB_STAKING_CONTAINER_NAME }} || true
+            docker rm ${{ env.WEB_STAKING_CONTAINER_NAME }} || true
+          fi
+
+      - name: Run web-connect container
+        run: |
+          docker compose -f .dev-deploy/docker-compose.yml run -d --name ${{ env.WEB_CONNECT_CONTAINER_NAME }} web-connect
+
+      - name: Run web-staking container
+        run: |
+          docker compose -f .dev-deploy/docker-compose.yml run -d --name ${{ env.WEB_STAKING_CONTAINER_NAME }} \
+            -e NEXT_PUBLIC_APP_ENV=development \
+            -e MONGODB_URL=${{ secrets.MONGODB_URL }} \
+            web-staking


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/188187038

This update adds github actions trigger to deploy dynamic dev environments for web-staking and web-connect.
These jobs will run on a self hosted github runner on a host setup with docker and a nginx proxy to route 

The triggers are setup to deploy on PR request review, PR approved and cleanup on PR close.