### PR TITLE
Fix Contract Size

### DIFF
--- a/infrastructure/smart-contracts/contracts/RefereeCalculations.sol
+++ b/infrastructure/smart-contracts/contracts/RefereeCalculations.sol
@@ -271,4 +271,45 @@ contract RefereeCalculations is Initializable, AccessControlUpgradeable {
         confirmHash = keccak256(abi.encodePacked(confirmData));
     }
 
+        /**
+     * @notice Takes in a string and converts it to an address if valid, otherwise returns the zero address
+     * @param _address The string that is a potential address to validate and convert
+     * @return The address if valid, otherwise the zero address
+     */
+    function validateAndConvertAddress(string memory _address) public pure returns (address) {
+        bytes memory addrBytes = bytes(_address);
+
+        // Check if the length is 42 characters
+        if (addrBytes.length != 42) {
+            return address(0);
+        }
+
+        // Check if it starts with '0x'
+        if (addrBytes[0] != '0' || addrBytes[1] != 'x') {
+            return address(0);
+        }
+
+        uint160 addr = 0;
+
+        // Convert and validate each character
+        for (uint i = 2; i < 42; i++) {
+            uint8 b = uint8(addrBytes[i]);
+            if (b >= 48 && b <= 57) {
+                // '0' to '9'
+                addr = addr * 16 + (b - 48);
+            } else if (b >= 97 && b <= 102) {
+                // 'a' to 'f'
+                addr = addr * 16 + (b - 87);
+            } else if (b >= 65 && b <= 70) {
+                // 'A' to 'F'
+                addr = addr * 16 + (b - 55);
+            } else {
+                // Invalid character found
+                return address(0);
+            }
+        }
+
+        return address(addr);
+    }
+
 }

--- a/infrastructure/smart-contracts/contracts/upgrade-tests/NodeLicenseUpgradeTest.sol
+++ b/infrastructure/smart-contracts/contracts/upgrade-tests/NodeLicenseUpgradeTest.sol
@@ -93,9 +93,13 @@ contract NodeLicenseUpgradeTest is
     
     mapping (bytes32 => bool) public usedTransferIds;
 
+    address public usdcAddress;
+    mapping (string => PromoCode) private _promoCodesUSDC;
+    mapping (address => uint256) private _referralRewardsUSDC;
 
-    bytes32 public constant AIRDROP_ADMIN_ROLE =
-        keccak256("AIRDROP_ADMIN_ROLE");
+    address public refereeCalculationsAddress;
+
+    bytes32 public constant AIRDROP_ADMIN_ROLE = keccak256("AIRDROP_ADMIN_ROLE");
     bytes32 public constant ADMIN_MINT_ROLE = keccak256("ADMIN_MINT_ROLE");
     bytes32 public constant TRANSFER_ROLE = keccak256("TRANSFER_ROLE");
 
