### PR TITLE
Bug Fix: Staking App: Unstake request disappears on claim error

### DIFF
--- a/apps/web-staking/src/app/components/summary/SummaryComponent.tsx
+++ b/apps/web-staking/src/app/components/summary/SummaryComponent.tsx
@@ -75,6 +75,7 @@ const SummaryComponent = ({ isBannedPool, poolFromDb }: { isBannedPool: boolean,
       );
       setRefreshUnstakeRequests(r => { return !r });
     }
+    setReceipt(undefined); 
   }, [address, chainId, poolAddress, isClaimRequest, receipt, unstakeRequestIndex]);
 
   const updateOnError = useCallback(() => {

--- a/apps/web-staking/src/app/components/summary/SummaryUnstakingItem.tsx
+++ b/apps/web-staking/src/app/components/summary/SummaryUnstakingItem.tsx
@@ -25,6 +25,12 @@ const SummaryUnstakingItem = ({
   const [transactionPending, setTransactionPending] = useState(false);
   const formattedAmount = formatCurrencyWithDecimals.format(amount);
 
+  // Note: button state remains disabled on a cancel transaction. There was discussion about
+  // refactoring the transaction pending state to be handled by the parent component or handling
+  // the tx initialization through this component. This would allow the button state to be re-enabled upon cancellation.
+  // Noting here in case we decide to implement in the future.
+  // https://github.com/xai-foundation/sentry/pull/425
+
   const sendClaimRequest = () => {
     setTransactionPending(true);
     onClaimRequest(request);


### PR DESCRIPTION
[Ticket](https://www.pivotaltracker.com/story/show/188167558)

Fixed requests being removed from local storage before tx has succeeded.

After a successful tx, the `isSuccess` state variable was not being reset, this allowed any subsequent txs to have the request removed from local storage regardless if the tx was successful. 

Fixed by resetting the tx receipt after each successful tx which resets the isSucces state in the hook.

Note: claim button for cancelled claim remains disabled after cancelation until refresh/clicking off page and back. Fixing that would require refactoring the button state outside of the component.

Tested locally and deployed on [develop here](https://develop.app.xai.games/).