### PR TITLE
Update node license transfer handler in subgraph

### DIFF
--- a/infrastructure/sentry-subgraph/src/node-license.ts
+++ b/infrastructure/sentry-subgraph/src/node-license.ts
@@ -31,9 +31,9 @@ export function handleTransfer(event: TransferEvent): void {
       fromSentryWallet.keyCount = fromSentryWallet.keyCount.minus(BigInt.fromI32(1));
       fromSentryWallet.save();
     }
-    }else{
-      log.warning("Failed to find SentryWallet for from address: " + event.params.from.toHexString() + ", TX: " + event.transaction.hash.toHexString(), []);
-      return;
+  }else{
+    log.warning("Failed to find SentryWallet for from address: " + event.params.from.toHexString() + ", TX: " + event.transaction.hash.toHexString(), []);
+    return;
   }
 
   let sentryKey = SentryKey.load(event.params.tokenId.toString())

--- a/infrastructure/sentry-subgraph/src/node-license.ts
+++ b/infrastructure/sentry-subgraph/src/node-license.ts
@@ -23,8 +23,17 @@ export function handleTransfer(event: TransferEvent): void {
   
   sentryWallet.keyCount = sentryWallet.keyCount.plus(BigInt.fromI32(1))
   sentryWallet.save();
-
-  //TODO should keys ever be transferable we need to decrease the keyCount of the from address
+  
+  //Decrease the keyCount of the from address if not a mint event
+  if (event.params.from != Address.zero()) {
+    const fromSentryWallet = SentryWallet.load(event.params.from.toHexString());
+    if (fromSentryWallet) {
+      fromSentryWallet.keyCount = fromSentryWallet.keyCount.minus(
+        BigInt.fromI32(1)
+      );
+      fromSentryWallet.save();
+    }
+  }
 
   let sentryKey = SentryKey.load(event.params.tokenId.toString())
   if (!sentryKey) {

--- a/infrastructure/sentry-subgraph/src/node-license.ts
+++ b/infrastructure/sentry-subgraph/src/node-license.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt } from "@graphprotocol/graph-ts"
+import { Address, BigInt, log } from "@graphprotocol/graph-ts"
 import {
   Transfer as TransferEvent,
 } from "../generated/NodeLicense/NodeLicense"
@@ -28,11 +28,12 @@ export function handleTransfer(event: TransferEvent): void {
   if (event.params.from != Address.zero()) {
     const fromSentryWallet = SentryWallet.load(event.params.from.toHexString());
     if (fromSentryWallet) {
-      fromSentryWallet.keyCount = fromSentryWallet.keyCount.minus(
-        BigInt.fromI32(1)
-      );
+      fromSentryWallet.keyCount = fromSentryWallet.keyCount.minus(BigInt.fromI32(1));
       fromSentryWallet.save();
     }
+    }else{
+      log.warning("Failed to find SentryWallet for from address: " + event.params.from.toHexString() + ", TX: " + event.transaction.hash.toHexString(), []);
+      return;
   }
 
   let sentryKey = SentryKey.load(event.params.tokenId.toString())


### PR DESCRIPTION
[Ticket](https://app.shortcut.com/ex-populus/story/5648/subgraph-fix-sentrykey-sync-on-transfer-from-non-zero-address)

Updated the NodeLicense transfer handler in the subgraph to handle transfer from non-zero address.

Tested by [deploying on Sepolia](https://subgraph.satsuma-prod.com/xai/sentry-sepolia/version/1.3.2-sepolia/playground) and confirming sync. Tested by [transferring a node license](https://sepolia.arbiscan.io/tx/0x421442ed8831f975aaac7529d88040cc9c6993df00db57ce123805c8ea595399) and confirming that the subgraph updated both the wallet key count and the key owner.