### PR TITLE
Operator Load Confirm Data

### DIFF
--- a/packages/core/src/operator/getConfirmDataAndHash.ts
+++ b/packages/core/src/operator/getConfirmDataAndHash.ts
@@ -1,6 +1,5 @@
 import { 
-    getConfirmDatafromGraph, 
-    getSubgraphHealthStatus, 
+    getConfirmDatafromGraph,
     getMultipleChallengeConfirmData,
 } from "../index.js";
 
@@ -11,6 +10,7 @@ import {
  */
 export async function getConfirmDataAndHash(
     assertionIds: number[],
+    isSubgraphHealthy: boolean
 ): Promise<{confirmData: string[], confirmHash: string}> {
 
     //declare return variables
@@ -18,8 +18,7 @@ export async function getConfirmDataAndHash(
     let confirmHash: string;
     
     //determine whether to hit subgraph or rpc
-    const graphStatus = await getSubgraphHealthStatus();
-    if (graphStatus.healthy) {
+    if (isSubgraphHealthy) {
         const res = await getConfirmDatafromGraph(assertionIds);
         confirmData = res.confirmData;
         confirmHash = res.confirmHash;

--- a/packages/core/src/operator/getConfirmDataAndHash.ts
+++ b/packages/core/src/operator/getConfirmDataAndHash.ts
@@ -1,0 +1,33 @@
+import { 
+    getConfirmDatafromGraph, 
+    getSubgraphHealthStatus, 
+    getMultipleChallengeConfirmData,
+} from "../index.js";
+
+/**
+ * Fetches the confirmData and confirmHash of a given array of assertion Ids.
+ * @param assertionIds - The array of assertion IDs.
+ * @returns The submissions.
+ */
+export async function getConfirmDataAndHash(
+    assertionIds: number[],
+): Promise<{confirmData: string[], confirmHash: string}> {
+
+    //initialize
+    let confirmData: string[]
+    let confirmHash: string
+    
+    //determine whether to hit subgraph or rpc
+    const graphStatus = await getSubgraphHealthStatus();
+    if (graphStatus.healthy) {
+        const res = await getConfirmDatafromGraph(assertionIds);
+        confirmData = res.confirmData;
+        confirmHash = res.confirmHash;
+    } else {
+        const res = await getMultipleChallengeConfirmData(assertionIds);
+        confirmData = res[0];
+        confirmHash = res[1];
+    }
+    
+    return {confirmData: confirmData, confirmHash: confirmHash};
+}

--- a/packages/core/src/operator/getConfirmDataAndHash.ts
+++ b/packages/core/src/operator/getConfirmDataAndHash.ts
@@ -7,15 +7,15 @@ import {
 /**
  * Fetches the confirmData and confirmHash of a given array of assertion Ids.
  * @param assertionIds - The array of assertion IDs.
- * @returns The submissions.
+ * @returns The confirmData and confirmHashS.
  */
 export async function getConfirmDataAndHash(
     assertionIds: number[],
 ): Promise<{confirmData: string[], confirmHash: string}> {
 
-    //initialize
-    let confirmData: string[]
-    let confirmHash: string
+    //declare return variables
+    let confirmData: string[];
+    let confirmHash: string;
     
     //determine whether to hit subgraph or rpc
     const graphStatus = await getSubgraphHealthStatus();

--- a/packages/core/src/operator/index.ts
+++ b/packages/core/src/operator/index.ts
@@ -13,3 +13,4 @@ export * from "./operatorRuntime.js";
 export * from "./checkRefereeBulkSubmissionCompatible.js";
 export * from "./operator-runtime/index.js";
 export * from "./processUnclaimedChallenges.js";
+export * from "./getConfirmDataAndHash.js";

--- a/packages/core/src/subgraph/getConfirmDataFromGraph.ts
+++ b/packages/core/src/subgraph/getConfirmDataFromGraph.ts
@@ -24,7 +24,6 @@ export async function getConfirmDatafromGraph(assertionIds: number[]): Promise<{
             }
         }
     `
-    console.log(`query: ${query}`);
 
     //send query
     const result = await client.request(query) as {

--- a/packages/core/src/subgraph/getConfirmDataFromGraph.ts
+++ b/packages/core/src/subgraph/getConfirmDataFromGraph.ts
@@ -1,0 +1,62 @@
+import { ethers } from "ethers";
+import { GraphQLClient, gql } from 'graphql-request'
+import { config } from "../config.js";
+
+/**
+ * Fetches the confirmation data for multiple challenge assertions from the graph.
+ * 
+ * @param {number[]} assertionIds - An array of assertion IDs for which confirmation data is required.
+ * @returns {Promise<{string[], string}>} A promise that resolves to a tuple containing an array of `bytes32` confirmation data and a `bytes32` confirmation hash.
+ */
+export async function getConfirmDatafromGraph(assertionIds: number[]): Promise<{confirmData: string[], confirmHash: string}> {
+    
+    //initialize graph client
+    const client = new GraphQLClient(config.subgraphEndpoint);
+
+    //query for each assertion id (aka nodeNum)
+    let confirmDataArray: string[] = [];
+    for (let i = 0; i < assertionIds.length; i++) {
+        
+        //craft query
+        const query = gql`
+            query NodeConfirmationQuery {
+                nodeConfirmation(id: ${assertionIds[i]}) {
+                    id
+                    confirmData
+                }
+            }
+        `
+
+        //send query
+        const result = await client.request(query) as {
+            nodeConfirmation: {
+                id: string;
+                confirmData: string;
+            } | null;
+        };
+
+        //null guard
+        if (!result.nodeConfirmation) {
+            console.log(`Error: nodeConfirmation field is null for assertion id: ${assertionIds[i]}`);
+            continue;
+        }
+
+        confirmDataArray.push(result.nodeConfirmation.confirmData);
+    }
+
+    //calculate confirmHash from array of confirmData
+    //NOTE: same as contract logic in RefereeCalculations.getConfirmDataMultipleAssertions
+    let concatenatedHexStr: string = "0x"; //start with 0x so final result is BytesLike
+    confirmDataArray.forEach((confirmData) => {
+        //trim leading 0x, if exists
+        let tempConfirmData = confirmData;
+        if (tempConfirmData.startsWith('0x')) {
+            tempConfirmData = tempConfirmData.slice(2);
+        }
+        concatenatedHexStr += tempConfirmData;
+    });
+    const concatenatedByteArray = ethers.getBytes(concatenatedHexStr);
+    const confirmHashHexStr = ethers.keccak256(concatenatedByteArray);
+    
+    return {confirmData: confirmDataArray, confirmHash: confirmHashHexStr};
+}

--- a/packages/core/src/subgraph/getConfirmDataFromGraph.ts
+++ b/packages/core/src/subgraph/getConfirmDataFromGraph.ts
@@ -37,8 +37,7 @@ export async function getConfirmDatafromGraph(assertionIds: number[]): Promise<{
 
     //null guard
     if (!result.nodeConfirmations) {
-        console.log(`Error: nodeConfirmations field is null for subgraph query`);
-        return {confirmData: [], confirmHash: ""};
+        throw new Error("Error: nodeConfirmations field is null for subgraph query");
     }
 
     //calculate confirmHash from array of confirmData

--- a/packages/core/src/subgraph/index.ts
+++ b/packages/core/src/subgraph/index.ts
@@ -11,3 +11,4 @@ export * from "./getSentryKeysFromGraphByPool.js";
 export * from "./getUserStakedPoolsFromGraph.js";
 export * from "./getCurrentRefereeVersionFromGraph.js";
 export * from "./getSentryKeysForUnclaimedFromGraph.js";
+export * from "./getConfirmDataFromGraph.js";

--- a/packages/core/src/utils/getMultipleChallengeConfirmData.ts
+++ b/packages/core/src/utils/getMultipleChallengeConfirmData.ts
@@ -18,7 +18,7 @@ export const getMultipleChallengeConfirmData = async (assertionIds: number[]): P
     const refereeCalculationsContract = new ethers.Contract(config.refereeCalculationsAddress, RefereeCalculationsAbi, provider);
     
     // Call the contract to retrieve confirmation data and hash for the provided assertion IDs
-    const [confirmData, confirmHash]: [string[], string] = await refereeCalculationsContract.getConfirmDataMultipleAssertions(assertionIds);
+    const [confirmData, confirmHash]: [string[], string] = await refereeCalculationsContract.getConfirmDataMultipleAssertions(assertionIds, config.rollupAddress);
 
     // Return the fetched confirmation data and hash
     return [confirmData, confirmHash];


### PR DESCRIPTION
[ticket](https://www.pivotaltracker.com/story/show/187985809)

* Added the `getConfirmDataFromGraph` function and added to the subgraph index file.
* Added the top-level `getConfirmDataAndHash` function to fetch confirm data from graph or RPC.
* Added missing parameter in `getConfirmDataMultipleAssertions` RPC function.

Tested by adding the new function calls to a CLI command (testing changes not committed for this PR). Both subgraph and the RPC fallback paths were tested successfully.

Added to `total-supply.ts` to trigger the function call:
```
try {
     let res = await getConfirmDataAndHash([1, 2, 3], true);
     this.log(`>>> TESTING: confirmData: ${res.confirmData} confirmHash: ${res.confirmHash}`);
 } catch (error) {
     this.log(`Error: ${error}`);
}
```

Also updated the `config.ts` as follows:
```
"refereeCalculationsAddress": "0x429c2C497c4763918E8Ae812CF6312003bAD7E57",
...
"subgraphEndpoint": "https://subgraph.satsuma-prod.com/f37507ea64fb/xai/sentry/version/1.1.21/api",
```
