### PR TITLE
Implement admin mintTo function

### DIFF
--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -818,6 +818,8 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         address to,
         uint256 amount
     ) external onlyRole(ADMIN_MINT_ROLE) {
+        require(to != address(0) && to != address(this), "Invalid to address");
+        require(amount > 0, "Invalid amount");
         _validateMint(amount);
         _mintNodeLicense(amount, 0, to);
         emit AdminMintTo(msg.sender, to, amount);

--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -122,6 +122,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     event ClaimableChanged(address indexed admin, bool newClaimableState);
     event WhitelistAmountUpdatedByAdmin(address indexed redeemer, uint16 newAmount);
     event WhitelistAmountRedeemed(address indexed redeemer, uint16 newAmount);
+    event AdminMintTo(address indexed admin, address indexed receiver, uint256 amount);
 
     /**
      * @notice Initializes the NodeLicense contract.
@@ -817,7 +818,9 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         address to,
         uint256 amount
     ) external onlyRole(ADMIN_MINT_ROLE) {
-        revert("Not implemented");
+        _validateMint(amount);
+        _mintNodeLicense(amount, 0, to);
+        emit AdminMintTo(msg.sender, to, amount);
     }
 
     


### PR DESCRIPTION
For [#188548397](https://www.pivotaltracker.com/story/show/188548397)

Add implementation for `adminMintTo`

Ran test from https://github.com/xai-foundation/sentry/pull/481, all passed.

```
✔ Checks calling adminMintTo without ADMIN_MINT_ROLE will fail (44ms)
✔ Checks that the admin can mint to a receiver without fee
✔ Should not allow the adminMintTo to exceed the maxSupply
```