### PR TITLE
Add tests for NodeLicense Admin minTo

### DIFF
--- a/infrastructure/smart-contracts/contracts/upgrade-tests/NodeLicenseUpgradeTest.sol
+++ b/infrastructure/smart-contracts/contracts/upgrade-tests/NodeLicenseUpgradeTest.sol
@@ -90,10 +90,14 @@ contract NodeLicenseUpgradeTest is
     
     // Reentrancy guard boolean
     bool private _reentrancyGuardClaimReferralReward;
+    
+    mapping (bytes32 => bool) public usedTransferIds;
 
 
     bytes32 public constant AIRDROP_ADMIN_ROLE =
         keccak256("AIRDROP_ADMIN_ROLE");
+    bytes32 public constant ADMIN_MINT_ROLE = keccak256("ADMIN_MINT_ROLE");
+    bytes32 public constant TRANSFER_ROLE = keccak256("TRANSFER_ROLE");
 
     uint256 private _count;
 
@@ -102,7 +106,7 @@ contract NodeLicenseUpgradeTest is
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[490] private __gap;
+    uint256[489] private __gap;
 
     // Define the pricing tiers
     struct Tier {

--- a/infrastructure/smart-contracts/hardhat.config.cjs
+++ b/infrastructure/smart-contracts/hardhat.config.cjs
@@ -23,7 +23,12 @@ const config = {
             details: {
               yul: true
             }
-          }
+          },
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
+          },
         }
       },
       {
@@ -32,7 +37,12 @@ const config = {
           optimizer: {
             enabled: true,
             runs: 200
-          }
+          },
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
+          },
         }
       }
     ]

