### PR TITLE
Add tests for transfer auth

### DIFF
--- a/infrastructure/smart-contracts/test/Fixture.mjs
+++ b/infrastructure/smart-contracts/test/Fixture.mjs
@@ -329,6 +329,7 @@ describe("Fixture Tests", function () {
 
         // Setup admin mint to role for nodeLicenseDefaultAdmin
         await nodeLicense8.connect(nodeLicenseDefaultAdmin).grantRole(await nodeLicense8.ADMIN_MINT_ROLE(), nodeLicenseDefaultAdmin.address);
+        await nodeLicense8.connect(nodeLicenseDefaultAdmin).grantRole(await nodeLicense8.TRANSFER_ROLE(), nodeLicenseDefaultAdmin.address);
 
         const RefereeCalculations = await ethers.getContractFactory("RefereeCalculations");
         const refereeCalculations = await upgrades.deployProxy(RefereeCalculations, [], { deployer: deployer });
@@ -396,7 +397,7 @@ describe("Fixture Tests", function () {
             publicKeyHex: "0x" + publicKeyHex,
             referee: referee10,
             nodeLicense: nodeLicense8,
-            poolFactory,
+            poolFactory: poolFactory2,
             gasSubsidy,
             esXai: esXai3,
             xai,


### PR DESCRIPTION
For [#188548418](https://www.pivotaltracker.com/story/show/188548418)

Add tests for allowing transfer with new role.
Update existing test for new expected revert message

Tested locally:

```
4) Should require TRANSFER_ROLE for any transfers
5) Should allow safeTransferFrom with TRANSFER_ROLE
6) Should allow transferFrom with TRANSFER_ROLE
7) Should allow adminTransferBatch with TRANSFER_ROLE
8) Should revert transfer of a token not owned by sender
9) Should revert adminTransferBatch using the same transferId
```

Additionally updated the fixture for using poolFactory2 so the TK tests will pass.
Made sure all test code will run with dummy functions within NodeLicense.