@@ -106,7 +110,7 @@ contract NodeLicenseUpgradeTest is
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[489] private __gap;
+    uint256[485] private __gap;
 
     // Define the pricing tiers
     struct Tier {

--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -10,8 +10,6 @@ import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol"
 import "../../upgrades/referee/Referee10.sol";
 import "../../RefereeCalculations.sol";
 
-import "hardhat/console.sol";
-
 interface IAggregatorV3Interface {
     function latestAnswer() external view returns (int256);
 }
@@ -91,15 +89,15 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     // Used as a safety to mitigate double transfer from admin wallet
     mapping (bytes32 => bool) public usedTransferIds;
 
-    bytes32 public constant AIRDROP_ADMIN_ROLE = keccak256("AIRDROP_ADMIN_ROLE");
-    bytes32 public constant ADMIN_MINT_ROLE = keccak256("ADMIN_MINT_ROLE");
-    bytes32 public constant TRANSFER_ROLE = keccak256("TRANSFER_ROLE");
-
     address public usdcAddress;
     mapping (string => PromoCode) private _promoCodesUSDC;
     mapping (address => uint256) private _referralRewardsUSDC;
 
     address public refereeCalculationsAddress;
+
+    bytes32 public constant AIRDROP_ADMIN_ROLE = keccak256("AIRDROP_ADMIN_ROLE");
+    bytes32 public constant ADMIN_MINT_ROLE = keccak256("ADMIN_MINT_ROLE");
+    bytes32 public constant TRANSFER_ROLE = keccak256("TRANSFER_ROLE");
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new

--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/Base64Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "../../upgrades/referee/Referee10.sol";
+import "../../RefereeCalculations.sol";
 
 interface IAggregatorV3Interface {
     function latestAnswer() external view returns (int256);
@@ -32,7 +33,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     bool public claimable;
 
     // Mapping from token ID to minting timestamp
-    mapping (uint256 => uint256) private _mintTimestamps;
+    mapping (uint256 => uint256) public _mintTimestamps;
 
     // Mapping from promo code to PromoCode struct
     mapping (string => PromoCode) private _promoCodes;
@@ -41,7 +42,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     mapping (address => uint256) private _referralRewards;
 
     // Mapping from token ID to average cost, this is used for refunds over multiple tiers
-    mapping (uint256 => uint256) private _averageCost;
+    mapping (uint256 => uint256) public _averageCost;
     
     // Mapping for whitelist to claim NFTs without a price
     mapping (address => uint16) public whitelistAmounts;
@@ -362,15 +363,15 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         _mintNodeLicense(_qtyToMint, 0, ownerOf(_keyId));
     }
 
-    /**
-    * @notice Revokes the airdrop admin role for the address passed in
-    * @param _address The address to revoke the airdrop admin role from
-    * @dev Only callable by the airdrop admin
-    */
+    // /**
+    // * @notice Revokes the airdrop admin role for the address passed in
+    // * @param _address The address to revoke the airdrop admin role from
+    // * @dev Only callable by the airdrop admin
+    // */
 
-    function revokeAirdropAdmin(address _address) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        revokeRole(AIRDROP_ADMIN_ROLE, _address);
-    }
+    // function revokeAirdropAdmin(address _address) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    //     revokeRole(AIRDROP_ADMIN_ROLE, _address);
+    // }
     
 
 
@@ -446,7 +447,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         // If promo code does not exist in the mapping
 
         // Check if the promo code is an address