--- a/infrastructure/smart-contracts/test/Fixture.mjs
+++ b/infrastructure/smart-contracts/test/Fixture.mjs
@@ -318,15 +318,17 @@ describe("Fixture Tests", function () {
         await tinyKeysAirDrop.waitForDeployment();
 
         // // PoolFactory2 Upgrade - Required For Tiny Keys
-        // const PoolFactory2 = await ethers.getContractFactory("PoolFactory2");
-        // const poolFactory2 = await upgrades.upgradeProxy((await poolFactory.getAddress()), PoolFactory2, { call: { fn: "initialize", args: [await tinyKeysAirDrop.getAddress()] } });
-        // await poolFactory2.waitForDeployment();
+        const PoolFactory2 = await ethers.getContractFactory("PoolFactory2");
+        const poolFactory2 = await upgrades.upgradeProxy((await poolFactory.getAddress()), PoolFactory2, { call: { fn: "initialize", args: [await tinyKeysAirDrop.getAddress()] } });
+        await poolFactory2.waitForDeployment();
 
         // // Node License8 Upgrade - Required For Tiny Keys
-        // const NodeLicense8 = await ethers.getContractFactory("NodeLicense8");
-        // const nodeLicense8 = await upgrades.upgradeProxy((await nodeLicense.getAddress()), NodeLicense8, { call: { fn: "initialize", args: [await xai.getAddress(), await esXai.getAddress(), await chainlinkEthUsdPriceFeed.getAddress(), await chainlinkXaiUsdPriceFeed.getAddress(), await tinyKeysAirDrop.getAddress()] } });
-        // await nodeLicense8.waitForDeployment();
-        // Deploy the Referee Calculations contract
+        const NodeLicense8 = await ethers.getContractFactory("NodeLicense8");
+        const nodeLicense8 = await upgrades.upgradeProxy((await nodeLicense.getAddress()), NodeLicense8, { call: { fn: "initialize", args: [await xai.getAddress(), await esXai.getAddress(), await chainlinkEthUsdPriceFeed.getAddress(), await chainlinkXaiUsdPriceFeed.getAddress(), await tinyKeysAirDrop.getAddress()] } });
+        await nodeLicense8.waitForDeployment();
+
+        // Setup admin mint to role for nodeLicenseDefaultAdmin
+        await nodeLicense8.connect(nodeLicenseDefaultAdmin).grantRole(await nodeLicense8.ADMIN_MINT_ROLE(), nodeLicenseDefaultAdmin.address);
 
         const RefereeCalculations = await ethers.getContractFactory("RefereeCalculations");
         const refereeCalculations = await upgrades.deployProxy(RefereeCalculations, [], { deployer: deployer });
@@ -334,10 +336,10 @@ describe("Fixture Tests", function () {
         
 
         // // Upgrade esXai3 upgrade - Required For Tiny Keys
-        // const maxKeysNonKyc = BigInt(1);
-        // const EsXai3 = await ethers.getContractFactory("esXai3");
-        // const esXai3 = await upgrades.upgradeProxy((await esXai.getAddress()), EsXai3, { call: { fn: "initialize", args: [await referee.getAddress(), await nodeLicense.getAddress(), poolFactoryAddress, maxKeysNonKyc] } });
-        // await esXai3.waitForDeployment();
+        const maxKeysNonKyc = BigInt(1);
+        const EsXai3 = await ethers.getContractFactory("esXai3");
+        const esXai3 = await upgrades.upgradeProxy((await esXai.getAddress()), EsXai3, { call: { fn: "initialize", args: [await referee.getAddress(), await nodeLicense.getAddress(), poolFactoryAddress, maxKeysNonKyc] } });
+        await esXai3.waitForDeployment();
 
         
         // Referee9
@@ -349,10 +351,10 @@ describe("Fixture Tests", function () {
         
         // // Referee10 upgrade - Required For Tiny Keys
         // // This upgrade needs to happen after all the setters are called, Referee 9 will remove the setters that are not needed in prod anymore to save contract size
-        // const Referee10 = await ethers.getContractFactory("Referee10");
-        // // Upgrade the Referee
-        // const referee10 = await upgrades.upgradeProxy((await referee.getAddress()), Referee10, { call: { fn: "initialize", args: [] } });
-        // await referee10.waitForDeployment();
+        const Referee10 = await ethers.getContractFactory("Referee10");
+        // Upgrade the Referee
+        const referee10 = await upgrades.upgradeProxy((await referee.getAddress()), Referee10, { call: { fn: "initialize", args: [] } });
+        await referee10.waitForDeployment();
 
         // MockRollup
         const MockRollupContractFactory = await ethers.getContractFactory("MockRollup");
@@ -392,11 +394,11 @@ describe("Fixture Tests", function () {
             tiers,
             secretKeyHex,
             publicKeyHex: "0x" + publicKeyHex,
-            referee: referee9,
-            nodeLicense: nodeLicense7,
+            referee: referee10,
+            nodeLicense: nodeLicense8,
             poolFactory,
             gasSubsidy,
-            esXai: esXai2,
+            esXai: esXai3,
             xai,
             rollupContract,
             chainlinkEthUsdPriceFeed,
@@ -420,7 +422,7 @@ describe("Fixture Tests", function () {
     // https://docs.google.com/document/d/1V_3svypWL26wDr2RNvcIBcMlFwdSWYR6xcLuKXXuWf8
 
     // Pre-Tiny Keys
-    describe("Pre-Tiny Keys Tests", PreTinyKeysTests(deployInfrastructure).bind(this));
+    // describe("Pre-Tiny Keys Tests", PreTinyKeysTests(deployInfrastructure).bind(this));
 
     // Post-Tiny Keys
     describe("EsXai", esXaiTests(deployInfrastructure).bind(this));
@@ -429,9 +431,9 @@ describe("Fixture Tests", function () {
     describe("StakingV2", StakingV2(deployInfrastructure).bind(this));
 
     // Uncomment these tests for tiny keys
-    //describe("BulkSubmissions", RefereeBulkSubmissions(deployInfrastructure).bind(this));
-    //describe("Node License Tiny Keys", NodeLicenseTinyKeysTest(deployInfrastructure, getBasicPoolConfiguration()).bind(this));
-    //describe("Failed KYC Tests", FailedKycTests(deployInfrastructure).bind(this));
+    describe("BulkSubmissions", RefereeBulkSubmissions(deployInfrastructure).bind(this));
+    describe("Node License Tiny Keys", NodeLicenseTinyKeysTest(deployInfrastructure, getBasicPoolConfiguration()).bind(this));
+    describe("Failed KYC Tests", FailedKycTests(deployInfrastructure).bind(this));
     
     //describe("Winning Key Count Simulations", RefereeWinningKeyCountSimulations(deployInfrastructure).bind(this));
 

--- a/infrastructure/smart-contracts/test/NodeLicense.mjs
+++ b/infrastructure/smart-contracts/test/NodeLicense.mjs
@@ -296,6 +296,99 @@ export function NodeLicenseTests(deployInfrastructure) {
             expect(await nodeLicense.supportsInterface("0x12345678")).to.be.false;
         });
 
-        
+        it("Checks calling adminMintTo without ADMIN_MINT_ROLE will fail", async function () {
+            const { nodeLicense, addr1 } = await loadFixture(deployInfrastructure);
+
+            // Verify that the wallet does not have the role
+            expect(
+                await nodeLicense.hasRole(await nodeLicense.ADMIN_MINT_ROLE(), addr1.address)
+            ).to.equal(false);
+
+            const amountToMint = 10;
+            const addr1BalanceBefore = await nodeLicense.balanceOf(addr1.address);
+
+            // Verify that we revert with the correct error for access control missing role
+            const expectedRevertMessage = `AccessControl: account ${addr1.address.toLowerCase()} is missing role ${await nodeLicense.ADMIN_MINT_ROLE()}`;
+            await expect(
+                nodeLicense.connect(addr1).adminMintTo(addr1.address, amountToMint)
+            ).to.be.revertedWith(expectedRevertMessage);
+
+            // Check that addr1's balance remains unchanged
+            const addr1Balance = await nodeLicense.balanceOf(addr1.address);
+            expect(addr1Balance).to.equal(addr1BalanceBefore);
+        });
+
+        it("Checks that the admin can mint to a receiver without fee", async function () {
+            const { nodeLicense, nodeLicenseDefaultAdmin, addr1 } = await loadFixture(deployInfrastructure);
+
+            const totalSupplyBefore = await nodeLicense.totalSupply();
+            const addr1BalanceBefore = await nodeLicense.balanceOf(addr1.address);
+            const adminETHBeforeMint = await ethers.provider.getBalance(nodeLicenseDefaultAdmin.address);
+
+            // Verify that the wallet has the role
+            expect(
+                await nodeLicense.hasRole(await nodeLicense.ADMIN_MINT_ROLE(), nodeLicenseDefaultAdmin.address)
+            ).to.equal(true);
+
+            // Call adminMintTo to mint tokens to addr1
+            const amountToMint = 10;
+            const tx = await nodeLicense.connect(nodeLicenseDefaultAdmin).adminMintTo(addr1.address, amountToMint);
+            // Calculate the gas used for checking balance 
+            const receipt = await tx.wait();
+            const gasUsed = receipt.gasUsed;
+            const gasPrice = tx.gasPrice;
+            const gasCost = gasUsed * gasPrice;
+
+            // Verify ETH balance has not changed
+            const adminETHAfterMint = await ethers.provider.getBalance(nodeLicenseDefaultAdmin.address);
+            expect(adminETHBeforeMint - gasCost).to.equal(adminETHAfterMint);
+
+            // Verify the totalSupply updated correctly
+            const totalSupplyAfter = await nodeLicense.totalSupply();
+            expect(totalSupplyAfter).to.equal(totalSupplyBefore + BigInt(amountToMint));
+
+            // Verify addr1 received the correct number of tokens
+            const addr1Balance = await nodeLicense.balanceOf(addr1.address);
+            expect(addr1Balance).to.equal(BigInt(addr1BalanceBefore) + BigInt(amountToMint));
+        });
+
+        it("Should not allow the adminMintTo to exceed the maxSupply", async function () {
+            const { nodeLicense, nodeLicenseDefaultAdmin, addr1 } = await loadFixture(deployInfrastructure);
+
+            const slotIndex = 253; // NodeLicense8 storage slot for maxSupply (Read this from the artifacts json after running compile)
+
+            const totalSupply = await nodeLicense.totalSupply();
+
+            //Set the maxSupply to the current totalSupply
+            const value = ethers.zeroPadValue(ethers.toBeHex(totalSupply), 32);
+            await ethers.provider.send("hardhat_setStorageAt", [
+                nodeLicense.target,
+                ethers.toQuantity(slotIndex),
+                value,
+            ]);
+
+            const maxSupply = await nodeLicense.maxSupply();
+            expect(maxSupply).to.equal(totalSupply);
+
+            const addr1BalanceBefore = await nodeLicense.balanceOf(addr1.address);
+
+            // Verify that the wallet does have the role
+            expect(
+                await nodeLicense.hasRole(await nodeLicense.ADMIN_MINT_ROLE(), nodeLicenseDefaultAdmin.address)
+            ).to.equal(true);
+
+            // Verify mintToFails for maxSupply
+            await expect(
+                nodeLicense.connect(nodeLicenseDefaultAdmin).adminMintTo(addr1.address, 10)
+            ).to.be.revertedWith("Exceeds maxSupply");
+
+            const totalSupplyAfter = await nodeLicense.totalSupply();
+            expect(totalSupplyAfter).to.equal(totalSupply);
+
+            const addr1Balance = await nodeLicense.balanceOf(addr1.address);
+            expect(addr1Balance).to.equal(addr1BalanceBefore);
+
+        });
+
     }
 }

--- a/infrastructure/smart-contracts/test/NodeLicense.mjs
+++ b/infrastructure/smart-contracts/test/NodeLicense.mjs
@@ -305,6 +305,7 @@ export function NodeLicenseTests(deployInfrastructure) {
             ).to.equal(false);
 
             const amountToMint = 10;
+            const totalSupplyBefore = await nodeLicense.totalSupply();
             const addr1BalanceBefore = await nodeLicense.balanceOf(addr1.address);
 
             // Verify that we revert with the correct error for access control missing role
@@ -316,6 +317,9 @@ export function NodeLicenseTests(deployInfrastructure) {
             // Check that addr1's balance remains unchanged
             const addr1Balance = await nodeLicense.balanceOf(addr1.address);
             expect(addr1Balance).to.equal(addr1BalanceBefore);
+
+            const totalSupplyAfter = await nodeLicense.totalSupply();
+            expect(totalSupplyAfter).to.equal(totalSupplyBefore);
         });
 
         it("Checks that the admin can mint to a receiver without fee", async function () {
@@ -377,7 +381,7 @@ export function NodeLicenseTests(deployInfrastructure) {
                 await nodeLicense.hasRole(await nodeLicense.ADMIN_MINT_ROLE(), nodeLicenseDefaultAdmin.address)
             ).to.equal(true);
 
-            // Verify mintToFails for maxSupply
+            // Verify mintTo fails for maxSupply
             await expect(
                 nodeLicense.connect(nodeLicenseDefaultAdmin).adminMintTo(addr1.address, 10)
             ).to.be.revertedWith("Exceeds maxSupply");


### PR DESCRIPTION
For [#188548399 ](https://www.pivotaltracker.com/story/show/188548399)

Add tests for adminMinTo.
Updated the fixture to upgrade to TK contracts.
Update hardhat config to add storageLayout to artifacts output for testing with altered state.


Tested locally, including not reverting in the nodeLicense Functions to run the full test code.
Only test that passes checks for the required access control role

```
✔ Checks calling adminMintTo without ADMIN_MINT_ROLE will fail (38ms)
1) Checks that the admin can mint to a receiver without fee
2) Should not allow the admin to mintTo past the maxSupply
```