### PR TITLE
Bug/ssa/fix desktop mac release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
       
       - name: Create and unlock keychain
         run: |
-          security create-keychain -p ${{ secrets.KEYCHAIN_PASSWORD }} build.keychain
-          security unlock-keychain -p ${{ secrets.KEYCHAIN_PASSWORD }} build.keychain
+          security create-keychain -p ${{ secrets.MAC_KEYCHAIN_PASSWORD }} build.keychain
+          security unlock-keychain -p ${{ secrets.MAC_KEYCHAIN_PASSWORD }} build.keychain
           security set-keychain-settings -t 3600 -l build.keychain
           security list-keychains -d user -s build.keychain login.keychain
           security default-keychain -s build.keychain
@@ -44,17 +44,17 @@ jobs:
 
       - name: Import certificate into keychain
         run: |
-          echo "$CERTIFICATE_P12_BASE64" | base64 --decode > certificate.p12
-          security import certificate.p12 -k build.keychain -P ${{ secrets.CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.KEYCHAIN_PASSWORD }} build.keychain
+          echo "$MAC_CERTIFICATE_P12_BASE64" | base64 --decode > certificate.p12
+          security import certificate.p12 -k build.keychain -P ${{ secrets.MAC_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.MAC_KEYCHAIN_PASSWORD }} build.keychain
         if: matrix.os == 'macos-latest'
 
       - name: Build monorepo
         run: npx nx run-many --target=build --all
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ secrets.CERTIFICATE_P12_BASE64 }}
-          CSC_KEY_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
+          CSC_LINK: ${{ secrets.MAC_CERTIFICATE_P12_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
 
       - name: Cleanup keychain
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,35 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+      
+      - name: Create and unlock keychain
+        run: |
+          security create-keychain -p ${{ secrets.KEYCHAIN_PASSWORD }} build.keychain
+          security unlock-keychain -p ${{ secrets.KEYCHAIN_PASSWORD }} build.keychain
+          security set-keychain-settings -t 3600 -l build.keychain
+          security list-keychains -d user -s build.keychain login.keychain
+          security default-keychain -s build.keychain
+        if: matrix.os == 'macos-latest'
+
+      - name: Import certificate into keychain
+        run: |
+          echo "$CERTIFICATE_P12_BASE64" | base64 --decode > certificate.p12
+          security import certificate.p12 -k build.keychain -P ${{ secrets.CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.KEYCHAIN_PASSWORD }} build.keychain
+        if: matrix.os == 'macos-latest'
 
       - name: Build monorepo
         run: npx nx run-many --target=build --all
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.CERTIFICATE_P12_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
+
+      - name: Cleanup keychain
+        run: |
+          security delete-keychain build.keychain
+          rm certificate.p12
+        if: matrix.os == 'macos-latest'
 
       - name: Upload sentry-client-desktop artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,20 +33,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       
-      - name: Create and unlock keychain
-        run: |
-          security create-keychain -p ${{ secrets.MAC_KEYCHAIN_PASSWORD }} build.keychain
-          security unlock-keychain -p ${{ secrets.MAC_KEYCHAIN_PASSWORD }} build.keychain
-          security set-keychain-settings -t 3600 -l build.keychain
-          security list-keychains -d user -s build.keychain login.keychain
-          security default-keychain -s build.keychain
-        if: matrix.os == 'macos-latest'
-
-      - name: Import certificate into keychain
-        run: |
-          echo "$MAC_CERTIFICATE_P12_BASE64" | base64 --decode > certificate.p12
-          security import certificate.p12 -k build.keychain -P ${{ secrets.MAC_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.MAC_KEYCHAIN_PASSWORD }} build.keychain
+      - name: Import mac certificate to keychain
+        uses: apple-actions/import-codesign-certs@v3
+        with: 
+          p12-file-base64: ${{ secrets.MAC_CERTIFICATE_P12_BASE64 }}
+          p12-password: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
         if: matrix.os == 'macos-latest'
 
       - name: Build monorepo
@@ -55,12 +46,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.MAC_CERTIFICATE_P12_BASE64 }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
-
-      - name: Cleanup keychain
-        run: |
-          security delete-keychain build.keychain
-          rm certificate.p12
-        if: matrix.os == 'macos-latest'
 
       - name: Upload sentry-client-desktop artifacts
         uses: actions/upload-artifact@v2

--- a/apps/sentry-client-desktop/README.md
+++ b/apps/sentry-client-desktop/README.md
@@ -37,7 +37,6 @@ For signing a macOS release a Apple Developer Application ID Certificate is requ
 
 For integrating the electron-builder signing the certificate has to be added to the mac key-chain, for this specific environment variables need to be set during the release build process:
 
-- `MAC_KEYCHAIN_PASSWORD` an arbitrary password for the tmp keychain used for storing the certificate
 - `MAC_CERTIFICATE_P12_BASE64` the base64 encoded certificate and private key
 - `MAC_CERTIFICATE_PASSWORD` the certificate encryption password
 
@@ -45,6 +44,14 @@ Electron builder signing env:
 
 - `CSC_LINK` same as `MAC_CERTIFICATE_P12_BASE64`, important for electron-builder finding the identity
 - `CSC_KEY_PASSWORD` same as `MAC_CERTIFICATE_PASSWORD`, important for electron-builder finding the identity from the cert above
+
+#### Verify Mac Signing:
+
+- Verify the app’s signature
+  - `codesign --verify --deep --verbose --strict /path/to/sentry-client-macos.dmg`
+
+- Check if Gatekeeper accepts the app (Requires notarized app - this is currently not implemented)
+  - `spctl --assess --type exec --verbose /path/to/sentry-client-macos.dmg`
 
 
 #### Create an Apple Developer Application ID Certificate

--- a/apps/sentry-client-desktop/README.md
+++ b/apps/sentry-client-desktop/README.md
@@ -37,11 +37,14 @@ For signing a macOS release a Apple Developer Application ID Certificate is requ
 
 For integrating the electron-builder signing the certificate has to be added to the mac key-chain, for this specific environment variables need to be set during the release build process:
 
-- `KEYCHAIN_PASSWORD` an arbitrary password for the tmp keychain used for storing the certificate
-- `CERTIFICATE_P12_BASE64` the base64 encoded certificate and private key
-- `CERTIFICATE_PASSWORD` the certificate encryption password
-- `CSC_LINK` same as `CERTIFICATE_P12_BASE64`, important for electron-builder finding the identity
-- `CSC_KEY_PASSWORD` same as `CERTIFICATE_PASSWORD`, important for electron-builder finding the identity from the cert above
+- `MAC_KEYCHAIN_PASSWORD` an arbitrary password for the tmp keychain used for storing the certificate
+- `MAC_CERTIFICATE_P12_BASE64` the base64 encoded certificate and private key
+- `MAC_CERTIFICATE_PASSWORD` the certificate encryption password
+
+Electron builder signing env: 
+
+- `CSC_LINK` same as `MAC_CERTIFICATE_P12_BASE64`, important for electron-builder finding the identity
+- `CSC_KEY_PASSWORD` same as `MAC_CERTIFICATE_PASSWORD`, important for electron-builder finding the identity from the cert above
 
 
 #### Create an Apple Developer Application ID Certificate

--- a/apps/sentry-client-desktop/README.md
+++ b/apps/sentry-client-desktop/README.md
@@ -22,6 +22,13 @@ The desktop client is build using [`electron-builder`](https://www.electron.buil
 
 Windows signing is done with SSL.com in the release workflow using the [EV Code signing certificate](https://www.electron.build/code-signing.html#windows)
 
+Required build environment variables for signing:
+
+
+- `SSL_USERNAME` SSL.com login username
+- `SSL_PASSWORD` SSL.com login password
+- `SSL_TOTP_SECRET` Certificate secret to pull the actual EV certificate from the SSL.com identity
+
 
 ### MacOS
 

--- a/apps/sentry-client-desktop/README.md
+++ b/apps/sentry-client-desktop/README.md
@@ -1,0 +1,118 @@
+# Xai Sentry Desktop Client
+
+An electron & vite cross platform desktop client for the Sentry Node Operator building on top of the `@sentry/core` operator services.
+
+## Local development
+
+Running and building is done from the root of the monorepo.
+The monorepo will handle all npm dependencies
+
+From the root run
+
+- `pnpm desktop` to run a local dev instance with hot reload
+- `pnpm -filter @sentry/sentry-client-desktop build` to create a release build for the current working os
+
+Building the monorepo with `pnpm run build` from the root of the repo will also create a release build of the desktop client.
+
+## Release build and signing
+
+The desktop client is build using [`electron-builder`](https://www.electron.build/code-signing.html). The configuration for the release build is defined in `apps\sentry-client-desktop\electron-builder.json5`. The release build will create the release for the OS running the build, so for multi platform release the build has to be run on all required platforms.
+
+### Windows
+
+Windows signing is done with SSL.com in the release workflow using the [EV Code signing certificate](https://www.electron.build/code-signing.html#windows)
+
+
+### MacOS
+
+Signing the mac build can be done by the `electron-builder`. Currently the configuration is setup to sign the app and the .dmg bundle.
+For signing a macOS release a Apple Developer Application ID Certificate is required, detailed steps in the section below.
+
+For integrating the electron-builder signing the certificate has to be added to the mac key-chain, for this specific environment variables need to be set during the release build process:
+
+- `KEYCHAIN_PASSWORD` an arbitrary password for the tmp keychain used for storing the certificate
+- `CERTIFICATE_P12_BASE64` the base64 encoded certificate and private key
+- `CERTIFICATE_PASSWORD` the certificate encryption password
+- `CSC_LINK` same as `CERTIFICATE_P12_BASE64`, important for electron-builder finding the identity
+- `CSC_KEY_PASSWORD` same as `CERTIFICATE_PASSWORD`, important for electron-builder finding the identity from the cert above
+
+
+#### Create an Apple Developer Application ID Certificate
+
+### Step 1: Create a Certificate Signing Request (CSR)
+
+1. Open **Keychain Access** (`Applications > Utilities > Keychain Access`).
+2. From the menu, select **Keychain Access > Certificate Assistant > Request a Certificate From a Certificate Authority**.
+3. Fill out the following fields:
+   - **User Email Address**: Your Apple Developer account email.
+   - **Common Name**: Your name or your company’s name.
+   - **CA Email Address**: Leave this blank.
+   - **Request is**: Select **Saved to disk**.
+4. Check the box for **Let me specify key pair information**.
+5. **Key Pair Information**:
+   - Algorithm: Select **RSA**.
+   - Key Size: Choose **2048-bit**.
+6. Click **Continue** and save the CSR file to your desktop (or any location).
+
+---
+
+### Step 2: Submit the CSR to Apple Developer
+
+1. Log in to your [Apple Developer Account](https://developer.apple.com/account/).
+2. Go to **Certificates, Identifiers & Profiles**.
+3. Under **Certificates**, click the **+** button to create a new certificate.
+4. Choose the appropriate certificate type based on your need (e.g., **Developer ID Installer** or **Mac App Distribution**).
+5. Upload the CSR file you generated earlier.
+6. Download the new certificate (`.cer` file) provided by Apple.
+
+---
+
+### Step 3: Install the Certificate in Keychain Access
+
+1. Double-click the downloaded `.cer` file to install it in **Keychain Access**.
+2. Open **Keychain Access** and navigate to **login > My Certificates**.
+3. Find the certificate you just installed.
+   - It should appear under **My Certificates** and when expanded, should show the private key associated with it.
+4. If the certificate is not under **My Certificates** or you don’t see the private key, see the troubleshooting steps below.
+
+---
+
+### Step 4: Export the Certificate and Private Key as a `.p12` File
+
+1. In **Keychain Access**, go to **My Certificates**.
+2. Right-click the certificate (which should now include the private key) and select **Export**.
+3. Choose the **.p12** format from the list of options.
+4. Set a name for the `.p12` file and choose a location to save it.
+5. You will be prompted to set a password to protect the `.p12` file.
+6. After setting the password, your `.p12` file will be exported and saved.
+
+---
+
+### Step 5: Use the `.p12` in Your Build Pipeline
+
+Once you have your `.p12` file, you can use it in your build process for signing packages or apps, such as in GitHub Actions:
+
+1. **Encode the `.p12` file to base64**:
+   ```bash
+   base64 -i certificate.p12 -o certificate.p12.base64
+
+---
+
+### Troubleshooting Tips
+
+- **Missing Private Key**: If your certificate is in the **Certificates** section but not in **My Certificates**, it means the private key is not associated. This can happen if the private key wasn’t created or stored correctly during the CSR process.
+  - In **Keychain Access**, go to **login > Keys** and look for a private key matching the common name of the certificate.
+  - If you find the private key, you can try manually associating it with the certificate by dragging the certificate onto the key.
+  - If the private key is not present, you'll need to regenerate the CSR and repeat the steps to create the certificate.
+
+---
+
+### Notes
+
+- **Key Size**: Make sure to select **RSA 2048-bit** or higher, as 1024-bit is no longer considered secure.
+- **Password**: You will need the password set during the `.p12` export when using the file for signing operations in your build pipeline.
+
+---
+
+
+

--- a/apps/sentry-client-desktop/build-config/entitlements.mac.plist
+++ b/apps/sentry-client-desktop/build-config/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>

--- a/apps/sentry-client-desktop/electron-builder.json5
+++ b/apps/sentry-client-desktop/electron-builder.json5
@@ -1,5 +1,5 @@
 /**
- * @see https://www.electron.build/configuration/configuration
+ * @see https://www.electron.build/configuration
  */
 {
   "$schema": "https://raw.githubusercontent.com/electron-userland/electron-builder/master/packages/app-builder-lib/scheme.json",
@@ -8,19 +8,26 @@
   "asar": true,
   "productName": "Xai Sentry Node",
   "directories": {
-    "output": "release",
+    "output": "release"
   },
   "files": [
     "dist",
     "dist-electron"
   ],
+  "dmg": {
+    "sign": true
+  },
   "mac": {
     "target": [
       "dmg",
       "zip"
     ],
     "artifactName": "sentry-client-macos.${ext}",
-    "icon": "public/xai.png"
+    "icon": "public/xai.png",
+    "hardenedRuntime": true,
+    "entitlements": "build-config/entitlements.mac.plist",
+    "entitlementsInherit": "build-config/entitlements.mac.plist",
+    "gatekeeperAssess": false
   },
   "win": {
     "target": [


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/187545038

Update the desktop app electron-builder config to sign the mac build.
Added required entitlements for signing mac build.
Add documentation on desktop app dev and release signing.

Tested creating signed build from base64 encoded certificate locally.
Create production signed mac release here: https://github.com/xai-foundation/sentry-development/releases/tag/1.1.16-sepolia-103

Tested install on local mac, still not working however the release is now signed:

```
codesign --verify --deep --verbose --strict sentry-client-macos.dmg
sentry-client-macos.dmg: valid on disk
sentry-client-macos.dmg: satisfies its Designated Requirement
```

Previous output from `codesign --verify --deep --verbose --strict sentry-client-macos-sig.dmg` would yield

```
sentry-client-macos.dmg: code object is not signed at all
```

Next step is to add the notarizing of the desktop app to make it fully accepted on mac clients.