### PR TITLE
Update Subgraph handlers to work with new PoolFactory2 Events

### DIFF
--- a/infrastructure/sentry-subgraph/abis/PoolFactory.json
+++ b/infrastructure/sentry-subgraph/abis/PoolFactory.json
@@ -1,1319 +1,1726 @@
 [
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            }
-        ],
-        "name": "ClaimFromPool",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "uint8",
-                "name": "version",
-                "type": "uint8"
-            }
-        ],
-        "name": "Initialized",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "poolIndex",
-                "type": "uint256"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "poolAddress",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "poolOwner",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "stakedKeyCount",
-                "type": "uint256"
-            }
-        ],
-        "name": "PoolCreated",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "oldDeployer",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "newDeployer",
-                "type": "address"
-            }
-        ],
-        "name": "PoolProxyDeployerUpdated",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "previousAdminRole",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "newAdminRole",
-                "type": "bytes32"
-            }
-        ],
-        "name": "RoleAdminChanged",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            }
-        ],
-        "name": "RoleGranted",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            }
-        ],
-        "name": "RoleRevoked",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "totalUserEsXaiStaked",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "totalEsXaiStaked",
-                "type": "uint256"
-            }
-        ],
-        "name": "StakeEsXai",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "totalUserKeysStaked",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "totalKeysStaked",
-                "type": "uint256"
-            }
-        ],
-        "name": "StakeKeys",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [],
-        "name": "StakingEnabled",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "totalUserEsXaiStaked",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "totalEsXaiStaked",
-                "type": "uint256"
-            }
-        ],
-        "name": "UnstakeEsXai",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "totalUserKeysStaked",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "totalKeysStaked",
-                "type": "uint256"
-            }
-        ],
-        "name": "UnstakeKeys",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "index",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "bool",
-                "name": "isKey",
-                "type": "bool"
-            }
-        ],
-        "name": "UnstakeRequestStarted",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [],
-        "name": "UpdateDelayPeriods",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            }
-        ],
-        "name": "UpdateMetadata",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "delegate",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            }
-        ],
-        "name": "UpdatePoolDelegate",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            }
-        ],
-        "name": "UpdateShares",
-        "type": "event"
-    },
-    {
-        "inputs": [],
-        "name": "DEFAULT_ADMIN_ROLE",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "bucketshareMaxValues",
-        "outputs": [
-            {
-                "internalType": "uint32",
-                "name": "",
-                "type": "uint32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "keyIds",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "checkKeysAreStaked",
-        "outputs": [
-            {
-                "internalType": "bool[]",
-                "name": "isStaked",
-                "type": "bool[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address[]",
-                "name": "pools",
-                "type": "address[]"
-            }
-        ],
-        "name": "claimFromPools",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_delegateOwner",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_keyIds",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint32[3]",
-                "name": "_shareConfig",
-                "type": "uint32[3]"
-            },
-            {
-                "internalType": "string[3]",
-                "name": "_poolMetadata",
-                "type": "string[3]"
-            },
-            {
-                "internalType": "string[]",
-                "name": "_poolSocials",
-                "type": "string[]"
-            },
-            {
-                "internalType": "string[2][2]",
-                "name": "trackerDetails",
-                "type": "string[2][2]"
-            }
-        ],
-        "name": "createPool",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "createUnstakeEsXaiRequest",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "keyAmount",
-                "type": "uint256"
-            }
-        ],
-        "name": "createUnstakeKeyRequest",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            }
-        ],
-        "name": "createUnstakeOwnerLastKeyRequest",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "deployerAddress",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "enableStaking",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "esXaiAddress",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "delegate",
-                "type": "address"
-            }
-        ],
-        "name": "getDelegatePools",
-        "outputs": [
-            {
-                "internalType": "address[]",
-                "name": "",
-                "type": "address[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "poolIndex",
-                "type": "uint256"
-            }
-        ],
-        "name": "getPoolAddress",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "index",
-                "type": "uint256"
-            }
-        ],
-        "name": "getPoolAddressOfUser",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            }
-        ],
-        "name": "getPoolIndicesOfUser",
-        "outputs": [
-            {
-                "internalType": "address[]",
-                "name": "",
-                "type": "address[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getPoolsCount",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            }
-        ],
-        "name": "getPoolsOfUserCount",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            }
-        ],
-        "name": "getRoleAdmin",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "uint256",
-                "name": "index",
-                "type": "uint256"
-            }
-        ],
-        "name": "getRoleMember",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            }
-        ],
-        "name": "getRoleMemberCount",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "internalType": "uint16",
-                "name": "offset",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint16",
-                "name": "pageLimit",
-                "type": "uint16"
-            }
-        ],
-        "name": "getUnstakedKeyIdsFromUser",
-        "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "unstakedKeyIds",
-                "type": "uint256[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "grantRole",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "hasRole",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "initialize",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "interactedPoolsOfUser",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "delegate",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            }
-        ],
-        "name": "isDelegateOfPoolOrOwner",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "nodeLicenseAddress",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "poolsCreatedViaFactory",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "poolsOfDelegate",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "poolsOfDelegateIndices",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "refereeAddress",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "renounceRole",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "revokeRole",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "stakeEsXai",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "keyIds",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "stakeKeys",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "stakingEnabled",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "stakingPools",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes4",
-                "name": "interfaceId",
-                "type": "bytes4"
-            }
-        ],
-        "name": "supportsInterface",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "unstakeRequestIndex",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "unstakeEsXai",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "unstakeEsXaiDelayPeriod",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "unstakeGenesisKeyDelayPeriod",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "unstakeRequestIndex",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "keyIds",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "unstakeKeys",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "unstakeKeysDelayPeriod",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_unstakeKeysDelayPeriod",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_unstakeGenesisKeyDelayPeriod",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_unstakeEsXaiDelayPeriod",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_updateRewardBreakdownDelayPeriod",
-                "type": "uint256"
-            }
-        ],
-        "name": "updateDelayPeriods",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "delegate",
-                "type": "address"
-            }
-        ],
-        "name": "updateDelegateOwner",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "internalType": "string[3]",
-                "name": "_poolMetadata",
-                "type": "string[3]"
-            },
-            {
-                "internalType": "string[]",
-                "name": "_poolSocials",
-                "type": "string[]"
-            }
-        ],
-        "name": "updatePoolMetadata",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newDeployer",
-                "type": "address"
-            }
-        ],
-        "name": "updatePoolProxyDeployer",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "updateRewardBreakdownDelayPeriod",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "pool",
-                "type": "address"
-            },
-            {
-                "internalType": "uint32[3]",
-                "name": "_shareConfig",
-                "type": "uint32[3]"
-            }
-        ],
-        "name": "updateShares",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "userToInteractedPoolIds",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    }
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "ClaimFromPool",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "poolIndex",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "poolAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "poolOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "stakedKeyCount",
+        "type": "uint256"
+      }
+    ],
+    "name": "PoolCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "poolIndex",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "poolAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "poolOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "stakedKeyCount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "delegateAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "keyIds",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32[3]",
+        "name": "shareConfig",
+        "type": "uint32[3]"
+      },
+      {
+        "indexed": false,
+        "internalType": "string[3]",
+        "name": "poolMetadata",
+        "type": "string[3]"
+      },
+      {
+        "indexed": false,
+        "internalType": "string[]",
+        "name": "poolSocials",
+        "type": "string[]"
+      }
+    ],
+    "name": "PoolCreatedV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldDeployer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newDeployer",
+        "type": "address"
+      }
+    ],
+    "name": "PoolProxyDeployerUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalUserEsXaiStaked",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalEsXaiStaked",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakeEsXai",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalUserKeysStaked",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalKeysStaked",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakeKeys",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalUserKeysStaked",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalKeysStaked",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "keyIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "StakeKeysV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "StakingEnabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalUserEsXaiStaked",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalEsXaiStaked",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnstakeEsXai",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalUserEsXaiStaked",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalEsXaiStaked",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "requestIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnstakeEsXaiV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalUserKeysStaked",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalKeysStaked",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnstakeKeys",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalUserKeysStaked",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalKeysStaked",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "requestIndex",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "keyIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "UnstakeKeysV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isKey",
+        "type": "bool"
+      }
+    ],
+    "name": "UnstakeRequestStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "UpdateDelayPeriods",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "UpdateMetadata",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string[3]",
+        "name": "poolMetadata",
+        "type": "string[3]"
+      },
+      {
+        "indexed": false,
+        "internalType": "string[]",
+        "name": "poolSocials",
+        "type": "string[]"
+      }
+    ],
+    "name": "UpdateMetadataV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegate",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "UpdatePoolDelegate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "UpdateShares",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32[3]",
+        "name": "shareConfig",
+        "type": "uint32[3]"
+      }
+    ],
+    "name": "UpdateSharesV2",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "STAKE_KEYS_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "bucketshareMaxValues",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "users",
+        "type": "address[]"
+      }
+    ],
+    "name": "calculateUserTotalStake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "keyIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "checkKeysAreStaked",
+    "outputs": [
+      {
+        "internalType": "bool[]",
+        "name": "isStaked",
+        "type": "bool[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "pools",
+        "type": "address[]"
+      }
+    ],
+    "name": "claimFromPools",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_delegateOwner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_keyIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint32[3]",
+        "name": "_shareConfig",
+        "type": "uint32[3]"
+      },
+      {
+        "internalType": "string[3]",
+        "name": "_poolMetadata",
+        "type": "string[3]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "_poolSocials",
+        "type": "string[]"
+      },
+      {
+        "internalType": "string[2][2]",
+        "name": "trackerDetails",
+        "type": "string[2][2]"
+      }
+    ],
+    "name": "createPool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "createUnstakeEsXaiRequest",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "keyAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "createUnstakeKeyRequest",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "createUnstakeOwnerLastKeyRequest",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "deployerAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "enableStaking",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "esXaiAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "failedKyc",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "delegate",
+        "type": "address"
+      }
+    ],
+    "name": "getDelegatePools",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "poolIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "getPoolAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getPoolAddressOfUser",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolIndicesOfUser",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPoolsCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolsOfUserCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRoleMember",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleMemberCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "getTotalesXaiStakedByUser",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint16",
+        "name": "offset",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "pageLimit",
+        "type": "uint16"
+      }
+    ],
+    "name": "getUnstakedKeyIdsFromUser",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "unstakedKeyIds",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "interactedPoolsOfUser",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "delegate",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "isDelegateOfPoolOrOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nodeLicenseAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "poolsCreatedViaFactory",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "poolsOfDelegate",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "poolsOfDelegateIndices",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "refereeAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeStakeKeysAdminRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "failed",
+        "type": "bool"
+      }
+    ],
+    "name": "setFailedKyc",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "stakeEsXai",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "keyIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "stakeKeys",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "keyIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address",
+        "name": "staker",
+        "type": "address"
+      }
+    ],
+    "name": "stakeKeysAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakingEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "stakingPools",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "totalEsXaiStakeCalculated",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "unstakeRequestIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "unstakeEsXai",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unstakeEsXaiDelayPeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unstakeGenesisKeyDelayPeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "unstakeRequestIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "keyIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "unstakeKeys",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unstakeKeysDelayPeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_unstakeKeysDelayPeriod",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_unstakeGenesisKeyDelayPeriod",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_unstakeEsXaiDelayPeriod",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_updateRewardBreakdownDelayPeriod",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateDelayPeriods",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "delegate",
+        "type": "address"
+      }
+    ],
+    "name": "updateDelegateOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "string[3]",
+        "name": "_poolMetadata",
+        "type": "string[3]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "_poolSocials",
+        "type": "string[]"
+      }
+    ],
+    "name": "updatePoolMetadata",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newDeployer",
+        "type": "address"
+      }
+    ],
+    "name": "updatePoolProxyDeployer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "updateRewardBreakdownDelayPeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32[3]",
+        "name": "_shareConfig",
+        "type": "uint32[3]"
+      }
+    ],
+    "name": "updateShares",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "userToInteractedPoolIds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "validateSubmitPoolAssertion",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
 ]

