### PR TITLE
Prepare stakingapp pre upgrade, fix staking pool list order

### DIFF
--- a/apps/web-staking/src/app/components/navbar/WrapperComponent.tsx
+++ b/apps/web-staking/src/app/components/navbar/WrapperComponent.tsx
@@ -17,7 +17,7 @@ export default function WrapperComponent({ children }: { children: React.ReactNo
 	return (
 		<>
 			<AnnouncementBanner
-				activateBanner={true}
+				activateBanner={false}
 				bannerVersion="tk"
 				title={"Announcement title."}
 				text={"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc non porttitor urna."}

--- a/apps/web-staking/src/app/components/pool/MyPoolComponent.tsx
+++ b/apps/web-staking/src/app/components/pool/MyPoolComponent.tsx
@@ -22,11 +22,7 @@ import PoolPanelComponent from "./PoolPanelComponent";
 const PoolComponent = () => {
   const router = useRouter();
   const { address } = useAccount();
-  // // Comment out for #188413859 / #188457183, needs to go back in post contract upgrade (for reference search for story id)
-  // // Additionally this will need to just check kycApproved on the Referee and possibly if failedKYC on the factory.
-  // // useGetKYCApproved will ONLY check when a specific key amount is owned !
-  // const { isApproved } = useGetKYCApproved(); 
-  const isApproved = true;
+  const { isApproved } = useGetKYCApproved(); 
   const { open } = useWeb3Modal();
   const { tiers } = useGetTiers();
 

--- a/apps/web-staking/src/app/components/pool/MyPoolComponent.tsx
+++ b/apps/web-staking/src/app/components/pool/MyPoolComponent.tsx
@@ -22,7 +22,11 @@ import PoolPanelComponent from "./PoolPanelComponent";
 const PoolComponent = () => {
   const router = useRouter();
   const { address } = useAccount();
-  const { isApproved } = useGetKYCApproved();
+  // // Comment out for #188413859 / #188457183, needs to go back in post contract upgrade (for reference search for story id)
+  // // Additionally this will need to just check kycApproved on the Referee and possibly if failedKYC on the factory.
+  // // useGetKYCApproved will ONLY check when a specific key amount is owned !
+  // const { isApproved } = useGetKYCApproved(); 
+  const isApproved = true;
   const { open } = useWeb3Modal();
   const { tiers } = useGetTiers();
 

--- a/apps/web-staking/src/app/components/redeem/History.tsx
+++ b/apps/web-staking/src/app/components/redeem/History.tsx
@@ -152,8 +152,10 @@ export default function History({ redemptions, reloadRedemptions }: {
 	const [showKYCModal, setShowKYCModal] = useState(false);
 	const [selectedCountry, setSelectedCountry] = useState<string | null>('');
     const [isOpen, setIsOpen] = useState<boolean>(false);
-	const { isApproved } = useGetKYCApproved();
-	const {blocked, loading} = useBlockIp();
+	
+	// Comment out for #188413859 / #188457183, needs to go back in post contract upgrade (for reference search for story id)
+	// const { isApproved } = useGetKYCApproved();
+	const { loading } = useBlockIp();
 	
 
 	const { switchChain } = useSwitchChain();
@@ -190,10 +192,11 @@ export default function History({ redemptions, reloadRedemptions }: {
 	}, [isSuccess, isError, updateOnSuccess, updateOnError]);
 
 	const onClaim = async (redemption: RedemptionRequest) => {
-		if(!isApproved) {
-			setShowKYCModal(true);
-			return
-		}
+		// Comment out for #188413859 / #188457183, needs to go back in post contract upgrade (for reference search for story id)
+		// if(!isApproved) {
+		// 	setShowKYCModal(true);
+		// 	return
+		// }
 		setIsCancel(false);
 		setLoadingIndex(redemption.index);
 		toastId.current = loadingNotification("Transaction is pending...");

--- a/apps/web-staking/src/app/components/redeem/History.tsx
+++ b/apps/web-staking/src/app/components/redeem/History.tsx
@@ -16,7 +16,7 @@ import { MODAL_BODY_TEXT } from "./Constants";
 import { WriteFunctions, executeContractWrite } from "@/services/web3.writes";
 import { BaseModal, PrimaryButton } from "@/app/components/ui";
 import { TextButton } from "@/app/components/ui/buttons";
-import { useBlockIp, useGetKYCApproved } from "@/app/hooks";
+import { useBlockIp, useGetKYCApprovedForRedemptionClaim } from "@/app/hooks";
 import { listOfCountries } from "../constants/constants";
 
 interface HistoryCardProps {
@@ -154,7 +154,7 @@ export default function History({ redemptions, reloadRedemptions }: {
     const [isOpen, setIsOpen] = useState<boolean>(false);
 	
 	// Comment out for #188413859 / #188457183, needs to go back in post contract upgrade (for reference search for story id)
-	// const { isApproved } = useGetKYCApproved();
+	// const { isApproved } = useGetKYCApprovedForRedemptionClaim();
 	const { loading } = useBlockIp();
 	
 

--- a/apps/web-staking/src/app/hooks/index.ts
+++ b/apps/web-staking/src/app/hooks/index.ts
@@ -3,6 +3,7 @@ export *  from './useGetAvailableKeysForStaking';
 export *  from './useGetBalance';
 export *  from './useGetEsXaiAllowance';
 export *  from './useGetEsXaiBalance';
+export *  from './useGetKYCApprovedForRedemptionClaim';
 export *  from './useGetKYCApproved';
 export *  from './useGetMaxBucketShares';
 export *  from './useGetMaxKeyPerPool';

--- a/apps/web-staking/src/app/hooks/useGetKYCApprovedForRedemptionClaim.ts
+++ b/apps/web-staking/src/app/hooks/useGetKYCApprovedForRedemptionClaim.ts
@@ -1,17 +1,17 @@
 import {
     getNetwork,
-    isKYCApproved
+    isKYCApprovedForRedemption
 } from "@/services/web3.service";
 import { useEffect, useState } from "react";
 import { useAccount } from "wagmi";
 
-export const useGetKYCApproved = () => {
+export const useGetKYCApprovedForRedemptionClaim = () => {
   const [isApproved, setIsApproved] = useState(false);
   const { address, chainId } = useAccount();
 
   useEffect(() => {
     if (!address || !chainId) return;
-    isKYCApproved(getNetwork(chainId), address).then((approved) => {
+    isKYCApprovedForRedemption(getNetwork(chainId), address).then((approved) => {
       setIsApproved(approved);
     });
   }, [address, chainId]);

--- a/apps/web-staking/src/app/staking/page.tsx
+++ b/apps/web-staking/src/app/staking/page.tsx
@@ -24,6 +24,7 @@ export default async function Staking({ searchParams }: {
   }
 }) {
 
+  //TODO #188457244
   const isSortedByName = () => {
     if (searchParams.sort !== "name") {
       return Number(searchParams.sortOrder);
@@ -41,7 +42,7 @@ export default async function Staking({ searchParams }: {
   const pageFilter: any = {
     limit: 10,
     page: searchParams.page ? Number(searchParams.page) : 1,
-    sort: searchParams.sort ? [[searchParams.sort, isSortedByName()]] : [["tierIndex", -1]]
+    sort: searchParams.sort ? [[searchParams.sort, isSortedByName()], ['name', 1]] : [['tierIndex', -1], ['name', 1]]
   };
 
   const searchName = searchParams.search || "";

--- a/apps/web-staking/src/app/staking/page.tsx
+++ b/apps/web-staking/src/app/staking/page.tsx
@@ -42,7 +42,7 @@ export default async function Staking({ searchParams }: {
   const pageFilter: any = {
     limit: 10,
     page: searchParams.page ? Number(searchParams.page) : 1,
-    sort: searchParams.sort ? [[searchParams.sort, isSortedByName()], ['name', 1]] : [['tierIndex', -1], ['name', 1]]
+    sort: searchParams.sort ? [[searchParams.sort, isSortedByName()], ['_id', -1]] : [['tierIndex', -1], ['_id', -1]]
   };
 
   const searchName = searchParams.search || "";

--- a/apps/web-staking/src/server/services/Pool.service.ts
+++ b/apps/web-staking/src/server/services/Pool.service.ts
@@ -31,18 +31,18 @@ type Pagination = {
 export type PagedPools = { count: number, poolInfos: PoolInfo[], totalPoolsInDB: number }
 
 export const findPools = async ({
-									pagination = {
-										limit: 10,
-										page: 1,
-										sort: [['tierIndex', -1], ['name', 1]],
-									},
-									hideFullEsXai = false,
-									hideFullKeys = false,
-									searchName,
-									owner,
-									network,
-									esXaiMinStake
-								}: {
+	pagination = {
+		limit: 10,
+		page: 1,
+		sort: [['tierIndex', -1], ['name', 1]],
+	},
+	hideFullEsXai = false,
+	hideFullKeys = false,
+	searchName,
+	owner,
+	network,
+	esXaiMinStake
+}: {
 	pagination: Pagination;
 	searchName?: string;
 	owner?: string;
@@ -76,10 +76,14 @@ export const findPools = async ({
 			filter.$expr = { $gt: [maxKeyCount, "$keyCount"] };
 		}
 	}
-	
+
 	// Filter by minimum esXAI stake
-	if(esXaiMinStake){
+	if (esXaiMinStake) {
 		filter.totalStakedAmount = { $gte: esXaiMinStake };
+	}
+
+	if (pagination.sort.length == 1) {
+		pagination.sort.push(['name', 1])
 	}
 
 	try {

--- a/apps/web-staking/src/server/services/Pool.service.ts
+++ b/apps/web-staking/src/server/services/Pool.service.ts
@@ -82,8 +82,11 @@ export const findPools = async ({
 		filter.totalStakedAmount = { $gte: esXaiMinStake };
 	}
 
+	// For context #188456707
+	// Only sorting by one field if duplicate across documents, mongoDB will not have a consistent order across pages
+	// https://www.mongodb.com/docs/manual/reference/method/cursor.sort/#sort-consistency
 	if (pagination.sort.length == 1) {
-		pagination.sort.push(['name', 1])
+		pagination.sort.push(['_id', -1])
 	}
 
 	try {

--- a/apps/web-staking/src/services/web3.service.ts
+++ b/apps/web-staking/src/services/web3.service.ts
@@ -579,6 +579,12 @@ export const isKYCApprovedForRedemption = async (network: NetworkKey, walletAddr
 	if (ownedKeyCount <= Number(maxKeysNonKyc)) {
 		return true;
 	}
+	
+	return await isKYCApproved(network, walletAddress);
+}
+
+export const isKYCApproved = async (network: NetworkKey, walletAddress: string): Promise<boolean> => {
+	const web3Instance = getWeb3Instance(network);
 
 	const refereeContract = new web3Instance.web3.eth.Contract(RefereeAbi, web3Instance.refereeAddress);
 	try {
@@ -588,7 +594,6 @@ export const isKYCApprovedForRedemption = async (network: NetworkKey, walletAddr
 		console.log("Error checking isKYCApproved", error);
 		return false;
 	}
-
 }
 
 export const POOL_SHARES_BASE = 10_000;


### PR DESCRIPTION
For [#188413859](https://www.pivotaltracker.com/story/show/188413859)

Comment out KYC check for before contract upgrade.
Readd function for Referee KYC check used on pool create.

For [#188456707](https://www.pivotaltracker.com/story/show/188456707)

Add additional `_id` on sort for pools table to preserve consistent order across pages

Tested locally running `pnpm staking-preview`, verified KYC not required for claim redemption & create pool. 
Tested staking pool order on prod mainnet pools.