### PR TITLE
Fix USDC Decimal Conversion Bug

### DIFF
--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -317,9 +317,9 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         _validateMint(_amount);
 
         //convert the final price to USDC
-        uint256 mintPriceInWei = price(_amount, _promoCode);
-        uint256 ethPriceInUSDC = uint256(ethPriceFeed.latestAnswer()) * 10**10; //convert to 18 decimals
-        uint256 mintPriceInUSDC = (mintPriceInWei * ethPriceInUSDC) / 10**18;
+        uint256 mintPriceInWei = price(_amount, _promoCode); //.15 ETH
+        uint256 ethRateInUSDC = uint256(ethPriceFeed.latestAnswer()); //8 decimals
+        uint256 mintPriceInUSDC = (mintPriceInWei * ethRateInUSDC) / (10**20); //(18 + 8) - 20 = 6 decimals
         require(mintPriceInUSDC <= _expectedCostInUSDC, "Price Exceeds Expected Cost");
 
         //mint node license tokens

--- a/infrastructure/smart-contracts/test/NodeLicense.mjs
+++ b/infrastructure/smart-contracts/test/NodeLicense.mjs
@@ -332,7 +332,7 @@ export function NodeLicenseTests(deployInfrastructure) {
 
             //mint USDC tokens to caller and approve
             const price = await nodeLicense.price(1, ""); //157945445600000000
-            const expectedPriceInUSDC = 473_836336800000000000n;
+            const expectedPriceInUSDC = 473_836336n;
             await usdcToken.mint(callerAddress, expectedPriceInUSDC);
             await usdcToken.connect(addr1).approve(await nodeLicense.getAddress(), expectedPriceInUSDC);
             
@@ -374,8 +374,8 @@ export function NodeLicenseTests(deployInfrastructure) {
 
             //mint USDC tokens to caller and approve
             const price = await nodeLicense.price(1, ""); //157945445600000000
-            const expectedPriceInUSDC = 426_452703120000000000n;
-            const expectedReferralReward = 8_529054062400000000n;
+            const expectedPriceInUSDC = 426_452703n;
+            const expectedReferralReward = 8_529054n;
             await usdcToken.mint(callerAddress, expectedPriceInUSDC);
             await usdcToken.connect(addr1).approve(await nodeLicense.getAddress(), expectedPriceInUSDC);
             
@@ -426,8 +426,8 @@ export function NodeLicenseTests(deployInfrastructure) {
 
             //mint USDC tokens to caller and approve
             const price = await nodeLicense.price(1, ""); //157945445600000000
-            const expectedPriceInUSDC = 426_452703120000000000n;
-            const expectedReferralReward = 8_529054062400000000n;
+            const expectedPriceInUSDC = 426_452703n;
+            const expectedReferralReward = 8_529054n;
             await usdcToken.mint(callerAddress, expectedPriceInUSDC);
             await usdcToken.connect(addr1).approve(await nodeLicense.getAddress(), expectedPriceInUSDC);
 


### PR DESCRIPTION
* Added a fix for usdc decimal conversion bug.
* Updated tests to reflect changes.

Tested by running `pnpm test` and observing successful USDC test results:

```
✔ Check if can mint with USDC to recipient address
✔ Check if can mint with USDC to recipient address using a valid promo code (48ms)
✔ Check if can claim USDC referral rewards (48ms)
```