### PR TITLE
Nodelicense revert on transfer staked

### DIFF
--- a/infrastructure/smart-contracts/contracts/drops/TinyKeysAirdrop.sol
+++ b/infrastructure/smart-contracts/contracts/drops/TinyKeysAirdrop.sol
@@ -90,7 +90,7 @@ contract TinyKeysAirdrop is Initializable, AccessControlUpgradeable {
         // The node license contract will then notify the referee contract
         // This will disable minting in the node license contract
         // This will also disable staking in the referee contract
-        NodeLicense8(nodeLicenseAddress).startAirdrop(refereeAddress);
+        NodeLicense8(nodeLicenseAddress).startAirdrop();
 
         // Set the total supply of node licenses at the start of the airdrop
         totalSupplyAtStart = NodeLicense8(nodeLicenseAddress).totalSupply();
@@ -180,7 +180,7 @@ contract TinyKeysAirdrop is Initializable, AccessControlUpgradeable {
         require(stakeCounter == totalSupplyAtStart + 1, "Staking not complete");
 
         // Notify the node license contract that the airdrop is complete
-        NodeLicense8(nodeLicenseAddress).finishAirdrop(refereeAddress, keyMultiplier + 1);
+        NodeLicense8(nodeLicenseAddress).finishAirdrop(keyMultiplier + 1);
 
         airdropStarted = false;
         airdropEnded = true;

--- a/infrastructure/smart-contracts/contracts/upgrade-tests/NodeLicenseUpgradeTest.sol
+++ b/infrastructure/smart-contracts/contracts/upgrade-tests/NodeLicenseUpgradeTest.sol
@@ -98,6 +98,7 @@ contract NodeLicenseUpgradeTest is
     mapping (address => uint256) private _referralRewardsUSDC;
 
     address public refereeCalculationsAddress;
+    address public refereeAddress;
 
     bytes32 public constant AIRDROP_ADMIN_ROLE = keccak256("AIRDROP_ADMIN_ROLE");
     bytes32 public constant ADMIN_MINT_ROLE = keccak256("ADMIN_MINT_ROLE");
@@ -110,7 +111,7 @@ contract NodeLicenseUpgradeTest is
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[485] private __gap;
+    uint256[484] private __gap;
 
     // Define the pricing tiers
     struct Tier {

--- a/infrastructure/smart-contracts/scripts/tiny-keys/deployTinyKeys.mjs
+++ b/infrastructure/smart-contracts/scripts/tiny-keys/deployTinyKeys.mjs
@@ -64,7 +64,7 @@ async function main() {
     const NodeLicense8 = await ethers.getContractFactory("NodeLicense8");    
     console.log("Got NodeLicense factory");
 
-    const nodeLicenseUpgradeParams = [config.xaiAddress, config.esXaiAddress, config.chainlinkEthUsdPriceFeed, config.chainlinkXaiUsdPriceFeed, tinyKeysAirdropAddress, config.usdcContractAddress, config.refereeCalculationsAddress];
+    const nodeLicenseUpgradeParams = [config.xaiAddress, config.esXaiAddress, config.chainlinkEthUsdPriceFeed, config.chainlinkXaiUsdPriceFeed, tinyKeysAirdropAddress, config.usdcContractAddress, config.refereeCalculationsAddress, config.refereeAddress];
     const nodeLicense8 = await upgrades.upgradeProxy(config.nodeLicenseAddress, NodeLicense8, { call: {fn: "initialize", args: nodeLicenseUpgradeParams } });
 
     /**

--- a/infrastructure/smart-contracts/test/Fixture.mjs
+++ b/infrastructure/smart-contracts/test/Fixture.mjs
@@ -335,13 +335,28 @@ describe("Fixture Tests", function () {
         const RefereeCalculations = await ethers.getContractFactory("RefereeCalculations");
         const refereeCalculations = await upgrades.deployProxy(RefereeCalculations, [], { deployer: deployer });
         await refereeCalculations.waitForDeployment();
-        
+
         // Node License8 Upgrade - Required For Tiny Keys
         const NodeLicense8 = await ethers.getContractFactory("NodeLicense8");
         const nodeLicense8 = await upgrades.upgradeProxy(
-            (await nodeLicense.getAddress()), 
-            NodeLicense8, 
-            { call: { fn: "initialize", args: [await xai.getAddress(), await esXai.getAddress(), await chainlinkEthUsdPriceFeed.getAddress(), await chainlinkXaiUsdPriceFeed.getAddress(), await tinyKeysAirDrop.getAddress(), await usdcToken.getAddress(), await refereeCalculations.getAddress()] } }
+            (await nodeLicense.getAddress()),
+            NodeLicense8,
+            {
+                call:
+                {
+                    fn: "initialize",
+                    args: [
+                        await xai.getAddress(),
+                        await esXai.getAddress(),
+                        await chainlinkEthUsdPriceFeed.getAddress(),
+                        await chainlinkXaiUsdPriceFeed.getAddress(),
+                        await tinyKeysAirDrop.getAddress(),
+                        await usdcToken.getAddress(),
+                        await refereeCalculations.getAddress(),
+                        await referee.getAddress(),
+                    ]
+                }
+            }
         );
         await nodeLicense8.waitForDeployment();
 

--- a/infrastructure/smart-contracts/test/NodeLicense.mjs
+++ b/infrastructure/smart-contracts/test/NodeLicense.mjs
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import { parse } from "csv/sync";
 import fs from "fs";
 import { mintBatchedLicenses } from "./utils/mintLicenses.mjs"
+import { createPool } from "./utils/createPool.mjs"
 
 export function NodeLicenseTests(deployInfrastructure) {
     return function() {
@@ -17,7 +18,8 @@ export function NodeLicenseTests(deployInfrastructure) {
                 chainlinkEthUsdPriceFeed,
                 chainlinkXaiUsdPriceFeed, 
                 usdcToken,
-                refereeCalculations
+                refereeCalculations,
+                referee
             } = await loadFixture(deployInfrastructure);
 
             const expectedRevertMessage = "Initializable: contract is already initialized";
@@ -29,7 +31,8 @@ export function NodeLicenseTests(deployInfrastructure) {
                     chainlinkXaiUsdPriceFeed.getAddress(), 
                     await deployer.getAddress(), 
                     await usdcToken.getAddress(),
-                    await refereeCalculations.getAddress()
+                    await refereeCalculations.getAddress(),
+                    await referee.getAddress(),
                 )
             ).to.be.revertedWith(expectedRevertMessage);
         })
@@ -785,6 +788,50 @@ export function NodeLicenseTests(deployInfrastructure) {
             // Check that balance stayed the same
             expect(addr1Balance + 3n).to.equal(await nodeLicense.balanceOf(nodeLicenseDefaultAdmin.address));
             expect(addr2Balance).to.equal(await nodeLicense.balanceOf(addr2.address));
+        });
+
+        it("Should not allow a staked key to be transferred", async function () {
+            const { nodeLicense, addr1, addr2, referee, poolFactory } = await loadFixture(deployInfrastructure);
+
+            // Verify that the wallet does not have the role
+            expect(
+                await nodeLicense.hasRole(await nodeLicense.TRANSFER_ROLE(), addr1.address)
+            ).to.equal(false);
+
+            const addr1BalanceBefore = await nodeLicense.balanceOf(addr1.address);
+            const addr2BalanceBefore = await nodeLicense.balanceOf(addr2.address);
+            expect(addr1BalanceBefore).to.be.greaterThan(0n);
+
+			const mintedKeyId = await nodeLicense.tokenOfOwnerByIndex(addr1.address, 0n);
+
+            // Verify the key not staked
+            expect(await referee.assignedKeyToPool(mintedKeyId)).to.equal(ethers.ZeroAddress);
+
+            // Create pool & stake key
+            await createPool(poolFactory, addr1, [mintedKeyId]);
+			const stakingPoolAddress = await poolFactory.connect(addr1).getPoolAddress(0);
+            // Verify the key is assigned to the pool
+            expect(await referee.assignedKeyToPool(mintedKeyId)).to.equal(stakingPoolAddress);
+
+            const testTxHash = "0xf63670b4dc0a1468cdf2a37758ea82907655809857c8e5a41cda697152cc7fa8"
+            await expect(
+                nodeLicense.connect(addr1).adminTransferBatch(addr2.address, [mintedKeyId], testTxHash)
+            ).to.be.revertedWith("Cannot transfer staked key");
+
+            await expect(
+                nodeLicense.connect(addr1).safeTransferFrom(addr1.address, addr2.address, mintedKeyId)
+            ).to.be.revertedWith("Cannot transfer staked key");
+            
+            await expect(
+                nodeLicense.connect(addr1).transferFrom(addr1.address, addr2.address, mintedKeyId)
+            ).to.be.revertedWith("Cannot transfer staked key");
+
+            // Check that balance remains unchanged
+            const addr1Balance = await nodeLicense.balanceOf(addr1.address);
+            expect(addr1Balance).to.equal(addr1BalanceBefore);
+            
+            const addr2Balance = await nodeLicense.balanceOf(addr2.address);
+            expect(addr2Balance).to.equal(addr2BalanceBefore);
         });
 
     }

--- a/infrastructure/smart-contracts/test/utils/createPool.mjs
+++ b/infrastructure/smart-contracts/test/utils/createPool.mjs
@@ -13,7 +13,7 @@ const VALID_SHARE_VALUES = [50_000n, 850_000n, 100_000n];
  * Creates a new pool using the provided pool factory.
  * @param {Contract} poolFactory - The pool factory contract instance.
  * @param {Wallet} poolOwner - The wallet of the pool owner creating the pool.
- * @param {BigInt} keysToStake - The number of keys to stake in the pool.
+ * @param {BigInt[]} keysToStake - The number of keys to stake in the pool.
  * @param {string} [poolDelegate] - The address of the pool delegate. Defaults to zero address if not provided.
  * @returns {Promise<string>} - The address of the newly created pool.
  */


### PR DESCRIPTION
For [#188577671](https://www.pivotaltracker.com/story/show/188577671)

Add require key to be unstaked on NodeLicense transfer.
Add refereeAddress to NodeLicense state.
Add test for checking fail on transfer of staked key.

Update TKAirdrop for not passing refAddress anymore.
Update tk deploy script.

Ran full test suite locally.
Deployed this NodeLicense upgrade to sepolia, tested transfer manually.