-        address promoCodeAsAddress = validateAndConvertAddress(_promoCode);
+        address promoCodeAsAddress = RefereeCalculations(address(this)).validateAndConvertAddress(_promoCode);
 
         // If the promo code is an address, determine if the recipient has been set
         if(promoCodeAsAddress != address(0)){
@@ -478,39 +479,39 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     }
 
 
-    /**
-     * @notice Public function to redeem tokens from on whitelist.
-     */
-    function redeemFromWhitelist() external {
+    // /**
+    //  * @notice Public function to redeem tokens from on whitelist.
+    //  */
+    // function redeemFromWhitelist() external {
 
-        uint256 startTime = 1703275200; // Fri Dec 22 2023 12:00:00 GMT-0800 (Pacific Standard Time)
-        require(block.timestamp >= startTime, "Redemption is not eligible yet");
-        require(block.timestamp <= startTime + 30 days, "Redemption period has ended");
+    //     uint256 startTime = 1703275200; // Fri Dec 22 2023 12:00:00 GMT-0800 (Pacific Standard Time)
+    //     require(block.timestamp >= startTime, "Redemption is not eligible yet");
+    //     require(block.timestamp <= startTime + 30 days, "Redemption period has ended");
 
-        require(whitelistAmounts[msg.sender] > 0, "Invalid whitelist amount");
+    //     require(whitelistAmounts[msg.sender] > 0, "Invalid whitelist amount");
 
-        uint16 toMint = whitelistAmounts[msg.sender];
+    //     uint16 toMint = whitelistAmounts[msg.sender];
 
-        if(toMint > 50){
-            toMint = 50;
-        }
+    //     if(toMint > 50){
+    //         toMint = 50;
+    //     }
 
-        require(
-            _tokenIds.current() + toMint <= maxSupply,
-            "Exceeds maxSupply"
-        );
+    //     require(
+    //         _tokenIds.current() + toMint <= maxSupply,
+    //         "Exceeds maxSupply"
+    //     );
 
-        for (uint16 i = 0; i < toMint; i++) {
-           _tokenIds.increment();
-            uint256 newItemId = _tokenIds.current();
-            _mint(msg.sender, newItemId);
-            _mintTimestamps[newItemId] = block.timestamp;
-        }
+    //     for (uint16 i = 0; i < toMint; i++) {
+    //        _tokenIds.increment();
+    //         uint256 newItemId = _tokenIds.current();
+    //         _mint(msg.sender, newItemId);
+    //         _mintTimestamps[newItemId] = block.timestamp;
+    //     }
 
-        uint16 newAmount = whitelistAmounts[msg.sender] - toMint;
-        whitelistAmounts[msg.sender] = newAmount;
-        emit WhitelistAmountRedeemed(msg.sender, newAmount);
-    }
+    //     uint16 newAmount = whitelistAmounts[msg.sender] - toMint;
+    //     whitelistAmounts[msg.sender] = newAmount;
+    //     emit WhitelistAmountRedeemed(msg.sender, newAmount);
+    // }
 
     /**
      * @notice Calculates the price for minting NodeLicense tokens.
@@ -549,7 +550,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         }else{
             // Check if the promo code is an address
             // Returns 0 address if not an address
-            address promoCodeAsAddress = validateAndConvertAddress(_promoCode);
+            address promoCodeAsAddress = RefereeCalculations(address(this)).validateAndConvertAddress(_promoCode);
 
             // If the promo code is a valid address, check if it owns a license
             if(promoCodeAsAddress != address(0)){
@@ -615,35 +616,35 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         emit ClaimableChanged(msg.sender, _claimable);
     }
 
-    /**
-     * @notice Sets the fundsReceiver address.
-     * @param _newFundsReceiver The new fundsReceiver address.
-     * @dev The new fundsReceiver address cannot be the zero address.
-     */
-    function setFundsReceiver(
-        address payable _newFundsReceiver
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(_newFundsReceiver != address(0), "New fundsReceiver cannot be the zero address");
-        fundsReceiver = _newFundsReceiver;
-        emit FundsReceiverChanged(msg.sender, _newFundsReceiver);
-    }
+    // /**
+    //  * @notice Sets the fundsReceiver address.
+    //  * @param _newFundsReceiver The new fundsReceiver address.
+    //  * @dev The new fundsReceiver address cannot be the zero address.
+    //  */
+    // function setFundsReceiver(
+    //     address payable _newFundsReceiver
+    // ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    //     require(_newFundsReceiver != address(0), "New fundsReceiver cannot be the zero address");
+    //     fundsReceiver = _newFundsReceiver;
+    //     emit FundsReceiverChanged(msg.sender, _newFundsReceiver);
+    // }
 