--- a/infrastructure/sentry-subgraph/generated/PoolFactory/PoolFactory.ts
+++ b/infrastructure/sentry-subgraph/generated/PoolFactory/PoolFactory.ts
@@ -80,6 +80,56 @@ export class PoolCreated__Params {
   }
 }
 
+export class PoolCreatedV2 extends ethereum.Event {
+  get params(): PoolCreatedV2__Params {
+    return new PoolCreatedV2__Params(this);
+  }
+}
+
+export class PoolCreatedV2__Params {
+  _event: PoolCreatedV2;
+
+  constructor(event: PoolCreatedV2) {
+    this._event = event;
+  }
+
+  get poolIndex(): BigInt {
+    return this._event.parameters[0].value.toBigInt();
+  }
+
+  get poolAddress(): Address {
+    return this._event.parameters[1].value.toAddress();
+  }
+
+  get poolOwner(): Address {
+    return this._event.parameters[2].value.toAddress();
+  }
+
+  get stakedKeyCount(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+
+  get delegateAddress(): Address {
+    return this._event.parameters[4].value.toAddress();
+  }
+
+  get keyIds(): Array<BigInt> {
+    return this._event.parameters[5].value.toBigIntArray();
+  }
+
+  get shareConfig(): Array<BigInt> {
+    return this._event.parameters[6].value.toBigIntArray();
+  }
+
+  get poolMetadata(): Array<string> {
+    return this._event.parameters[7].value.toStringArray();
+  }
+
+  get poolSocials(): Array<string> {
+    return this._event.parameters[8].value.toStringArray();
+  }
+}
+
 export class PoolProxyDeployerUpdated extends ethereum.Event {
   get params(): PoolProxyDeployerUpdated__Params {
     return new PoolProxyDeployerUpdated__Params(this);
@@ -248,6 +298,44 @@ export class StakeKeys__Params {
   }
 }
 
+export class StakeKeysV2 extends ethereum.Event {
+  get params(): StakeKeysV2__Params {
+    return new StakeKeysV2__Params(this);
+  }
+}
+
+export class StakeKeysV2__Params {
+  _event: StakeKeysV2;
+
+  constructor(event: StakeKeysV2) {
+    this._event = event;
+  }
+
+  get user(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get pool(): Address {
+    return this._event.parameters[1].value.toAddress();
+  }
+
+  get amount(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get totalUserKeysStaked(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+
+  get totalKeysStaked(): BigInt {
+    return this._event.parameters[4].value.toBigInt();
+  }
+
+  get keyIds(): Array<BigInt> {
+    return this._event.parameters[5].value.toBigIntArray();
+  }
+}
+
 export class StakingEnabled extends ethereum.Event {
   get params(): StakingEnabled__Params {
     return new StakingEnabled__Params(this);
@@ -296,6 +384,44 @@ export class UnstakeEsXai__Params {
   }
 }
 
+export class UnstakeEsXaiV2 extends ethereum.Event {
+  get params(): UnstakeEsXaiV2__Params {
+    return new UnstakeEsXaiV2__Params(this);
+  }
+}
+
+export class UnstakeEsXaiV2__Params {
+  _event: UnstakeEsXaiV2;
+
+  constructor(event: UnstakeEsXaiV2) {
+    this._event = event;
+  }
+
+  get user(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get pool(): Address {
+    return this._event.parameters[1].value.toAddress();
+  }
+
+  get amount(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get totalUserEsXaiStaked(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+
+  get totalEsXaiStaked(): BigInt {
+    return this._event.parameters[4].value.toBigInt();
+  }
+
+  get requestIndex(): BigInt {
+    return this._event.parameters[5].value.toBigInt();
+  }
+}
+
 export class UnstakeKeys extends ethereum.Event {
   get params(): UnstakeKeys__Params {
     return new UnstakeKeys__Params(this);
@@ -327,6 +453,48 @@ export class UnstakeKeys__Params {
 
   get totalKeysStaked(): BigInt {
     return this._event.parameters[4].value.toBigInt();
+  }
+}
+
+export class UnstakeKeysV2 extends ethereum.Event {
+  get params(): UnstakeKeysV2__Params {
+    return new UnstakeKeysV2__Params(this);
+  }
+}
+
+export class UnstakeKeysV2__Params {
+  _event: UnstakeKeysV2;
+
+  constructor(event: UnstakeKeysV2) {
+    this._event = event;
+  }
+
+  get user(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get pool(): Address {
+    return this._event.parameters[1].value.toAddress();
+  }
+
+  get amount(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get totalUserKeysStaked(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+
+  get totalKeysStaked(): BigInt {
+    return this._event.parameters[4].value.toBigInt();
+  }
+
+  get requestIndex(): BigInt {
+    return this._event.parameters[5].value.toBigInt();
+  }
+
+  get keyIds(): Array<BigInt> {
+    return this._event.parameters[6].value.toBigIntArray();
   }
 }
 
@@ -396,6 +564,32 @@ export class UpdateMetadata__Params {
   }
 }
 
+export class UpdateMetadataV2 extends ethereum.Event {
+  get params(): UpdateMetadataV2__Params {
+    return new UpdateMetadataV2__Params(this);
+  }
+}
+
+export class UpdateMetadataV2__Params {
+  _event: UpdateMetadataV2;
+
+  constructor(event: UpdateMetadataV2) {
+    this._event = event;
+  }
+
+  get pool(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get poolMetadata(): Array<string> {
+    return this._event.parameters[1].value.toStringArray();
+  }
+
+  get poolSocials(): Array<string> {
+    return this._event.parameters[2].value.toStringArray();
+  }
+}
+
 export class UpdatePoolDelegate extends ethereum.Event {
   get params(): UpdatePoolDelegate__Params {
     return new UpdatePoolDelegate__Params(this);
@@ -436,6 +630,28 @@ export class UpdateShares__Params {
   }
 }
 
+export class UpdateSharesV2 extends ethereum.Event {
+  get params(): UpdateSharesV2__Params {
+    return new UpdateSharesV2__Params(this);
+  }
+}
+
+export class UpdateSharesV2__Params {
+  _event: UpdateSharesV2;
+
+  constructor(event: UpdateSharesV2) {
+    this._event = event;
+  }
+
+  get pool(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get shareConfig(): Array<BigInt> {
+    return this._event.parameters[1].value.toBigIntArray();
+  }
+}
+
 export class PoolFactory extends ethereum.SmartContract {
   static bind(address: Address): PoolFactory {
     return new PoolFactory("PoolFactory", address);
@@ -455,6 +671,29 @@ export class PoolFactory extends ethereum.SmartContract {
     let result = super.tryCall(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
+      [],
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
+  }
+
+  STAKE_KEYS_ADMIN_ROLE(): Bytes {
+    let result = super.call(
+      "STAKE_KEYS_ADMIN_ROLE",
+      "STAKE_KEYS_ADMIN_ROLE():(bytes32)",
+      [],
+    );
+
+    return result[0].toBytes();
+  }
+
+  try_STAKE_KEYS_ADMIN_ROLE(): ethereum.CallResult<Bytes> {
+    let result = super.tryCall(
+      "STAKE_KEYS_ADMIN_ROLE",
+      "STAKE_KEYS_ADMIN_ROLE():(bytes32)",
       [],
     );
     if (result.reverted) {
@@ -548,6 +787,25 @@ export class PoolFactory extends ethereum.SmartContract {
     }
     let value = result.value;
     return ethereum.CallResult.fromValue(value[0].toAddress());
+  }
+
+  failedKyc(param0: Address): boolean {
+    let result = super.call("failedKyc", "failedKyc(address):(bool)", [
+      ethereum.Value.fromAddress(param0),
+    ]);
+
+    return result[0].toBoolean();
+  }
+
+  try_failedKyc(param0: Address): ethereum.CallResult<boolean> {
+    let result = super.tryCall("failedKyc", "failedKyc(address):(bool)", [
+      ethereum.Value.fromAddress(param0),
+    ]);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   getDelegatePools(delegate: Address): Array<Address> {
@@ -758,6 +1016,29 @@ export class PoolFactory extends ethereum.SmartContract {
       "getRoleMemberCount",
       "getRoleMemberCount(bytes32):(uint256)",
       [ethereum.Value.fromFixedBytes(role)],
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  getTotalesXaiStakedByUser(user: Address): BigInt {
+    let result = super.call(
+      "getTotalesXaiStakedByUser",
+      "getTotalesXaiStakedByUser(address):(uint256)",
+      [ethereum.Value.fromAddress(user)],
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_getTotalesXaiStakedByUser(user: Address): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "getTotalesXaiStakedByUser",
+      "getTotalesXaiStakedByUser(address):(uint256)",
+      [ethereum.Value.fromAddress(user)],
     );
     if (result.reverted) {
       return new ethereum.CallResult();
@@ -1063,6 +1344,29 @@ export class PoolFactory extends ethereum.SmartContract {
     return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
+  totalEsXaiStakeCalculated(param0: Address): boolean {
+    let result = super.call(
+      "totalEsXaiStakeCalculated",
+      "totalEsXaiStakeCalculated(address):(bool)",
+      [ethereum.Value.fromAddress(param0)],
+    );
+
+    return result[0].toBoolean();
+  }
+
+  try_totalEsXaiStakeCalculated(param0: Address): ethereum.CallResult<boolean> {
+    let result = super.tryCall(
+      "totalEsXaiStakeCalculated",
+      "totalEsXaiStakeCalculated(address):(bool)",
+      [ethereum.Value.fromAddress(param0)],
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
+  }
+
   unstakeEsXaiDelayPeriod(): BigInt {
     let result = super.call(
       "unstakeEsXaiDelayPeriod",
@@ -1179,6 +1483,62 @@ export class PoolFactory extends ethereum.SmartContract {
     }
     let value = result.value;
     return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  validateSubmitPoolAssertion(pool: Address, user: Address): boolean {
+    let result = super.call(
+      "validateSubmitPoolAssertion",
+      "validateSubmitPoolAssertion(address,address):(bool)",
+      [ethereum.Value.fromAddress(pool), ethereum.Value.fromAddress(user)],
+    );
+
+    return result[0].toBoolean();
+  }
+
+  try_validateSubmitPoolAssertion(
+    pool: Address,
+    user: Address,
+  ): ethereum.CallResult<boolean> {
+    let result = super.tryCall(
+      "validateSubmitPoolAssertion",
+      "validateSubmitPoolAssertion(address,address):(bool)",
+      [ethereum.Value.fromAddress(pool), ethereum.Value.fromAddress(user)],
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
+  }
+}
+
+export class CalculateUserTotalStakeCall extends ethereum.Call {
+  get inputs(): CalculateUserTotalStakeCall__Inputs {
+    return new CalculateUserTotalStakeCall__Inputs(this);
+  }
+
+  get outputs(): CalculateUserTotalStakeCall__Outputs {
+    return new CalculateUserTotalStakeCall__Outputs(this);
+  }
+}
+
+export class CalculateUserTotalStakeCall__Inputs {
+  _call: CalculateUserTotalStakeCall;
+
+  constructor(call: CalculateUserTotalStakeCall) {
+    this._call = call;
+  }
+
+  get users(): Array<Address> {
+    return this._call.inputValues[0].value.toAddressArray();
+  }
+}
+
+export class CalculateUserTotalStakeCall__Outputs {
+  _call: CalculateUserTotalStakeCall;
+
+  constructor(call: CalculateUserTotalStakeCall) {
+    this._call = call;
   }
 }
 
@@ -1436,6 +1796,10 @@ export class InitializeCall__Inputs {
   constructor(call: InitializeCall) {
     this._call = call;
   }
+
+  get version(): i32 {
+    return this._call.inputValues[0].value.toI32();
+  }
 }
 
 export class InitializeCall__Outputs {
@@ -1514,6 +1878,70 @@ export class RevokeRoleCall__Outputs {
   }
 }
 
+export class RevokeStakeKeysAdminRoleCall extends ethereum.Call {
+  get inputs(): RevokeStakeKeysAdminRoleCall__Inputs {
+    return new RevokeStakeKeysAdminRoleCall__Inputs(this);
+  }
+
+  get outputs(): RevokeStakeKeysAdminRoleCall__Outputs {
+    return new RevokeStakeKeysAdminRoleCall__Outputs(this);
+  }
+}
+
+export class RevokeStakeKeysAdminRoleCall__Inputs {
+  _call: RevokeStakeKeysAdminRoleCall;
+
+  constructor(call: RevokeStakeKeysAdminRoleCall) {
+    this._call = call;
+  }
+
+  get account(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+}
+
+export class RevokeStakeKeysAdminRoleCall__Outputs {
+  _call: RevokeStakeKeysAdminRoleCall;
+
+  constructor(call: RevokeStakeKeysAdminRoleCall) {
+    this._call = call;
+  }
+}
+
+export class SetFailedKycCall extends ethereum.Call {
+  get inputs(): SetFailedKycCall__Inputs {
+    return new SetFailedKycCall__Inputs(this);
+  }
+
+  get outputs(): SetFailedKycCall__Outputs {
+    return new SetFailedKycCall__Outputs(this);
+  }
+}
+
+export class SetFailedKycCall__Inputs {
+  _call: SetFailedKycCall;
+
+  constructor(call: SetFailedKycCall) {
+    this._call = call;
+  }
+
+  get user(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+
+  get failed(): boolean {
+    return this._call.inputValues[1].value.toBoolean();
+  }
+}
+
+export class SetFailedKycCall__Outputs {
+  _call: SetFailedKycCall;
+
+  constructor(call: SetFailedKycCall) {
+    this._call = call;
+  }
+}
+
 export class StakeEsXaiCall extends ethereum.Call {
   get inputs(): StakeEsXaiCall__Inputs {
     return new StakeEsXaiCall__Inputs(this);
@@ -1578,6 +2006,44 @@ export class StakeKeysCall__Outputs {
   _call: StakeKeysCall;
 
   constructor(call: StakeKeysCall) {
+    this._call = call;
+  }
+}
+
+export class StakeKeysAdminCall extends ethereum.Call {
+  get inputs(): StakeKeysAdminCall__Inputs {
+    return new StakeKeysAdminCall__Inputs(this);
+  }
+
+  get outputs(): StakeKeysAdminCall__Outputs {
+    return new StakeKeysAdminCall__Outputs(this);
+  }
+}
+
+export class StakeKeysAdminCall__Inputs {
+  _call: StakeKeysAdminCall;
+
+  constructor(call: StakeKeysAdminCall) {
+    this._call = call;
+  }
+
+  get pool(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+
+  get keyIds(): Array<BigInt> {
+    return this._call.inputValues[1].value.toBigIntArray();
+  }
+
+  get staker(): Address {
+    return this._call.inputValues[2].value.toAddress();
+  }
+}
+
+export class StakeKeysAdminCall__Outputs {
+  _call: StakeKeysAdminCall;
+
+  constructor(call: StakeKeysAdminCall) {
     this._call = call;
   }
 }

--- a/infrastructure/sentry-subgraph/sepolia.subgraph.yaml
+++ b/infrastructure/sentry-subgraph/sepolia.subgraph.yaml
@@ -114,6 +114,18 @@ dataSources:
           handler: handleClaimFromPool
         - event: UpdateDelayPeriods()
           handler: handleUpdateDelayPeriods
+        - event: StakeKeysV2(indexed address,indexed address,uint256,uint256,uint256,uint256[])
+          handler: handleStakeKeysV2
+        - event: UnstakeKeysV2(indexed address,indexed address,uint256,uint256,uint256,uint256,uint256[])
+          handler: handleUnstakeKeysV2
+        - event: PoolCreatedV2(indexed uint256,indexed address,indexed address,uint256,address,uint256[],uint32[3],string[3],string[])
+          handler: handlePoolCreatedV2
+        - event: UnstakeEsXaiV2(indexed address,indexed address,uint256,uint256,uint256,uint256)
+          handler: handleUnstakeEsXaiV2
+        - event: UpdateMetadataV2(indexed address,string[3],string[])
+          handler: handleUpdateMetadataV2
+        - event: UpdateSharesV2(indexed address,uint32[3])
+          handler: handleUpdatePendingSharesV2
       file: ./src/pool-factory.ts
   - kind: ethereum
     name: Xai

--- a/infrastructure/sentry-subgraph/src/pool-factory.ts
+++ b/infrastructure/sentry-subgraph/src/pool-factory.ts
@@ -53,10 +53,17 @@ export function handleInitialized(event: Initialized): void {
 
   const poolFactory = PoolFactory.bind(event.address)
   poolConfig.version = BigInt.fromI32(event.params.version)
-  poolConfig.unstakeKeysDelayPeriod = poolFactory.unstakeKeysDelayPeriod()
-  poolConfig.unstakeGenesisKeyDelayPeriod = poolFactory.unstakeGenesisKeyDelayPeriod()
-  poolConfig.unstakeEsXaiDelayPeriod = poolFactory.unstakeEsXaiDelayPeriod()
-  poolConfig.updateRewardBreakdownDelayPeriod = poolFactory.updateRewardBreakdownDelayPeriod()
+
+  const unstakeKeysDelay = poolFactory.try_unstakeKeysDelayPeriod();
+  const unstakeGenesisKeyDelay = poolFactory.try_unstakeGenesisKeyDelayPeriod();
+  const unstakeEsXaiDelay = poolFactory.try_unstakeEsXaiDelayPeriod();
+  const updateRewardBreakdownDelay = poolFactory.try_updateRewardBreakdownDelayPeriod();
+
+  poolConfig.unstakeKeysDelayPeriod = unstakeKeysDelay.reverted ? BigInt.fromI32(0) : unstakeKeysDelay.value;
+  poolConfig.unstakeGenesisKeyDelayPeriod = unstakeGenesisKeyDelay.reverted ? BigInt.fromI32(0) : unstakeGenesisKeyDelay.value;
+  poolConfig.unstakeEsXaiDelayPeriod = unstakeEsXaiDelay.reverted ? BigInt.fromI32(0) : unstakeEsXaiDelay.value;
+  poolConfig.updateRewardBreakdownDelayPeriod = updateRewardBreakdownDelay.reverted ? BigInt.fromI32(0) : updateRewardBreakdownDelay.value;
+
   poolConfig.save();
 }
 

--- a/infrastructure/sentry-subgraph/src/pool-factory.ts
+++ b/infrastructure/sentry-subgraph/src/pool-factory.ts
@@ -12,7 +12,13 @@ import {
   PoolFactory,
   Initialized,
   UpdateDelayPeriods,
-  ClaimFromPool
+  ClaimFromPool,
+  StakeKeysV2,
+  UnstakeKeysV2,
+  UnstakeEsXaiV2,
+  PoolCreatedV2,
+  UpdateMetadataV2,
+  UpdateSharesV2
 } from "../generated/PoolFactory/PoolFactory"
 import {
   SentryKey,
@@ -55,6 +61,12 @@ export function handleInitialized(event: Initialized): void {
 }
 
 export function handleStakeKeys(event: StakeKeys): void {
+
+  const poolConfig = PoolFactoryConfig.load("PoolFactoryConfig");
+  const version = poolConfig ? poolConfig.version : BigInt.fromI32(0);
+  if (version.gt(BigInt.fromI32(1))) {
+    return;
+  }
 
   let pool = PoolInfo.load(event.params.pool.toHexString());
 
@@ -136,6 +148,12 @@ export function handleStakeKeys(event: StakeKeys): void {
 }
 
 export function handleUnstakeKeys(event: UnstakeKeys): void {
+  
+  const poolConfig = PoolFactoryConfig.load("PoolFactoryConfig");
+  const version = poolConfig ? poolConfig.version : BigInt.fromI32(0);
+  if (version.gt(BigInt.fromI32(1))) {
+    return;
+  }
 
   let pool = PoolInfo.load(event.params.pool.toHexString());
 
@@ -203,6 +221,13 @@ export function handleUnstakeKeys(event: UnstakeKeys): void {
 }
 
 export function handlePoolCreated(event: PoolCreated): void {
+
+  const poolConfig = PoolFactoryConfig.load("PoolFactoryConfig");
+  const version = poolConfig ? poolConfig.version : BigInt.fromI32(0);
+  if (version.gt(BigInt.fromI32(1))) {
+    return;
+  }
+
   const dataToDecode = getInputFromEvent(event, true)
   const decoded = ethereum.decode('(address,uint256[],uint32[3],string[3],string[],string[2][2])', dataToDecode);
   if (!decoded) {
@@ -311,6 +336,13 @@ export function handleStakeEsXai(event: StakeEsXai): void {
 }
 
 export function handleUnstakeEsXai(event: UnstakeEsXai): void {
+
+  const poolConfig = PoolFactoryConfig.load("PoolFactoryConfig");
+  const version = poolConfig ? poolConfig.version : BigInt.fromI32(0);
+  if (version.gt(BigInt.fromI32(1))) {
+    return;
+  }
+
   const pool = PoolInfo.load(event.params.pool.toHexString())
   if (!pool) {
     log.warning("handleUnstakeEsXai - pool is undefined " + event.params.pool.toHexString() + ", TX: " + event.transaction.hash.toHexString(), []);
@@ -361,6 +393,13 @@ export function handleUnstakeEsXai(event: UnstakeEsXai): void {
 }
 
 export function handleUpdateMetadata(event: UpdateMetadata): void {
+
+  const poolConfig = PoolFactoryConfig.load("PoolFactoryConfig");
+  const version = poolConfig ? poolConfig.version : BigInt.fromI32(0);
+  if (version.gt(BigInt.fromI32(1))) {
+    return;
+  }
+
   const pool = PoolInfo.load(event.params.pool.toHexString())
   if (!pool) {
     log.warning("handleUpdateMetadata - pool is undefined " + event.params.pool.toHexString() + ", TX: " + event.transaction.hash.toHexString(), []);
@@ -380,13 +419,18 @@ export function handleUpdateMetadata(event: UpdateMetadata): void {
 }
 
 export function handleUpdatePendingShares(event: UpdateShares): void {
+
+  const poolConfig = PoolFactoryConfig.load("PoolFactoryConfig");
+  const version = poolConfig ? poolConfig.version : BigInt.fromI32(0);
+  if (version.gt(BigInt.fromI32(1))) {
+    return;
+  }
+
   const pool = PoolInfo.load(event.params.pool.toHexString());
   if (!pool) {
     log.warning("handleUpdatePendingShares - pool is undefined " + event.params.pool.toHexString() + ", TX: " + event.transaction.hash.toHexString(), []);
     return;
   }
-
-  let poolConfig = PoolFactoryConfig.load("PoolFactoryConfig");
 
   const dataToDecode = getInputFromEvent(event, false)
   const decoded = ethereum.decode('(address,uint32[3])', dataToDecode);
@@ -471,4 +515,369 @@ export function handleUpdateDelayPeriods(event: UpdateDelayPeriods): void {
   } else {
     log.warning("Failed to decode handleUpdateDelayPeriods TX: " + event.transaction.hash.toHexString(), [])
   }
+}
+
+/******************* Pool Factory V2 Events ****************************/
+
+export function handleStakeKeysV2(event: StakeKeysV2): void {
+  const pool = PoolInfo.load(event.params.pool.toHexString());
+
+  if (!pool) {
+    //StakeKeys will be emitted before pool creation, so we expect on the pool creation to not find the pool yet, however it will still be initialized correctly in the createPool event
+    if (getTxSignatureFromEvent(event) != "0x098e8ae7") {
+      log.warning(
+        "handleStakeKeys - pool is undefined " +
+          event.params.pool.toHexString() +
+          ", TX: " +
+          event.transaction.hash.toHexString(),
+        []
+      );
+    }
+    return;
+  }
+
+  if (pool.owner == event.params.user) {
+    pool.ownerStakedKeys = pool.ownerStakedKeys.plus(event.params.amount);
+  }
+
+  pool.totalStakedKeyAmount = event.params.totalKeysStaked;
+  handlePoolBreakdown(pool, event.block.timestamp);
+
+  const sentryWallet = SentryWallet.load(event.params.user.toHexString());
+  if (sentryWallet) {
+    sentryWallet.stakedKeyCount = sentryWallet.stakedKeyCount.plus(
+      event.params.amount
+    );
+    sentryWallet.save();
+  } else {
+    log.warning(
+      "Failed to find sentryWallet on handleStakeKeys: TX: " +
+        event.transaction.hash.toHexString(),
+      []
+    );
+  }
+
+  const signature = getTxSignatureFromEvent(event);
+
+  // Check if this is triggered from the tiny keys airdrop admin stake
+  // processAirdropSegmentOnlyStake(uint256) => 0x3ada44c1
+  if (signature == "0x3ada44c1") {
+    // If the event was triggered by the airdrop admin stake, we ignore as that event is handled separately
+    return;
+  }
+
+  const nodeLicenseIds: BigInt[] = event.params.keyIds;
+
+  for (let i = 0; i < nodeLicenseIds.length; i++) {
+    const sentryKey = SentryKey.load(nodeLicenseIds[i].toString());
+    if (sentryKey) {
+      sentryKey.assignedPool = event.params.pool;
+      sentryKey.save();
+    } else {
+      log.warning(
+        "Failed to find sentryKey on handleStakeKeys: TX: " +
+          event.transaction.hash.toHexString() +
+          ", keyId: " +
+          nodeLicenseIds[i].toString(),
+        []
+      );
+    }
+  }
+
+  // Update the Users Pool Stake
+  const poolStakeId =
+    event.params.pool.toHexString() + "_" + event.params.user.toHexString();
+  const poolStake = PoolStake.load(poolStakeId);
+
+  // If the stake does not exist, create a new one
+  if (!poolStake) {
+    const poolStake = new PoolStake(poolStakeId);
+    poolStake.id = poolStakeId;
+    poolStake.pool = event.params.pool.toHexString();
+    poolStake.wallet = event.params.user.toHexString();
+    poolStake.keyStakeAmount = event.params.amount;
+    poolStake.esXaiStakeAmount = BigInt.fromI32(0);
+    poolStake.save();
+  } else {
+    // If the stake exists, update the key stake amount
+    poolStake.keyStakeAmount = poolStake.keyStakeAmount.plus(
+      event.params.amount
+    );
+    poolStake.save();
+  }
+}
+export function handleUnstakeKeysV2(event: UnstakeKeysV2): void {
+  const pool = PoolInfo.load(event.params.pool.toHexString());
+
+  if (!pool) {
+    log.warning(
+      "handleUnstakeKeys - pool is undefined " +
+        event.params.pool.toHexString() +
+        ", TX: " +
+        event.transaction.hash.toHexString(),
+      []
+    );
+    return;
+  }
+
+  if (pool.owner == event.params.user) {
+    pool.ownerStakedKeys = pool.ownerStakedKeys.minus(event.params.amount);
+    pool.ownerRequestedUnstakeKeyAmount =
+      pool.ownerRequestedUnstakeKeyAmount.minus(event.params.amount);
+  }
+
+  pool.totalStakedKeyAmount = event.params.totalKeysStaked;
+  handlePoolBreakdown(pool, event.block.timestamp);
+
+  const sentryWallet = SentryWallet.load(event.params.user.toHexString());
+  if (sentryWallet) {
+    sentryWallet.stakedKeyCount = sentryWallet.stakedKeyCount.minus(
+      event.params.amount
+    );
+    sentryWallet.save();
+  } else {
+    log.warning(
+      "Failed to find sentryWallet on handleUnstakeKeys: TX: " +
+        event.transaction.hash.toHexString(),
+      []
+    );
+  }
+
+  const nodeLicenseIds = event.params.keyIds;
+  for (let i = 0; i < nodeLicenseIds.length; i++) {
+    const sentryKey = SentryKey.load(nodeLicenseIds[i].toString());
+    if (sentryKey) {
+      sentryKey.assignedPool = new Address(0);
+      sentryKey.save();
+    } else {
+      log.warning(
+        "Failed to find sentryKey on handleUnstakeKeys: TX: " +
+          event.transaction.hash.toHexString() +
+          ", keyId: " +
+          nodeLicenseIds[i].toString(),
+        []
+      );
+    }
+  }
+
+  // Update the Users Pool Stake
+  const poolStakeId =
+    event.params.pool.toHexString() + "_" + event.params.user.toHexString();
+  const poolStake = PoolStake.load(poolStakeId);
+
+  // If the stake does not exist, log a warning
+  if (!poolStake) {
+    log.warning(
+      "Failed to find poolStake on handleUnstakeKeys: TX: " +
+        event.transaction.hash.toHexString() +
+        ", poolStakeId: " +
+        poolStakeId,
+      []
+    );
+  } else {
+    // If the stake exists, update the key stake amount
+    poolStake.keyStakeAmount = poolStake.keyStakeAmount.minus(
+      event.params.amount
+    );
+    poolStake.save();
+  }
+
+  const index = event.params.requestIndex;
+  const unstakeRequest = UnstakeRequest.load(
+    event.params.pool.toHexString() +
+      event.params.user.toHexString() +
+      index.toString()
+  );
+  if (unstakeRequest) {
+    unstakeRequest.open = false;
+    unstakeRequest.completeTime = event.block.timestamp;
+    unstakeRequest.save();
+  } else {
+    log.warning("handleUnstakeKeys - Could not find unstake key request!", []);
+    log.warning(
+      "pool: " +
+        event.params.pool.toHexString() +
+        ", user: " +
+        event.params.user.toHexString() +
+        ", index: " +
+        index.toString() +
+        ", TX: " +
+        event.transaction.hash.toHexString(),
+      []
+    );
+  }
+}
+export function handleUnstakeEsXaiV2(event: UnstakeEsXaiV2): void {
+  const pool = PoolInfo.load(event.params.pool.toHexString());
+  if (!pool) {
+    log.warning(
+      "handleUnstakeEsXai - pool is undefined " +
+        event.params.pool.toHexString() +
+        ", TX: " +
+        event.transaction.hash.toHexString(),
+      []
+    );
+    return;
+  }
+
+  pool.totalStakedEsXaiAmount = event.params.totalEsXaiStaked;
+  handlePoolBreakdown(pool, event.block.timestamp);
+
+  const sentryWallet = SentryWallet.load(event.params.user.toHexString());
+  if (sentryWallet) {
+    sentryWallet.esXaiStakeAmount = sentryWallet.esXaiStakeAmount.minus(
+      event.params.amount
+    );
+    sentryWallet.save();
+  } else {
+    log.warning(
+      "Failed to find sentryWallet on handleUnstakeEsXai: TX: " +
+        event.transaction.hash.toHexString(),
+      []
+    );
+  }
+
+  // Update the Users Pool Stake
+  const poolStakeId =
+    event.params.pool.toHexString() + "_" + event.params.user.toHexString();
+  const poolStake = PoolStake.load(poolStakeId);
+
+  // If the stake does not exist, log a warning
+  if (!poolStake) {
+    log.warning(
+      "Failed to find poolStake on handleUnstakeEsXai: TX: " +
+        event.transaction.hash.toHexString() +
+        ", poolStakeId: " +
+        poolStakeId,
+      []
+    );
+  } else {
+    // If the stake exists, update the key stake amount
+    poolStake.esXaiStakeAmount = poolStake.esXaiStakeAmount.minus(
+      event.params.amount
+    );
+    poolStake.save();
+  }
+
+  const index = event.params.requestIndex;
+  const unstakeRequest = UnstakeRequest.load(
+    event.params.pool.toHexString() +
+      event.params.user.toHexString() +
+      index.toString()
+  );
+  if (unstakeRequest) {
+    unstakeRequest.open = false;
+    unstakeRequest.completeTime = event.block.timestamp;
+    unstakeRequest.save();
+  } else {
+    log.warning("handleUnstakeEsXai - Could not find unstake key request!", []);
+    log.warning(
+      "pool: " +
+        event.params.pool.toHexString() +
+        ", user: " +
+        event.params.user.toHexString() +
+        ", index: " +
+        index.toString() +
+        ", TX: " +
+        event.transaction.hash.toHexString(),
+      []
+    );
+  }
+}
+export function handlePoolCreatedV2(event: PoolCreatedV2): void {
+  const pool = new PoolInfo(event.params.poolAddress.toHexString());
+  pool.address = event.params.poolAddress;
+  pool.owner = event.params.poolOwner;
+  pool.delegateAddress = event.params.delegateAddress;
+  pool.totalStakedEsXaiAmount = BigInt.fromI32(0);
+  pool.totalStakedKeyAmount = event.params.stakedKeyCount;
+  pool.ownerShare = event.params.shareConfig[0];
+  pool.keyBucketShare = event.params.shareConfig[1];
+  pool.stakedBucketShare = event.params.shareConfig[2];
+  pool.updateSharesTimestamp = BigInt.fromI32(0);
+  pool.pendingShares = [
+    BigInt.fromI32(0),
+    BigInt.fromI32(0),
+    BigInt.fromI32(0),
+  ];
+  pool.metadata = event.params.poolMetadata;
+  pool.socials = event.params.poolSocials;
+  pool.ownerStakedKeys = pool.totalStakedKeyAmount;
+  pool.ownerRequestedUnstakeKeyAmount = BigInt.fromI32(0);
+  pool.ownerLatestUnstakeRequestCompletionTime = BigInt.fromI32(0);
+  pool.createdTimestamp = event.block.timestamp;
+  pool.totalAccruedAssertionRewards = BigInt.fromI32(0);
+  pool.save();
+
+  const sentryWallet = SentryWallet.load(event.params.poolOwner.toHexString());
+  if (sentryWallet) {
+    sentryWallet.stakedKeyCount = sentryWallet.stakedKeyCount.plus(
+      event.params.stakedKeyCount
+    );
+    sentryWallet.save();
+  } else {
+    log.warning(
+      "Failed to find sentryWallet on poolCreate: PoolAddress: " +
+        event.params.poolAddress.toHexString() +
+        ", TX: " +
+        event.transaction.hash.toHexString(),
+      []
+    );
+  }
+
+  const nodeLicenseIds = event.params.keyIds;
+  for (let i = 0; i < nodeLicenseIds.length; i++) {
+    const sentryKey = SentryKey.load(nodeLicenseIds[i].toString());
+    if (sentryKey) {
+      sentryKey.assignedPool = event.params.poolAddress;
+      sentryKey.save();
+    } else {
+      log.warning(
+        "Failed to find sentryKey on poolCreate: PoolAddress: " +
+          event.params.poolAddress.toHexString() +
+          ", TX: " +
+          event.transaction.hash.toHexString() +
+          ", keyId: " +
+          nodeLicenseIds[i].toString(),
+        []
+      );
+    }
+  }
+}
+export function handleUpdateMetadataV2(event: UpdateMetadataV2): void {
+  const pool = PoolInfo.load(event.params.pool.toHexString());
+  if (!pool) {
+    log.warning(
+      "handleUpdateMetadata - pool is undefined " +
+        event.params.pool.toHexString() +
+        ", TX: " +
+        event.transaction.hash.toHexString(),
+      []
+    );
+    return;
+  }
+
+  pool.metadata = event.params.poolMetadata;
+  pool.socials = event.params.poolSocials;
+  pool.save();
+}
+export function handleUpdatePendingSharesV2(event: UpdateSharesV2): void {
+  const pool = PoolInfo.load(event.params.pool.toHexString());
+  if (!pool) {
+    log.warning(
+      "handleUpdatePendingShares - pool is undefined " +
+        event.params.pool.toHexString() +
+        ", TX: " +
+        event.transaction.hash.toHexString(),
+      []
+    );
+    return;
+  }
+
+  const poolConfig = PoolFactoryConfig.load("PoolFactoryConfig");
+  pool.pendingShares = event.params.shareConfig;
+  pool.updateSharesTimestamp = event.block.timestamp.plus(
+    poolConfig!.updateRewardBreakdownDelayPeriod
+  );
+  pool.save();
 }

--- a/infrastructure/sentry-subgraph/src/pool-factory.ts
+++ b/infrastructure/sentry-subgraph/src/pool-factory.ts
@@ -54,15 +54,22 @@ export function handleInitialized(event: Initialized): void {
   const poolFactory = PoolFactory.bind(event.address)
   poolConfig.version = BigInt.fromI32(event.params.version)
 
-  const unstakeKeysDelay = poolFactory.try_unstakeKeysDelayPeriod();
-  const unstakeGenesisKeyDelay = poolFactory.try_unstakeGenesisKeyDelayPeriod();
-  const unstakeEsXaiDelay = poolFactory.try_unstakeEsXaiDelayPeriod();
-  const updateRewardBreakdownDelay = poolFactory.try_updateRewardBreakdownDelayPeriod();
+  poolConfig.unstakeKeysDelayPeriod = poolFactory.unstakeKeysDelayPeriod()
+  poolConfig.unstakeGenesisKeyDelayPeriod = poolFactory.unstakeGenesisKeyDelayPeriod()
+  poolConfig.unstakeEsXaiDelayPeriod = poolFactory.unstakeEsXaiDelayPeriod()
+  poolConfig.updateRewardBreakdownDelayPeriod = poolFactory.updateRewardBreakdownDelayPeriod()
 
-  poolConfig.unstakeKeysDelayPeriod = unstakeKeysDelay.reverted ? BigInt.fromI32(0) : unstakeKeysDelay.value;
-  poolConfig.unstakeGenesisKeyDelayPeriod = unstakeGenesisKeyDelay.reverted ? BigInt.fromI32(0) : unstakeGenesisKeyDelay.value;
-  poolConfig.unstakeEsXaiDelayPeriod = unstakeEsXaiDelay.reverted ? BigInt.fromI32(0) : unstakeEsXaiDelay.value;
-  poolConfig.updateRewardBreakdownDelayPeriod = updateRewardBreakdownDelay.reverted ? BigInt.fromI32(0) : updateRewardBreakdownDelay.value;
+  // Code below was previously required due to Sepolia failing on deployment, but commenting out because mainnet deployment is working
+
+  // const unstakeKeysDelay = poolFactory.try_unstakeKeysDelayPeriod();
+  // const unstakeGenesisKeyDelay = poolFactory.try_unstakeGenesisKeyDelayPeriod();
+  // const unstakeEsXaiDelay = poolFactory.try_unstakeEsXaiDelayPeriod();
+  // const updateRewardBreakdownDelay = poolFactory.try_updateRewardBreakdownDelayPeriod();
+
+  // poolConfig.unstakeKeysDelayPeriod = unstakeKeysDelay.reverted ? BigInt.fromI32(0) : unstakeKeysDelay.value;
+  // poolConfig.unstakeGenesisKeyDelayPeriod = unstakeGenesisKeyDelay.reverted ? BigInt.fromI32(0) : unstakeGenesisKeyDelay.value;
+  // poolConfig.unstakeEsXaiDelayPeriod = unstakeEsXaiDelay.reverted ? BigInt.fromI32(0) : unstakeEsXaiDelay.value;
+  // poolConfig.updateRewardBreakdownDelayPeriod = updateRewardBreakdownDelay.reverted ? BigInt.fromI32(0) : updateRewardBreakdownDelay.value;
 
   poolConfig.save();
 }

--- a/infrastructure/sentry-subgraph/subgraph.yaml
+++ b/infrastructure/sentry-subgraph/subgraph.yaml
@@ -114,6 +114,18 @@ dataSources:
           handler: handleClaimFromPool
         - event: UpdateDelayPeriods()
           handler: handleUpdateDelayPeriods
+        - event: StakeKeysV2(indexed address,indexed address,uint256,uint256,uint256,uint256[])
+          handler: handleStakeKeysV2
+        - event: UnstakeKeysV2(indexed address,indexed address,uint256,uint256,uint256,uint256,uint256[])
+          handler: handleUnstakeKeysV2
+        - event: PoolCreatedV2(indexed uint256,indexed address,indexed address,uint256,address,uint256[],uint32[3],string[3],string[])
+          handler: handlePoolCreatedV2
+        - event: UnstakeEsXaiV2(indexed address,indexed address,uint256,uint256,uint256,uint256)
+          handler: handleUnstakeEsXaiV2
+        - event: UpdateMetadataV2(indexed address,string[3],string[])
+          handler: handleUpdateMetadataV2
+        - event: UpdateSharesV2(indexed address,uint32[3])
+          handler: handleUpdatePendingSharesV2
       file: ./src/pool-factory.ts
   - kind: ethereum
     name: Xai


### PR DESCRIPTION
[Ticket](https://app.shortcut.com/ex-populus/story/6190/update-subgraph-to-work-with-new-poolfactory2-events)

Update Subgraph handlers to work with new PoolFactory2 Events

Added new handlers for PoolFactoryV2 events.
Updated existing events to be ignored after PoolFactory2 is deployed.

Tested by deploying on [Sepolia](https://subgraphs.alchemy.com/subgraphs/6221/versions/31282) & [Mainnet](https://subgraphs.alchemy.com/subgraphs/4740/versions/31284). Seeded some new test events on Sepolia and confirmed they were handled.

