### PR TITLE
Add totalAccruedAssertionRewards to subgraph

### DIFF
--- a/infrastructure/sentry-subgraph/generated/schema.ts
+++ b/infrastructure/sentry-subgraph/generated/schema.ts
@@ -389,6 +389,19 @@ export class PoolInfo extends Entity {
       "submissions",
     );
   }
+
+  get totalAccruedAssertionRewards(): BigInt {
+    let value = this.get("totalAccruedAssertionRewards");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set totalAccruedAssertionRewards(value: BigInt) {
+    this.set("totalAccruedAssertionRewards", Value.fromBigInt(value));
+  }
 }
 
 export class UnstakeRequest extends Entity {
@@ -1498,6 +1511,19 @@ export class SentryWallet extends Entity {
       this.get("id")!.toString(),
       "bulkSubmissions",
     );
+  }
+
+  get totalAccruedAssertionRewards(): BigInt {
+    let value = this.get("totalAccruedAssertionRewards");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set totalAccruedAssertionRewards(value: BigInt) {
+    this.set("totalAccruedAssertionRewards", Value.fromBigInt(value));
   }
 }
 

--- a/infrastructure/sentry-subgraph/schema.graphql
+++ b/infrastructure/sentry-subgraph/schema.graphql
@@ -55,6 +55,7 @@ type PoolInfo @entity(immutable: false) {
   createdTimestamp: BigInt!
   poolChallenges: [PoolChallenge!]! @derivedFrom(field: "pool")
   submissions: [BulkSubmission!]! @derivedFrom(field: "poolInfo")
+  totalAccruedAssertionRewards: BigInt!
 }
 
 type UnstakeRequest @entity(immutable: false) {
@@ -69,7 +70,6 @@ type UnstakeRequest @entity(immutable: false) {
   completeTime: BigInt!
 }
 
-# global delayperiods in entity might be problematic as event is not on initialize and therefore might not be created at all
 type PoolFactoryConfig @entity(immutable: false) {
   id: String!
   version: BigInt!
@@ -172,6 +172,7 @@ type SentryWallet @entity(immutable: false) {
   sentryKeys: [SentryKey!]! @derivedFrom(field: "sentryWallet")
   poolStakes: [PoolStake!]! @derivedFrom(field: "wallet")
   bulkSubmissions: [BulkSubmission!]! @derivedFrom(field: "sentryWallet")
+  totalAccruedAssertionRewards: BigInt!
 }
 
 type RefereeConfig @entity(immutable: false) {

--- a/infrastructure/sentry-subgraph/schema/events/PoolFactory.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/PoolFactory.graphql
@@ -18,6 +18,7 @@ type PoolInfo @entity(immutable: false) {
   createdTimestamp: BigInt!
   poolChallenges: [PoolChallenge!]! @derivedFrom(field: "pool")
   submissions: [BulkSubmission!]! @derivedFrom(field: "poolInfo")
+  totalAccruedAssertionRewards: BigInt!
 }
 
 type UnstakeRequest @entity(immutable: false) {
@@ -32,7 +33,6 @@ type UnstakeRequest @entity(immutable: false) {
   completeTime: BigInt!
 }
 
-# global delayperiods in entity might be problematic as event is not on initialize and therefore might not be created at all
 type PoolFactoryConfig @entity(immutable: false) {
   id: String!
   version: BigInt!

--- a/infrastructure/sentry-subgraph/schema/events/Referee.graphql
+++ b/infrastructure/sentry-subgraph/schema/events/Referee.graphql
@@ -67,6 +67,7 @@ type SentryWallet @entity(immutable: false) {
   sentryKeys: [SentryKey!]! @derivedFrom(field: "sentryWallet")
   poolStakes: [PoolStake!]! @derivedFrom(field: "wallet")
   bulkSubmissions: [BulkSubmission!]! @derivedFrom(field: "sentryWallet")
+  totalAccruedAssertionRewards: BigInt!
 }
 
 type RefereeConfig @entity(immutable: false) {

--- a/infrastructure/sentry-subgraph/src/node-license.ts
+++ b/infrastructure/sentry-subgraph/src/node-license.ts
@@ -18,6 +18,7 @@ export function handleTransfer(event: TransferEvent): void {
     sentryWallet.esXaiStakeAmount = BigInt.fromI32(0)
     sentryWallet.keyCount = BigInt.fromI32(0)
     sentryWallet.stakedKeyCount = BigInt.fromI32(0)
+    sentryWallet.totalAccruedAssertionRewards = BigInt.fromI32(0)
   }
   
   sentryWallet.keyCount = sentryWallet.keyCount.plus(BigInt.fromI32(1))

--- a/infrastructure/sentry-subgraph/src/pool-factory.ts
+++ b/infrastructure/sentry-subgraph/src/pool-factory.ts
@@ -228,6 +228,7 @@ export function handlePoolCreated(event: PoolCreated): void {
   pool.ownerRequestedUnstakeKeyAmount = BigInt.fromI32(0)
   pool.ownerLatestUnstakeRequestCompletionTime = BigInt.fromI32(0)
   pool.createdTimestamp = event.block.timestamp
+  pool.totalAccruedAssertionRewards = BigInt.fromI32(0)
   pool.save()
 
 
@@ -282,6 +283,7 @@ export function handleStakeEsXai(event: StakeEsXai): void {
     sentryWallet.keyCount = BigInt.fromI32(0)
     sentryWallet.stakedKeyCount = BigInt.fromI32(0)
     sentryWallet.keyCount = BigInt.fromI32(0)
+    sentryWallet.totalAccruedAssertionRewards = BigInt.fromI32(0)
   }
 
   sentryWallet.esXaiStakeAmount = sentryWallet.esXaiStakeAmount.plus(event.params.amount)

--- a/infrastructure/sentry-subgraph/src/utils/updateTotalAccruedRewards.ts
+++ b/infrastructure/sentry-subgraph/src/utils/updateTotalAccruedRewards.ts
@@ -1,0 +1,30 @@
+import { SentryKey, PoolInfo, SentryWallet } from "../../generated/schema";
+import { Address, BigInt, ethereum, log } from "@graphprotocol/graph-ts"
+
+/**
+ * 
+ * Update the total Accrued esXai for either the sentryWallet or the staking pool for key based submissions
+ * 
+*/
+export function updateTotalAccruedRewards(sentryKey: SentryKey, reward: BigInt, event: ethereum.Event): void {
+  if (sentryKey.assignedPool.toHexString() == new Address(0).toHexString()) {
+    // Rewards claimed to the owner of the key
+    const sentryWallet = SentryWallet.load(sentryKey.sentryWallet);
+    if (!sentryWallet) {
+      log.warning("Failed to find sentryWallet handleAssertionSubmitted: keyID: " + sentryKey.keyId.toString() + ", TX: " + event.transaction.hash.toHexString(), []);
+      return;
+    }
+    sentryWallet.totalAccruedAssertionRewards = sentryWallet.totalAccruedAssertionRewards.plus(reward)
+    sentryWallet.save()
+
+  } else {
+    // Rewards claimed to the pool the key is staked in
+    const pool = PoolInfo.load(sentryKey.assignedPool.toHexString());
+    if (!pool) {
+      log.warning("Failed to find pool handleAssertionSubmitted: keyID: " + sentryKey.keyId.toString() + ", pool: " + sentryKey.assignedPool.toHexString()+  " , TX: " + event.transaction.hash.toHexString(), []);
+      return;
+    }
+    pool.totalAccruedAssertionRewards = pool.totalAccruedAssertionRewards.plus(reward)
+    pool.save()
+  }
+}


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/188210182

Adding a new field `totalAccruedAssertionRewards` to the SentryWallet and PoolInfo entities.
This will be used to display the total accrued rewards in the desktop app without having to fetch each submission for each key.

Subgraph deployed and currently syncing:
- Mainnet: https://subgraphs.alchemy.com/subgraphs/4740/versions/26457
- Testnet: https://subgraphs.alchemy.com/subgraphs/6221/versions/26456