-    /**
-     * @notice Sets the referral discount and reward percentages.
-     * @param _referralDiscountPercentage The referral discount percentage.
-     * @param _referralRewardPercentage The referral reward percentage.
-     * @dev The referral discount and reward percentages cannot be greater than 99.
-     */
-    function setReferralPercentages(
-        uint256 _referralDiscountPercentage,
-        uint256 _referralRewardPercentage
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(_referralDiscountPercentage <= 99, "Referral discount percentage cannot be greater than 99");
-        require(_referralRewardPercentage <= 99, "Referral reward percentage cannot be greater than 99");
-        referralDiscountPercentage = _referralDiscountPercentage;
-        referralRewardPercentage = _referralRewardPercentage;
-        emit ReferralRewardPercentagesChanged(_referralDiscountPercentage, _referralRewardPercentage);
-    }
+    // /**
+    //  * @notice Sets the referral discount and reward percentages.
+    //  * @param _referralDiscountPercentage The referral discount percentage.
+    //  * @param _referralRewardPercentage The referral reward percentage.
+    //  * @dev The referral discount and reward percentages cannot be greater than 99.
+    //  */
+    // function setReferralPercentages(
+    //     uint256 _referralDiscountPercentage,
+    //     uint256 _referralRewardPercentage
+    // ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    //     require(_referralDiscountPercentage <= 99, "Referral discount percentage cannot be greater than 99");
+    //     require(_referralRewardPercentage <= 99, "Referral reward percentage cannot be greater than 99");
+    //     referralDiscountPercentage = _referralDiscountPercentage;
+    //     referralRewardPercentage = _referralRewardPercentage;
+    //     emit ReferralRewardPercentagesChanged(_referralDiscountPercentage, _referralRewardPercentage);
+    // }
 
     /**
      * @notice Sets or adds a pricing tier.
@@ -758,25 +759,25 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         return string(abi.encodePacked("data:application/json;base64,", json));
     }
 
-    /**
-     * @notice Returns the average cost of a NodeLicense token. This is primarily used for refunds.
-     * @param _tokenId The ID of the token.
-     * @return The average cost.
-     */
-    function getAverageCost(uint256 _tokenId) public view returns (uint256) {
-        require(_exists(_tokenId), "ERC721Metadata: Query for nonexistent token");
-        return _averageCost[_tokenId];
-    }
+    // /**
+    //  * @notice Returns the average cost of a NodeLicense token. This is primarily used for refunds.
+    //  * @param _tokenId The ID of the token.
+    //  * @return The average cost.
+    //  */
+    // function getAverageCost(uint256 _tokenId) public view returns (uint256) {
+    //     require(_exists(_tokenId), "ERC721Metadata: Query for nonexistent token");
+    //     return _averageCost[_tokenId];
+    // }
 
