### PR TITLE
Add mintTo Function to Node License Contract.

### DIFF
--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -196,6 +196,19 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
      * @param _promoCode The promo code.
      */
     function mint(uint256 _amount, string calldata _promoCode) public payable {
+        _mintInternal(msg.sender, _amount, _promoCode);
+    }
+    /**
+     * @notice Mints new NodeLicense tokens.
+     * @param _mintToAddress The address to mint the tokens to.
+     * @param _amount The amount of tokens to mint.
+     * @param _promoCode The promo code.
+     */
+    function mintTo(address _mintToAddress, uint256 _amount, string calldata _promoCode) public payable {
+        _mintInternal(_mintToAddress, _amount, _promoCode);
+    }
+
+    function _mintInternal(address _mintToAddress, uint256 _amount, string calldata _promoCode) internal {
         // Validate the mint data
         _validateMint(_amount);
 
@@ -207,7 +220,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         require(msg.value >= finalPrice, "Ether value sent is not correct");
 
         // Mint the NodeLicense tokens
-        _mintNodeLicense(_amount, averageCost, msg.sender);
+        _mintNodeLicense(_amount, averageCost, _mintToAddress);
 
         // Calculate the referral reward and determine if the promo code is an address
         (uint256 referralReward, address recipientAddress)  = _calculateReferralReward(finalPrice, _promoCode);

--- a/infrastructure/smart-contracts/contracts/xai-subsidy/Forwarder.sol
+++ b/infrastructure/smart-contracts/contracts/xai-subsidy/Forwarder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";

--- a/infrastructure/smart-contracts/test/Fixture.mjs
+++ b/infrastructure/smart-contracts/test/Fixture.mjs
@@ -397,7 +397,7 @@ describe("Fixture Tests", function () {
     //describe("Xai Gasless Claim", XaiGaslessClaimTests(deployInfrastructure).bind(this));
     //describe("Xai", XaiTests(deployInfrastructure).bind(this));
     //describe("EsXai", esXaiTests(deployInfrastructure).bind(this));
-    //describe("Node License", NodeLicenseTests(deployInfrastructure).bind(this));
+    describe("Node License", NodeLicenseTests(deployInfrastructure).bind(this));
     //describe("Referee", RefereeTests(deployInfrastructure).bind(this));
     //describe("StakingV2", StakingV2(deployInfrastructure).bind(this));
     //describe("Beacon Tests", Beacons(deployInfrastructure).bind(this));

--- a/infrastructure/smart-contracts/test/Fixture.mjs
+++ b/infrastructure/smart-contracts/test/Fixture.mjs
@@ -404,9 +404,9 @@ describe("Fixture Tests", function () {
     //describe("Gas Subsidy", GasSubsidyTests(deployInfrastructure).bind(this));
     //describe("Upgrade Tests", UpgradeabilityTests(deployInfrastructure).bind(this));
     //describe("BulkSubmissions", RefereeBulkSubmissions(deployInfrastructure).bind(this));
-    //describe("Node License Tiny Keys", NodeLicenseTinyKeysTest(deployInfrastructure, getBasicPoolConfiguration()).bind(this));
+    describe("Node License Tiny Keys", NodeLicenseTinyKeysTest(deployInfrastructure, getBasicPoolConfiguration()).bind(this));
     //describe("Failed KYC Tests", FailedKycTests(deployInfrastructure).bind(this));
-    describe("Winning Key Count Simulations", RefereeWinningKeyCountSimulations(deployInfrastructure).bind(this));
+    //describe("Winning Key Count Simulations", RefereeWinningKeyCountSimulations(deployInfrastructure).bind(this));
 
     // This doesn't work when running coverage
     //describe("Runtime", RuntimeTests(deployInfrastructure).bind(this));

--- a/infrastructure/smart-contracts/test/NodeLicenseTinyKeys.mjs
+++ b/infrastructure/smart-contracts/test/NodeLicenseTinyKeys.mjs
@@ -460,5 +460,36 @@ export function NodeLicenseTinyKeysTest(deployInfrastructure, poolConfigurations
             const totalSupplyAfterMint = await nodeLicense.totalSupply();
             expect(totalSupplyAfterMint).to.eq(totalSupplyBeforeMint + BigInt(1));
         });
+        
+        it("Check minting with a promo code using the mintTo function and receiving the correct funds", async function() {
+            const {nodeLicense, nodeLicenseDefaultAdmin, addr1: referrer, addr2: minter, addr3: keyReceiver, fundsReceiver} = await loadFixture(deployInfrastructure);
+            const promoCode = "PROMO2023";
+            const initialBalance = await ethers.provider.getBalance(fundsReceiver.address);
+            const initialKeyBalance = await nodeLicense.balanceOf(keyReceiver.address);
+            const referralRewardPercentage = await nodeLicense.referralRewardPercentage();
+
+            // Create a new promo code
+            await nodeLicense.connect(nodeLicenseDefaultAdmin).createPromoCode(promoCode, referrer.address);
+
+            // Mint an key with a promo code
+            const price = await nodeLicense.price(1, promoCode);
+            const referralReward = price * referralRewardPercentage / BigInt(100);
+
+            await nodeLicense.connect(minter).mintTo(keyReceiver.address, 1, promoCode, { value: price });
+
+            // Check the key was received
+            const keyBalanceAfter = await nodeLicense.balanceOf(keyReceiver.address);
+            expect(keyBalanceAfter).to.eq(initialKeyBalance + BigInt(1));
+
+            // Check the fundsReceiver received the correct funds
+            const finalBalance = await ethers.provider.getBalance(fundsReceiver.address);
+            expect(finalBalance).to.eq(initialBalance + price - referralReward);
+
+            // Check the contract balance is the referral reward
+            const contractBalance = await ethers.provider.getBalance(await nodeLicense.getAddress());
+            expect(contractBalance).to.eq(referralReward);
+
+        });
+
     }
 }

--- a/infrastructure/smart-contracts/test/NodeLicenseTinyKeys.mjs
+++ b/infrastructure/smart-contracts/test/NodeLicenseTinyKeys.mjs
@@ -445,10 +445,10 @@ export function NodeLicenseTinyKeysTest(deployInfrastructure, poolConfigurations
             const price = await nodeLicense.price(1, "");
             const totalSupplyBeforeMint = await nodeLicense.totalSupply();
 
-            // Mint an NFT
+            // Mint an NFT to addr1 from addr2
             await nodeLicense.connect(addr2).mintTo(addr1.address, 1, "", { value: price });
 
-            // Check the NFT was received
+            // Check the NFT was received by addr1
             const owner = await nodeLicense.ownerOf(totalSupplyBeforeMint + BigInt(1));
             expect(owner).to.equal(addr1.address);
 

--- a/infrastructure/smart-contracts/test/NodeLicenseTinyKeys.mjs
+++ b/infrastructure/smart-contracts/test/NodeLicenseTinyKeys.mjs
@@ -498,7 +498,7 @@ export function NodeLicenseTinyKeysTest(deployInfrastructure, poolConfigurations
             const totalSupplyBeforeMint = await nodeLicense.totalSupply();
             const keyBalanceBefore = await nodeLicense.balanceOf(receiver.address);
 
-            // Mint a key from minter to receiver
+            // Mint multiple keys from minter to receiver
             await nodeLicense.connect(minter).mintTo(receiver.address, qtyToMint, "", { value: price });
 
             // Check the last key was received

--- a/infrastructure/smart-contracts/test/NodeLicenseTinyKeys.mjs
+++ b/infrastructure/smart-contracts/test/NodeLicenseTinyKeys.mjs
@@ -490,7 +490,7 @@ export function NodeLicenseTinyKeysTest(deployInfrastructure, poolConfigurations
             expect(contractBalance).to.eq(referralReward);
         });
 
-        it("Check minting an multiple keys and receiving them using the MintTo Function", async function() {
+        it("Check minting multiple keys and receiving them using the mintTo Function", async function() {
             const {nodeLicense, addr1: receiver, addr2: minter, fundsReceiver} = await loadFixture(deployInfrastructure);
             const initialBalance = await ethers.provider.getBalance(fundsReceiver.address);
             const qtyToMint = 5;


### PR DESCRIPTION
[Ticket](https://www.pivotaltracker.com/story/show/188332927)

Updated NodeLicense contract by adding a new mintTo function that allows the minter to pass in the address that the license should be minted to.

Testing: tested with test cases. Also deployed on [Sepolia here ](https://sepolia.arbiscan.io/address/0x07C05C6459B0F86A6aBB3DB71C259595d22af3C2).

Completed a test using mintTo on Sepolia and confirmed the recipient received the license via [this transaction](https://sepolia.arbiscan.io/tx/0x4e39ada9bc9141c37cb1fae3b66f860471f1db4d86c9e2f6d0244f43ba269680).