### PR TITLE
Fix staking progress bar

### DIFF
--- a/apps/web-staking/src/app/components/navbar/NavbarComponent.tsx
+++ b/apps/web-staking/src/app/components/navbar/NavbarComponent.tsx
@@ -17,6 +17,7 @@ export default function NavbarComponent() {
 	const { open } = useWeb3Modal();
 	const { address, chainId } = useAccount();
 	const [isTestnet, setIsTestnet] = useState(false);
+	const [lastToggle, setLastToggle] = useState<number>(0);
 	const url = usePathname();
 
 	useEffect(() => {
@@ -29,11 +30,19 @@ export default function NavbarComponent() {
       : "";
 	}
 
+	const handleToggle = () => {
+		const currentTime = new Date().getTime();
+		if (currentTime - lastToggle > 500) {
+			setIsMenuOpen(!isMenuOpen);
+			setLastToggle(currentTime);
+		}
+	}
+
 	return (
 		<Navbar isBordered isBlurred={false} maxWidth="full"
 						className={`flex bg-transparent mb-5 border-0 sticky`}
 			isMenuOpen={isMenuOpen}
-			onMenuOpenChange={() => setIsMenuOpen(!isMenuOpen)}
+			onMenuOpenChange={handleToggle}
 			classNames={{
             wrapper: "pl-0 pr-3",
           }}
@@ -68,13 +77,19 @@ export default function NavbarComponent() {
 			</div>
 			<NavbarContent className="lg:hidden" justify="end">
 				<NavbarMenuToggle className="text-white text-lg w-[64px] items-center h-full"
-													icon={isMenuOpen ? <IoMdClose color="white" size={34} className="z-[40]" /> :
-														<div className="bg-hornetSting h-[64px] w-[64px] flex items-center justify-center">
-															<Burger />
-														</div>} />
+				icon={isMenuOpen ? null :
+					<div className="bg-hornetSting h-[64px] w-[64px] flex items-center justify-center">
+						<Burger />
+						</div>} />
 			</NavbarContent>
 			<NavbarMenu
-				className="lg:hidden flex fixed z-[40] top-0 left-0 flex-col justify-between bg-tourchRed min-h-screen pt-[70px]">
+				className="lg:hidden flex fixed z-[40] top-0 left-0 flex-col justify-between bg-tourchRed min-h-screen pt-[70px] relative">
+				<IoMdClose 
+					color="white" 
+					size={34} 
+					className="absolute right-4 top-4 z-50 cursor-pointer" 
+					onClick={() => handleToggle()}
+				/>
 				<NavbarMenuItem>
 					<div className="">
 						<div className='flex flex-col'>

--- a/apps/web-staking/src/app/components/navbar/NavbarComponent.tsx
+++ b/apps/web-staking/src/app/components/navbar/NavbarComponent.tsx
@@ -31,6 +31,9 @@ export default function NavbarComponent() {
 	}
 
 	const handleToggle = () => {
+		// Delay is to prevent double click on mobile
+		// from opening and closing the menu
+		// Close button is in same position as open button
 		const currentTime = new Date().getTime();
 		if (currentTime - lastToggle > 500) {
 			setIsMenuOpen(!isMenuOpen);

--- a/apps/web-staking/src/app/components/navbar/NavbarComponent.tsx
+++ b/apps/web-staking/src/app/components/navbar/NavbarComponent.tsx
@@ -34,6 +34,7 @@ export default function NavbarComponent() {
 		// Delay is to prevent double click on mobile
 		// from opening and closing the menu
 		// Close button is in same position as open button
+		// Pivotal ticket #188527767 for cleanup
 		const currentTime = new Date().getTime();
 		if (currentTime - lastToggle > 500) {
 			setIsMenuOpen(!isMenuOpen);

--- a/apps/web-staking/src/app/components/navbar/SidebarComponent.tsx
+++ b/apps/web-staking/src/app/components/navbar/SidebarComponent.tsx
@@ -21,7 +21,7 @@ export default function SidebarComponent() {
   }, []);
 
   return (
-    <div className="sticky bg-transparent top-0 flex h-screen w-[245px] flex-col justify-between">
+    <div className="sticky bg-transparent top-0 flex h-screen w-[245px] sm:[w-screen] flex-col justify-between">
       {/* Add your sidebar content here */}
       <div>
         <Link

--- a/apps/web-staking/src/app/components/staking/TableChunksComponents.tsx
+++ b/apps/web-staking/src/app/components/staking/TableChunksComponents.tsx
@@ -198,8 +198,8 @@ export function TableRowCapacity({
                   aria-labelledby="progress"
                   value={
                     showTableKeys
-                      ? (pool.keyCount / maxKeyPerPool) * 100
-                      : (pool.totalStakedAmount / pool.maxStakedAmount) * 100
+                    ? (maxKeyPerPool ? (pool.keyCount / maxKeyPerPool) * 100 : 0)
+                    : (pool.maxStakedAmount ? (pool.totalStakedAmount / pool.maxStakedAmount) * 100 : 0)
                   }
                   classNames={{
                     base: "border border-gray-500",

--- a/apps/web-staking/src/app/components/staking/TableChunksComponents.tsx
+++ b/apps/web-staking/src/app/components/staking/TableChunksComponents.tsx
@@ -202,10 +202,11 @@ export function TableRowCapacity({
                     : (pool.maxStakedAmount ? (pool.totalStakedAmount / pool.maxStakedAmount) * 100 : 0)
                   }
                   classNames={{
-                    base: "border border-gray-500",
-                    track: "!h-2",
-                    indicator: "!h-2 bg-white"
+                    track: "!bg-[#201C1C]",
+                    indicator: "!bg-[#F7F6F6] h-[6px]"
                   }}
+                  aria-label="Staking progress"
+                  showValueLabel={false}
                 />
               </div>
             </div>

--- a/apps/web-staking/src/app/components/staking/TableChunksComponents.tsx
+++ b/apps/web-staking/src/app/components/staking/TableChunksComponents.tsx
@@ -193,17 +193,19 @@ export function TableRowCapacity({
               </div>
               <div className={`w-full sm:max-w-[90%] lg:max-w-[50%] mt-1 ${progressClass}`}>
                 <Progress
-                    size="sm"
-                    radius="none"
-                    aria-labelledby="progress"
-                    value={
-                      showTableKeys
-                          ? (pool.keyCount / maxKeyPerPool) * 100 ?? 0
-                          : (pool.totalStakedAmount / pool.maxStakedAmount) * 100 ?? 0
-                    }
-                    classNames={{
-                      indicator: "bg-white"
-                    }}
+                  size="sm"
+                  radius="none"
+                  aria-labelledby="progress"
+                  value={
+                    showTableKeys
+                      ? (pool.keyCount / maxKeyPerPool) * 100
+                      : (pool.totalStakedAmount / pool.maxStakedAmount) * 100
+                  }
+                  classNames={{
+                    base: "border border-gray-500",
+                    track: "!h-2",
+                    indicator: "!h-2 bg-white"
+                  }}
                 />
               </div>
             </div>


### PR DESCRIPTION
[Ticket](https://www.pivotaltracker.com/story/show/188513584)

Fixed progress bar that was missing by updating the css.

Pending fix for menu being full width on mobile.

Tested locally and on PR link. On PR link there's currently no data to show the progress bar, but the mobile menu works on the PR link.

### Update
Fixed mobile menu close button (X) movied it back to the correct position (top right). Created a toggle handler function with a small delay to prevent unintentional clicks when the hamburger button is clicked.