-    /**
-     * @notice Returns the minting timestamp of a NodeLicense token.
-     * @param _tokenId The ID of the token.
-     * @return The minting timestamp.
-     */
-    function getMintTimestamp(uint256 _tokenId) public view returns (uint256) {
-        require(_exists(_tokenId), "ERC721Metadata: Query for nonexistent token");
-        return _mintTimestamps[_tokenId];
-    }
+    // /**
+    //  * @notice Returns the minting timestamp of a NodeLicense token.
+    //  * @param _tokenId The ID of the token.
+    //  * @return The minting timestamp.
+    //  */
+    // function getMintTimestamp(uint256 _tokenId) public view returns (uint256) {
+    //     require(_exists(_tokenId), "ERC721Metadata: Query for nonexistent token");
+    //     return _mintTimestamps[_tokenId];
+    // }
 
     /**
      * @notice Overrides the supportsInterface function of the AccessControl contract.
@@ -807,46 +808,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         return amountInXai;
     }
 
-    /**
-     * @notice Takes in a string and converts it to an address if valid, otherwise returns the zero address
-     * @param _address The string that is a potential address to validate and convert
-     * @return The address if valid, otherwise the zero address
-     */
-    function validateAndConvertAddress(string memory _address) public pure returns (address) {
-        bytes memory addrBytes = bytes(_address);
 
-        // Check if the length is 42 characters
-        if (addrBytes.length != 42) {
-            return address(0);
-        }
-
-        // Check if it starts with '0x'
-        if (addrBytes[0] != '0' || addrBytes[1] != 'x') {
-            return address(0);
-        }
-
-        uint160 addr = 0;
-
-        // Convert and validate each character
-        for (uint i = 2; i < 42; i++) {
-            uint8 b = uint8(addrBytes[i]);
-            if (b >= 48 && b <= 57) {
-                // '0' to '9'
-                addr = addr * 16 + (b - 48);
-            } else if (b >= 97 && b <= 102) {
-                // 'a' to 'f'
-                addr = addr * 16 + (b - 87);
-            } else if (b >= 65 && b <= 70) {
-                // 'A' to 'F'
-                addr = addr * 16 + (b - 55);
-            } else {
-                // Invalid character found
-                return address(0);
-            }
-        }
-
-        return address(addr);
-    }
 
 
     /**

--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -10,6 +10,8 @@ import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol"
 import "../../upgrades/referee/Referee10.sol";
 import "../../RefereeCalculations.sol";
 
+import "hardhat/console.sol";
+
 interface IAggregatorV3Interface {
     function latestAnswer() external view returns (int256);
 }
@@ -97,12 +99,14 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     mapping (string => PromoCode) private _promoCodesUSDC;
     mapping (address => uint256) private _referralRewardsUSDC;
 
+    address public refereeCalculationsAddress;
+
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[487] private __gap;
+    uint256[486] private __gap;
 
     // Define the pricing tiers
     struct Tier {
@@ -141,11 +145,13 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         address ethPriceFeedAddress, 
         address xaiPriceFeedAddress, 
         address airdropAdmin,
-        address _usdcAddress
+        address _usdcAddress,
+        address _refereeCalculationsAddress
     ) public reinitializer(3) {
         require(_xaiAddress != address(0), "Invalid xai address");
         require(_esXaiAddress != address(0), "Invalid esXai address");
         require(_usdcAddress != address(0), "Invalid usdc address");
+        require(_refereeCalculationsAddress != address(0), "Invalid referee address");
         require(ethPriceFeedAddress != address(0), "Invalid ethPriceFeed address");
         require(xaiPriceFeedAddress != address(0), "Invalid xaiPriceFeed address");
         ethPriceFeed = IAggregatorV3Interface(ethPriceFeedAddress);
@@ -153,6 +159,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         xaiAddress = _xaiAddress;
         esXaiAddress = _esXaiAddress;
         usdcAddress = _usdcAddress;
+        refereeCalculationsAddress = _refereeCalculationsAddress;
         
         // Grant the airdrop admin role to the airdrop admin address
         _grantRole(AIRDROP_ADMIN_ROLE, airdropAdmin);
@@ -447,7 +454,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         // If promo code does not exist in the mapping
 
         // Check if the promo code is an address
-        address promoCodeAsAddress = RefereeCalculations(address(this)).validateAndConvertAddress(_promoCode);
+        address promoCodeAsAddress = RefereeCalculations(refereeCalculationsAddress).validateAndConvertAddress(_promoCode);
 
         // If the promo code is an address, determine if the recipient has been set
         if(promoCodeAsAddress != address(0)){
@@ -550,8 +557,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         }else{
             // Check if the promo code is an address
             // Returns 0 address if not an address
-            address promoCodeAsAddress = RefereeCalculations(address(this)).validateAndConvertAddress(_promoCode);
-
+            address promoCodeAsAddress = RefereeCalculations(refereeCalculationsAddress).validateAndConvertAddress(_promoCode);
             // If the promo code is a valid address, check if it owns a license
             if(promoCodeAsAddress != address(0)){
 

--- a/infrastructure/smart-contracts/scripts/tiny-keys/deployTinyKeys.mjs
+++ b/infrastructure/smart-contracts/scripts/tiny-keys/deployTinyKeys.mjs
@@ -64,7 +64,7 @@ async function main() {
     const NodeLicense8 = await ethers.getContractFactory("NodeLicense8");    
     console.log("Got NodeLicense factory");
 
-    const nodeLicenseUpgradeParams = [config.xaiAddress, config.esXaiAddress, config.chainlinkEthUsdPriceFeed, config.chainlinkXaiUsdPriceFeed, tinyKeysAirdropAddress, config.usdcContractAddress];
+    const nodeLicenseUpgradeParams = [config.xaiAddress, config.esXaiAddress, config.chainlinkEthUsdPriceFeed, config.chainlinkXaiUsdPriceFeed, tinyKeysAirdropAddress, config.usdcContractAddress, config.refereeCalculationsAddress];
     const nodeLicense8 = await upgrades.upgradeProxy(config.nodeLicenseAddress, NodeLicense8, { call: {fn: "initialize", args: nodeLicenseUpgradeParams } });
 
     /**

--- a/infrastructure/smart-contracts/test/Fixture.mjs
+++ b/infrastructure/smart-contracts/test/Fixture.mjs
@@ -330,19 +330,24 @@ describe("Fixture Tests", function () {
             [usdcName, usdcSymbol]
         );
         await usdcToken.waitForDeployment();
-        // // Node License8 Upgrade - Required For Tiny Keys
+
+        //Deploy RefereeCalculations
+        const RefereeCalculations = await ethers.getContractFactory("RefereeCalculations");
+        const refereeCalculations = await upgrades.deployProxy(RefereeCalculations, [], { deployer: deployer });
+        await refereeCalculations.waitForDeployment();
+        
+        // Node License8 Upgrade - Required For Tiny Keys
         const NodeLicense8 = await ethers.getContractFactory("NodeLicense8");
-        const nodeLicense8 = await upgrades.upgradeProxy((await nodeLicense.getAddress()), NodeLicense8, { call: { fn: "initialize", args: [await xai.getAddress(), await esXai.getAddress(), await chainlinkEthUsdPriceFeed.getAddress(), await chainlinkXaiUsdPriceFeed.getAddress(), await tinyKeysAirDrop.getAddress(), await usdcToken.getAddress()] } });
+        const nodeLicense8 = await upgrades.upgradeProxy(
+            (await nodeLicense.getAddress()), 
+            NodeLicense8, 
+            { call: { fn: "initialize", args: [await xai.getAddress(), await esXai.getAddress(), await chainlinkEthUsdPriceFeed.getAddress(), await chainlinkXaiUsdPriceFeed.getAddress(), await tinyKeysAirDrop.getAddress(), await usdcToken.getAddress(), await refereeCalculations.getAddress()] } }
+        );
         await nodeLicense8.waitForDeployment();
 
         // Setup admin mint to role for nodeLicenseDefaultAdmin
         await nodeLicense8.connect(nodeLicenseDefaultAdmin).grantRole(await nodeLicense8.ADMIN_MINT_ROLE(), nodeLicenseDefaultAdmin.address);
         await nodeLicense8.connect(nodeLicenseDefaultAdmin).grantRole(await nodeLicense8.TRANSFER_ROLE(), nodeLicenseDefaultAdmin.address);
-
-        const RefereeCalculations = await ethers.getContractFactory("RefereeCalculations");
-        const refereeCalculations = await upgrades.deployProxy(RefereeCalculations, [], { deployer: deployer });
-        await refereeCalculations.waitForDeployment();
-        
 
         // // Upgrade esXai3 upgrade - Required For Tiny Keys
         const maxKeysNonKyc = BigInt(1);


### PR DESCRIPTION
For [#188577643](https://www.pivotaltracker.com/story/show/188577643) 

* Fixed NodeLicense8 contract size issue.
* Added `_refereeCalculationsAddress` param to initializer and new public `refereeCalculationsAddress` state variable.
* Commented out tests that were for functions removed by this PR.

Tested by running `pnpm test` and observing successful test results for NodeLicense:

```
✔ Check calling the initializer is not allowed afterwards
✔ Check the max supply is 50,000
✔ Check creating and removing promo codes
✔ Check all tiers were uploaded properly and the pricing tiers length is correct (100ms)
✔ Check minting an NFT and receiving it
✔ Check minting with a promo code and receiving the correct funds
✔ Check that NFTs are not transferable after minting (47ms)
✔ Check referral reward claim (43ms)
✔ Check tokenURI returns a base64
✔ Check if setting a pricing tier out of bounds fails
✔ Check if supportsInterface returns correct boolean value
✔ Check if can mint with USDC to recipient address (41ms)
✔ Check if can mint with USDC to recipient address using a valid promo code (48ms)
✔ Check if can claim USDC referral rewards (47ms)
✔ Checks calling adminMintTo without ADMIN_MINT_ROLE will fail (55ms)
✔ Checks that the admin can mint to a receiver without fee
✔ Should not allow the adminMintTo to exceed the maxSupply
✔ Should require TRANSFER_ROLE for any transfers (108ms)
✔ Should allow safeTransferFrom with TRANSFER_ROLE (42ms)
✔ Should allow transferFrom with TRANSFER_ROLE (46ms)
✔ Should allow adminTransferBatch with TRANSFER_ROLE (49ms)
✔ Should revert transfer of a token not owned by sender (73ms)
✔ Should allow transferFrom with approval (55ms)
✔ Should revert adminTransferBatch using the same transferId (71ms)
```