### PR TITLE
Updated Referee to manage emissions calculations in the referee

### DIFF
--- a/infrastructure/smart-contracts/contracts/RefereeCalculations.sol
+++ b/infrastructure/smart-contracts/contracts/RefereeCalculations.sol
@@ -32,23 +32,37 @@ contract RefereeCalculations is Initializable, AccessControlUpgradeable {
      *
      * @param totalSupply The current total supply of tokens.
      * @param maxSupply The maximum supply of tokens.
+     * @param challengeStart The timestamp of the last challenge submitted.
+     * @param challengeEnd  The current timestamp for this challenge.
      * @return uint256 The challenge emission.
      * @return uint256 The emission tier.
      */
     function calculateChallengeEmissionAndTier(
         uint256 totalSupply,
-        uint256 maxSupply
+        uint256 maxSupply,
+        uint256 challengeStart,
+        uint256 challengeEnd
     ) public pure returns (uint256, uint256) {
         require(maxSupply > totalSupply, "5");
+        require(challengeEnd >= challengeStart, "7"); // Ensure that end time is not before start time
 
         uint256 tier = Math.log2(maxSupply / (maxSupply - totalSupply)); // calculate which tier we are in starting from 0
         require(tier <= 23, "6");
 
         // Calculate the emission tier
-        uint256 emissionTier = maxSupply / (2**(tier + 1)); // equal to the amount of tokens that are emitted during this tier
+        uint256 emissionTier = maxSupply / (2 ** (tier + 1)); // equal to the amount of tokens that are emitted during this tier
+
+        // Determine the emissions per hour
+        uint256 emissionsPerHour = emissionTier / 17520;       
+        
+        // Calculate the time difference in seconds
+        uint256 timePassedInSeconds = challengeEnd - challengeStart;
+
+        // Calculate the total emissions for the challenge based on the time passed
+        uint256 totalEmissions = emissionsPerHour * timePassedInSeconds / 3600;
 
         // determine what the size of the emission is based on each challenge having an estimated static length
-        return (emissionTier / 17520, emissionTier);
+        return (totalEmissions, emissionTier);
     }
 
     /**

--- a/infrastructure/smart-contracts/contracts/RefereeCalculations.sol
+++ b/infrastructure/smart-contracts/contracts/RefereeCalculations.sol
@@ -32,37 +32,23 @@ contract RefereeCalculations is Initializable, AccessControlUpgradeable {
      *
      * @param totalSupply The current total supply of tokens.
      * @param maxSupply The maximum supply of tokens.
-     * @param challengeStart The timestamp of the last challenge submitted.
-     * @param challengeEnd  The current timestamp for this challenge.
      * @return uint256 The challenge emission.
      * @return uint256 The emission tier.
      */
     function calculateChallengeEmissionAndTier(
         uint256 totalSupply,
-        uint256 maxSupply,
-        uint256 challengeStart,
-        uint256 challengeEnd
+        uint256 maxSupply
     ) public pure returns (uint256, uint256) {
         require(maxSupply > totalSupply, "5");
-        require(challengeEnd >= challengeStart, "7"); // Ensure that end time is not before start time
 
         uint256 tier = Math.log2(maxSupply / (maxSupply - totalSupply)); // calculate which tier we are in starting from 0
         require(tier <= 23, "6");
 
         // Calculate the emission tier
-        uint256 emissionTier = maxSupply / (2 ** (tier + 1)); // equal to the amount of tokens that are emitted during this tier
-
-        // Determine the emissions per hour
-        uint256 emissionsPerHour = emissionTier / 17520;       
-        
-        // Calculate the time difference in seconds
-        uint256 timePassedInSeconds = challengeEnd - challengeStart;
-
-        // Calculate the total emissions for the challenge based on the time passed
-        uint256 totalEmissions = emissionsPerHour * timePassedInSeconds / 3600;
+        uint256 emissionTier = maxSupply / (2**(tier + 1)); // equal to the amount of tokens that are emitted during this tier
 
         // determine what the size of the emission is based on each challenge having an estimated static length
-        return (totalEmissions, emissionTier);
+        return (emissionTier / 17520, emissionTier);
     }
 
     /**

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
@@ -403,15 +403,11 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
         }
 
         (uint256 emissionsPerHour, uint256 emissionTier)  = RefereeCalculations(refereeCalculationsAddress).calculateChallengeEmissionAndTier(totalSupply, maxSupply);
+        
+        uint256 timePassedInSeconds = block.timestamp - startTs; // Calculate the time difference in seconds
+        uint256 challengeEmissions = emissionsPerHour * timePassedInSeconds / 3600; // Calculate the total emissions for the challenge based on the time passed
 
-        // Calculate the time difference in seconds
-        uint256 timePassedInSeconds = block.timestamp - startTs;
-
-        // Calculate the total emissions for the challenge based on the time passed
-        uint256 challengeEmissions = emissionsPerHour * timePassedInSeconds / 3600;
-
-        // determine what the size of the emission is based on each challenge having an estimated static length
-        return (challengeEmissions, emissionTier);
+        return (challengeEmissions, emissionTier); // determine what the size of the emission is based on each challenge having an estimated static length
     }
 
     /**

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
@@ -505,16 +505,16 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
             startTs = challenges[challengeCounter - 1].createdTimestamp;
         }
 
-        uint256 challengeEmissions = emissionsPerHour * (block.timestamp - startTs) / 3600; // Calculate the total emissions for the challenge based on the time passed
+        uint256 challengeEmission = emissionsPerHour * (block.timestamp - startTs) / 3600; // Calculate the total emissions for the challenge based on the time passed
 
         // mint part of this for the gas subsidy contract
-        uint256 amountForGasSubsidy = (challengeEmissions * _gasSubsidyPercentage) / 100;
+        uint256 amountForGasSubsidy = (challengeEmission * _gasSubsidyPercentage) / 100;
 
         // mint xai for the gas subsidy
         Xai(xaiAddress).mint(gasSubsidyRecipient, amountForGasSubsidy);
 
         // the remaining part of the emission should be tracked and later allocated when claimed
-        uint256 rewardAmountForClaimers = challengeEmissions - amountForGasSubsidy;
+        uint256 rewardAmountForClaimers = challengeEmission - amountForGasSubsidy;
 
         // add the amount that will be given to claimers to the allocated field variable amount, so we can track how much esXai is owed
         _allocatedTokens += rewardAmountForClaimers;

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
@@ -424,9 +424,6 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
 
         require(_assertionId > _predecessorAssertionId, "9");
 
-        // Connect to the rollup contract
-        //IRollupCore rollup = IRollupCore(rollupAddress);
-
         // If the gap is more than 1 assertion, we need to handle as a batch challenge
         bool isBatch = _assertionId - _predecessorAssertionId > 1;
 

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
@@ -402,7 +402,16 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
             startTs = challenges[challengeCounter - 1].createdTimestamp;
         }
 
-        return RefereeCalculations(refereeCalculationsAddress).calculateChallengeEmissionAndTier(totalSupply, maxSupply, startTs, block.timestamp);
+        (uint256 emissionsPerHour, uint256 emissionTier)  = RefereeCalculations(refereeCalculationsAddress).calculateChallengeEmissionAndTier(totalSupply, maxSupply);
+
+        // Calculate the time difference in seconds
+        uint256 timePassedInSeconds = block.timestamp - startTs;
+
+        // Calculate the total emissions for the challenge based on the time passed
+        uint256 challengeEmissions = emissionsPerHour * timePassedInSeconds / 3600;
+
+        // determine what the size of the emission is based on each challenge having an estimated static length
+        return (challengeEmissions, emissionTier);
     }
 
     /**

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
@@ -425,7 +425,7 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
         require(_assertionId > _predecessorAssertionId, "9");
 
         // Connect to the rollup contract
-        IRollupCore rollup = IRollupCore(rollupAddress);
+        //IRollupCore rollup = IRollupCore(rollupAddress);
 
         // If the gap is more than 1 assertion, we need to handle as a batch challenge
         bool isBatch = _assertionId - _predecessorAssertionId > 1;
@@ -452,7 +452,7 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
             if (isCheckingAssertions) {
 
                 // get the node information for this assertion from the rollup.
-                Node memory node = rollup.getNode(i);
+                Node memory node = IRollupCore(rollupAddress).getNode(i);
 
                 // check the _predecessorAssertionId is correct
                 require(node.prevNum == i - 1, "10");   
@@ -504,9 +504,8 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
         } else {
             startTs = challenges[challengeCounter - 1].createdTimestamp;
         }
-        
-        uint256 timePassedInSeconds = block.timestamp - startTs; // Calculate the time difference in seconds
-        uint256 challengeEmissions = emissionsPerHour * timePassedInSeconds / 3600; // Calculate the total emissions for the challenge based on the time passed
+
+        uint256 challengeEmissions = emissionsPerHour * (block.timestamp - startTs) / 3600; // Calculate the total emissions for the challenge based on the time passed
 
         // mint part of this for the gas subsidy contract
         uint256 amountForGasSubsidy = (challengeEmissions * _gasSubsidyPercentage) / 100;

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
@@ -393,8 +393,8 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
     function calculateChallengeEmissionAndTier() public view returns (uint256, uint256) {
         uint256 totalSupply = getCombinedTotalSupply();  
         uint256 maxSupply = Xai(xaiAddress).MAX_SUPPLY();
-        
-        return RefereeCalculations(refereeCalculationsAddress).calculateChallengeEmissionAndTier(totalSupply, maxSupply);
+        uint256 startTs = block.timestamp - 3600; //1 hour
+        return RefereeCalculations(refereeCalculationsAddress).calculateChallengeEmissionAndTier(totalSupply, maxSupply, startTs, block.timestamp);
     }
 
     /**
@@ -493,9 +493,6 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
             // emit the batch challenge event
             emit BatchChallenge(challengeCounter, assertionIds);
         }
-                
-        // we need to determine how much token will be emitted
-        (uint256 emissionsPerHour, ) = calculateChallengeEmissionAndTier();
 
         // Get the timestamp of the start of the current challenge
         uint256 startTs;
@@ -505,8 +502,8 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
             startTs = challenges[challengeCounter - 1].createdTimestamp;
         }
 
-        uint256 challengeEmission = emissionsPerHour * (block.timestamp - startTs) / 3600; // Calculate the total emissions for the challenge based on the time passed
-
+        (uint256 challengeEmission, ) = RefereeCalculations(refereeCalculationsAddress).calculateChallengeEmissionAndTier(getCombinedTotalSupply(), Xai(xaiAddress).MAX_SUPPLY(), startTs, block.timestamp);
+    
         // mint part of this for the gas subsidy contract
         uint256 amountForGasSubsidy = (challengeEmission * _gasSubsidyPercentage) / 100;
 

--- a/infrastructure/smart-contracts/package.json
+++ b/infrastructure/smart-contracts/package.json
@@ -34,7 +34,8 @@
     "test": "hardhat test --network localhost",
     "coverage": "hardhat coverage --network localhost --solcoverjs ./.solcover.cjs --temp artifacts --testfiles \"./test/**/*.mjs\"",
     "clean": "rimraf artifacts && rimraf cache",
-    "size": "hardhat size-contracts"
+    "size": "hardhat size-contracts",
+    "compile": "hardhat compile"
   },
   "dependencies": {
     "@sentry/core": "workspace:*",


### PR DESCRIPTION
[Ticket](https://www.pivotaltracker.com/story/show/188311132)

Updated referee calculations to calculate emission using the previous calculation with no changes. 

Then updated the referee to calculate the time passed since last challenge and then determine the total emissions for the challenge based on the amount of time passed. 

Testing: tested, by confirming all Referee tests still pass. Also deployed on Sepolia and used the explorer to confirm the functions work as expected.

### Update
Made adjustments to meet story requirements. 
I confirmed all Referee tests still pass(minus two that were already failing and are being fixed in another story), and I redeployed on Sepolia and confirmed the calculateChallengeEmissionAndTier works as expected.

### Update 2
Additional revisions made to revert changes to RefereeCalculations. Upgraded both contracts on Sepolia, tested with explorer. Also confirmed all Referee tests still pass(not counting the ones being fixed in other stories not yet merged).