### PR TITLE
Add toggle network switch to electron menu

### DIFF
--- a/apps/sentry-client-desktop/src/features/sidebar/SidebarRoot.tsx
+++ b/apps/sentry-client-desktop/src/features/sidebar/SidebarRoot.tsx
@@ -7,11 +7,12 @@ import {GreenPulse, GreyPulse, YellowPulse} from "@/features/keys/StatusPulse.js
 import {useOperatorRuntime} from "@/hooks/useOperatorRuntime";
 import {accruingStateAtom} from "@/hooks/useAccruingInfo";
 import {useAtomValue} from "jotai";
-import { TelegramIcon, XaiHeaderIcon } from "@sentry/ui/src/rebrand/icons/IconsComponents";
+import { TelegramIcon, WarningIcon, XaiHeaderIcon } from "@sentry/ui/src/rebrand/icons/IconsComponents";
 import DashboardIconWhite from "@/assets/images/dashboard-icon-white.png";
 import DashboardIconGrey from "@/assets/images/dashboard-icon-grey.png";
 import { useStorage } from "@/features/storage";
 import ExternalLinkIcon from "@sentry/ui/dist/src/rebrand/icons/ExternalLinkIcon";
+import { chainStateAtom } from "@/hooks/useChainDataWithCallback";
 
 /**
  * Sidebar component
@@ -22,6 +23,7 @@ export function Sidebar() {
 	const location = useLocation();
 	const {sentryRunning} = useOperatorRuntime();
 	const { funded, hasAssignedKeys } = useAtomValue(accruingStateAtom);
+	const { network } = useAtomValue(chainStateAtom);
 	const {data} = useStorage();
 	const getActiveLink = (url: string) => {
 		if(location.pathname.includes(url)) {
@@ -41,6 +43,12 @@ export function Sidebar() {
 				>
 					<XaiHeaderIcon width={39} height={34} fill="fill-white" />
 				</div>
+
+				{network === "arbitrumSepolia" &&
+					<div className="text-bananaBoat text-[15px] mt-[20px] px-[17px]">
+						<p className="flex group items-center mb-[20px] text-xl font-bold gap-2"><WarningIcon width={18} height={16} className="fill-bananaBoat" /> TESTNET</p>
+					</div>
+				}
 
 				<div className="w-[237px] mb-[110px]">
 					<Link

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -73,13 +73,13 @@ const testnetConfig: Config = {
   poolFactoryAddress: "0x87Ae2373007C01FBCED0dCCe4a23CA3f17D1fA9A",
   poolFactoryAddressImplementationAddress: "0x87Ae2373007C01FBCED0dCCe4a23CA3f17D1fA9A",
   defaultNetworkName: "arbitrumSepolia",
-  subgraphEndpoint: "https://subgraph.satsuma-prod.com/f37507ea64fb/xai/sentry-sepolia/version/0.0.25-sepolia-mock-103/api", // TODO Update to point to live
+  subgraphEndpoint: "https://subgraph.satsuma-prod.com/f37507ea64fb/xai/sentry-sepolia/api",
   publicRPC: "https://arb-sepolia.g.alchemy.com/v2/8aXl_Mw4FGFlgxQO8Jz7FVPh2cg5m2_B",
   alchemyApiKey: "8aXl_Mw4FGFlgxQO8Jz7FVPh2cg5m2_B",
   crossmintProjectId: "cc616c84-6479-4981-a24e-adb4278df212",
   crossmintCollectionId: "854640e1-149c-4092-a40b-bdf2a3f36e64",
   minSecondsBetweenChallenges: 5 * 60, // 5 minutes on testnet
-  sentryKeySaleURI: "https://sentry.xai.games" // redirect from within desktop client for web3 interaction
+  sentryKeySaleURI: "https://xai-foundation.github.io/sentry-development" // redirect from within desktop client for web3 interaction
 };
 
 export let config: Config = mainnetConfig;


### PR DESCRIPTION
For [#188385835](https://www.pivotaltracker.com/story/show/188385835)

Extend Electron menu View with dev option to toggle network switch.

This will display Testnet on the Sidebar.
Not all blockchain state will automatically refresh, like balance or operatorRuntime, these need to be refreshed manually by clicking the refresh button/link. 
Refreshing the app windows will return to default mainnet state.

Tested with lcoal dev and release build.
Press `ALT` to trigger the App menu, under `View` click `[DEV] Network switch`. This will enable the sepolia config in the app.
