### PR TITLE
fix: add credential id for windows signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,12 +100,13 @@ jobs:
         run: mkdir release-desktop-windows-latest/signed-builds
 
       - name: Sign build Windows exe
-        uses: sslcom/actions-codesigner@develop
+        uses: sslcom/esigner-codesign@develop
         with:
           command: sign
           username: ${{ secrets.SSL_USERNAME }}
           password: ${{ secrets.SSL_PASSWORD }}
           totp_secret: ${{ secrets.SSL_TOTP_SECRET }}
+          credential_id: ${{secrets.SSL_CREDENTIAL_ID}}
           file_path: release-desktop-windows-latest/sentry-client-windows.exe
           output_path: release-desktop-windows-latest/signed-builds
       

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -86,6 +86,7 @@ jobs:
           username: ${{ secrets.SSL_USERNAME }}
           password: ${{ secrets.SSL_PASSWORD }}
           totp_secret: ${{ secrets.SSL_TOTP_SECRET }}
+          credential_id: ${{secrets.SSL_CREDENTIAL_ID}}
           file_path: release-desktop-windows-latest/sentry-client-windows.exe
           output_path: release-desktop-windows-latest/signed-builds
       

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,29 @@
 # Dockerfile
+
+ARG NEXT_PUBLIC_APP_ENV=production
+
 # ---- Base Node ----
 FROM node:20.11.0 AS base
-ENV NEXT_TELEMETRY_DISABLED 1
+ARG NEXT_PUBLIC_APP_ENV
+ENV NEXT_TELEMETRY_DISABLED=1
 WORKDIR /app
 COPY apps/web-staking/package.json ./apps/web-staking/
 COPY apps/web-staking/package-lock.json ./apps/web-staking/
 RUN npm install --loglevel verbose -dd --prefix ./apps/web-staking
 
-ARG NEXT_PUBLIC_APP_ENV=production
-
 # ---- Build ----
 FROM base AS build
-ENV NEXT_TELEMETRY_DISABLED 1
-ENV NEXT_PUBLIC_APP_ENV=${NEXT_PUBLIC_APP_ENV}
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_PUBLIC_APP_ENV=$NEXT_PUBLIC_APP_ENV
 WORKDIR /app
 COPY . .
 RUN npm run build --prefix ./apps/web-staking
 
 # --- Release ----
 FROM gcr.io/distroless/nodejs20-debian11 AS release
-ENV NEXT_TELEMETRY_DISABLED 1
-ENV NEXT_PUBLIC_APP_ENV=${NEXT_PUBLIC_APP_ENV}
+ARG NEXT_PUBLIC_APP_ENV
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_PUBLIC_APP_ENV=$NEXT_PUBLIC_APP_ENV
 WORKDIR /app
 COPY --from=build /app/apps/web-staking/.next ./.next
 COPY --from=build /app/apps/web-staking/public ./public

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,12 @@ COPY apps/web-staking/package.json ./apps/web-staking/
 COPY apps/web-staking/package-lock.json ./apps/web-staking/
 RUN npm install --loglevel verbose -dd --prefix ./apps/web-staking
 
+ARG NEXT_PUBLIC_APP_ENV=production
+
 # ---- Build ----
 FROM base AS build
 ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_PUBLIC_APP_ENV=${NEXT_PUBLIC_APP_ENV}
 WORKDIR /app
 COPY . .
 RUN npm run build --prefix ./apps/web-staking
@@ -17,6 +20,7 @@ RUN npm run build --prefix ./apps/web-staking
 # --- Release ----
 FROM gcr.io/distroless/nodejs20-debian11 AS release
 ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_PUBLIC_APP_ENV=${NEXT_PUBLIC_APP_ENV}
 WORKDIR /app
 COPY --from=build /app/apps/web-staking/.next ./.next
 COPY --from=build /app/apps/web-staking/public ./public


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/187983657

Add credential id argument to signer.

Update the signer action to the non depricated version.

Credentials were set correctly however the secret key got blocked for to many invalid attempts, see more context in the ticket.


Additionally updated the staking app Dockerfile for enabling the dev env build args

Waiting for the services team update to fix setting the docker build args - deployment to develop with the updated Dockerfile currentl fails