### PR TITLE
Add network toggle switch command to cli runtime

### DIFF
--- a/apps/cli/src/commands/boot-challenger.ts
+++ b/apps/cli/src/commands/boot-challenger.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import inquirer, { QuestionCollection } from 'inquirer';
 import axios from "axios";
 import { ethers, Signer } from 'ethers';
-import { config, createBlsKeyPair, getAssertion, getSignerFromPrivateKey, listenForAssertions, submitAssertionToReferee, EventListenerError, findMissedAssertion, isAssertionSubmitted, MINIMUM_SECONDS_BETWEEN_ASSERTIONS, isChallengeSubmitTime } from "@sentry/core";
+import { config, createBlsKeyPair, getAssertion, getSignerFromPrivateKey, listenForAssertions, submitAssertionToReferee, EventListenerError, findMissedAssertion, isAssertionSubmitted, isChallengeSubmitTime } from "@sentry/core";
 
 type PromptBodyKey = "secretKeyPrompt" | "walletKeyPrompt" | "webhookUrlPrompt" | "instancePrompt";
 
@@ -159,7 +159,7 @@ const onAssertionConfirmedCb = async (nodeNum: any) => {
     }
 
     // Log that the assertion was not submitted because it has not been enough time since the last assertion
-    console.log(`[${new Date().toISOString()}] Assertion ${nodeNum} not submitted because it has not been ${MINIMUM_SECONDS_BETWEEN_ASSERTIONS / 60 } minutes since the last assertion.`);
+    console.log(`[${new Date().toISOString()}] Assertion ${nodeNum} not submitted because it has not been ${config.minSecondsBetweenChallenges / 60 } minutes since the last assertion.`);
 };
 
 const checkTimeSinceLastAssertion = async (lastAssertionTime: number) => {
@@ -298,7 +298,7 @@ async function processMissedAssertions() {
         }
 
         // Log that the assertion was not submitted because it has not been enough time since the last assertion
-        console.log(`[${new Date().toISOString()}] Assertion ${missedAssertionNodeNum} not submitted because it has not been ${MINIMUM_SECONDS_BETWEEN_ASSERTIONS / 60} minutes since the last assertion.`);
+        console.log(`[${new Date().toISOString()}] Assertion ${missedAssertionNodeNum} not submitted because it has not been ${config.minSecondsBetweenChallenges / 60} minutes since the last assertion.`);
 
         } catch (error) {
             isProcessingMissedAssertions = false;

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,7 +3,7 @@ import inquirer from 'inquirer';
 import { addAdmin } from './commands/access-control/add-admin.js';
 import { syncStakingPools } from './commands/sync-staking-pools.js';
 import { bootChallenger } from './commands/boot-challenger.js';
-import { version } from "@sentry/core";
+import { version, config, setConfigByChainId, MAINNET_ID, TESTNET_ID } from "@sentry/core";
 import { processUnclaimedChallenges } from './commands/operator-control/process-unclaimed-challenges.js';
 import { monitorNodeCreated } from './commands/monitor-node-created.js';
 import { startCentralizationRuntime } from './commands/start-centralization-runtime.js';
@@ -134,6 +134,22 @@ cli.action(async () => {
         // Show help message if the user asks for it
         if (command === 'help' || command === '--help') {
             cli.outputHelp();
+            continue;
+        }
+        
+        // Show help message if the user asks for it
+        if (command === 'toggle-switch-network') {
+            if(config.defaultNetworkName === "arbitrum"){
+                console.log("==========================================================")
+                console.log("DEV MODE - SWITCHED TO TESTNET !");
+                console.log("YOU CANNOT EARN ANY REWARDS WHEN RUNNING ON TESTNET !!!");
+                console.log("THIS IS FOR TESTING PURPOSE ONLY !!!");
+                console.log("==========================================================\n")
+                setConfigByChainId(TESTNET_ID);
+            }else{
+                console.log("DEV MODE - switched to mainnet");
+                setConfigByChainId(MAINNET_ID);
+            }
             continue;
         }
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -137,7 +137,7 @@ cli.action(async () => {
             continue;
         }
         
-        // Show help message if the user asks for it
+        // DEV MODE - toggle network switch for using sepolia config
         if (command === 'toggle-switch-network') {
             if(config.defaultNetworkName === "arbitrum"){
                 console.log("==========================================================")

--- a/packages/core/src/challenger/findMissedAssertion.ts
+++ b/packages/core/src/challenger/findMissedAssertion.ts
@@ -40,7 +40,7 @@ export async function findMissedAssertion(): Promise<number | null> {
         }
 
         loopCount++;
-        if (loopCount > 10) {
+        if (loopCount > 30) {
             throw new Error(`Did not find any past assertion events for up to ${loopCount * blockRangePerRequest} blocks - checked until block ${fromBlock}`);
         }
 

--- a/packages/core/src/challenger/isChallengeSubmitTime.ts
+++ b/packages/core/src/challenger/isChallengeSubmitTime.ts
@@ -1,4 +1,4 @@
-import { MINIMUM_SECONDS_BETWEEN_ASSERTIONS } from "../constants/index.js";
+import { config } from "../config.js";
 import { getLatestChallenge } from "./getLatestChallenge.js";
 import { Challenge } from "./index.js";
 
@@ -9,7 +9,7 @@ export async function isChallengeSubmitTime(): Promise<{isSubmitTime:boolean, cu
 		const lastChallengeTime = Number(currentChallenge.createdTimestamp);
 	
 		// Calculate the minimum time to submit an assertion
-		const minimumTimeToSubmit = lastChallengeTime + MINIMUM_SECONDS_BETWEEN_ASSERTIONS;
+		const minimumTimeToSubmit = lastChallengeTime + config.minSecondsBetweenChallenges;
 
 		const isSubmitTime = Math.floor(Date.now() / 1000) > minimumTimeToSubmit;
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -38,6 +38,7 @@ const mainnetConfig = {
   alchemyApiKey: "oD4X3JXvJclnt36mDkqnp9CO2sZkNhYT",
   crossmintProjectId: "", //TODO Add Production Values
   crossmintCollectionId: "", //TODO Add Production Values
+  minSecondsBetweenChallenges: 50 * 60 // 1 hour
 };
 
 const testnetConfig: Config = {
@@ -76,6 +77,7 @@ const testnetConfig: Config = {
   alchemyApiKey: "8aXl_Mw4FGFlgxQO8Jz7FVPh2cg5m2_B",
   crossmintProjectId: "cc616c84-6479-4981-a24e-adb4278df212",
   crossmintCollectionId: "854640e1-149c-4092-a40b-bdf2a3f36e64",
+  minSecondsBetweenChallenges: 5 * 60 // 5 minutes on testnet
 };
 
 export let config: Config = mainnetConfig;

--- a/packages/core/src/constants/constants.ts
+++ b/packages/core/src/constants/constants.ts
@@ -1,1 +1,0 @@
-export  const MINIMUM_SECONDS_BETWEEN_ASSERTIONS = 50 * 60; // 1 hour

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -1,1 +1,0 @@
-export * from './constants.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,5 +11,4 @@ export * from "./xai-token/index.js";
 export * from "./operator/index.js";
 export * from "./data-centralization/index.js";
 export * from "./subgraph/index.js";
-export * from "./constants/index.js";
 export * from "./event-monitor/nodeCreatedMonitor.js";


### PR DESCRIPTION
For [#188385836](https://www.pivotaltracker.com/story/show/188385836)

Add dev cli command to toggle network switch: `toggle-switch-network`

Moved min seconds between challenges constant to config so it can be changes for testnet tests.
Increase loopCount for finding missed assertions, this will return undefined if too many blocks have passed until the latest NodeConfirmed. On testnet after about 10 hours, mainnet will have more blocks passing so this will be a shorter time.

Tested locally, added dev logs to print current config, tested toggle between mainnet and testnet and run commands in between to confirm toggle works.
Built locally and testent challenger and operator on testnet mode while confirming nodes on mockrollup.