### PR TITLE
 Add check for key id on sync subgraph and submit assertion

### DIFF
--- a/infrastructure/sentry-subgraph/sepolia.subgraph.yaml
+++ b/infrastructure/sentry-subgraph/sepolia.subgraph.yaml
@@ -8,9 +8,9 @@ dataSources:
     name: Referee
     network: arbitrum-sepolia
     source:
-      address: "0xF84D76755a68bE9DFdab9a0b6d934896Ceab957b"
+      address: "0x4be052206043a564206911657DeC698c6d24478C"
       abi: Referee
-      startBlock: 26974804
+      startBlock: 100245782
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -57,9 +57,9 @@ dataSources:
     name: NodeLicense
     network: arbitrum-sepolia
     source:
-      address: "0x07C05C6459B0F86A6aBB3DB71C259595d22af3C2"
+      address: "0x89F99fE730149B1f1a7cA1E24102F3f7A6E2E98D"
       abi: NodeLicense
-      startBlock: 15609970
+      startBlock: 100245782
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -77,9 +77,9 @@ dataSources:
     name: PoolFactory
     network: arbitrum-sepolia
     source:
-      address: "0x87Ae2373007C01FBCED0dCCe4a23CA3f17D1fA9A"
+      address: "0x79094A209e4c7AF288F9E4BD6fa32f7cc74740c9"
       abi: PoolFactory
-      startBlock: 26975569
+      startBlock: 100245782
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -131,9 +131,9 @@ dataSources:
     name: Xai
     network: arbitrum-sepolia
     source:
-      address: "0x724E98F16aC707130664bb00F4397406F74732D0"
+      address: "0x7C46a2f269ca1563B0Fc4a414999F31B62F9836A"
       abi: Xai
-      startBlock: 26975569
+      startBlock: 100245782
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -151,9 +151,9 @@ dataSources:
     name: Rollup
     network: arbitrum-sepolia
     source:
-      address: "0xC47DacFbAa80Bd9D8112F4e8069482c2A3221336" #TODO: change to sepolia rollup address when deployed in a later ticket
+      address: "0xcC071a98113e1968b21730Ef7d65553a10f71FdC"
       abi: Rollup
-      startBlock: 169689813 #TODO: change to deploy block number when rollup contract is deployed in a later ticket
+      startBlock: 100245782
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -167,23 +167,23 @@ dataSources:
         - event: NodeConfirmed(indexed uint64,bytes32,bytes32)
           handler: handleNodeConfirmed
       file: ./src/referee.ts
-  - kind: ethereum
-    name: TinyKeysAirdrop
-    network: arbitrum-sepolia
-    source:
-      address: "0xA65E7524b4714d1BB3208aEd9e9fC666806148a5"
-      abi: TinyKeysAirdrop
-      startBlock: 62587483
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.7
-      language: wasm/assemblyscript
-      entities:
-        - AirdropSegmentCompleteEvent
-      abis:
-        - name: TinyKeysAirdrop
-          file: ./abis/TinyKeysAirdrop.json
-      eventHandlers:
-        - event: AirdropSegmentStakeComplete(indexed address,indexed address,uint256,uint256)
-          handler: handleAirdropStakeSegmentComplete
-      file: ./src/tiny-keys-airdrop.ts
+  # - kind: ethereum
+  #   name: TinyKeysAirdrop
+  #   network: arbitrum-sepolia
+  #   source:
+  #     address: "0xA65E7524b4714d1BB3208aEd9e9fC666806148a5"
+  #     abi: TinyKeysAirdrop
+  #     startBlock: 100245782
+  #   mapping:
+  #     kind: ethereum/events
+  #     apiVersion: 0.0.7
+  #     language: wasm/assemblyscript
+  #     entities:
+  #       - AirdropSegmentCompleteEvent
+  #     abis:
+  #       - name: TinyKeysAirdrop
+  #         file: ./abis/TinyKeysAirdrop.json
+  #     eventHandlers:
+  #       - event: AirdropSegmentStakeComplete(indexed address,indexed address,uint256,uint256)
+  #         handler: handleAirdropStakeSegmentComplete
+  #     file: ./src/tiny-keys-airdrop.ts

--- a/infrastructure/sentry-subgraph/src/node-license.ts
+++ b/infrastructure/sentry-subgraph/src/node-license.ts
@@ -10,7 +10,6 @@ import {
 export function handleTransfer(event: TransferEvent): void {
   // We need to ignore keys greater than the totalSupply on deploy of the TK airdrop, so they won't get picked up by the operator
   if (event.params.tokenId.gt(BigInt.fromI32(35180))) {
-    log.warning("Skipping key with id " + event.params.tokenId.toString(), []);
     return;
   }
 

--- a/infrastructure/sentry-subgraph/src/node-license.ts
+++ b/infrastructure/sentry-subgraph/src/node-license.ts
@@ -8,6 +8,12 @@ import {
 } from "../generated/schema"
 
 export function handleTransfer(event: TransferEvent): void {
+  // We need to ignore keys greater than the totalSupply on deploy of the TK airdrop, so they won't get picked up by the operator
+  if (event.params.tokenId.gt(BigInt.fromI32(35180))) {
+    log.warning("Skipping key with id " + event.params.tokenId.toString(), []);
+    return;
+  }
+
   let sentryWallet = SentryWallet.load(event.params.to.toHexString())
   if (!sentryWallet) {
     sentryWallet = new SentryWallet(event.params.to.toHexString())
@@ -20,21 +26,9 @@ export function handleTransfer(event: TransferEvent): void {
     sentryWallet.stakedKeyCount = BigInt.fromI32(0)
     sentryWallet.totalAccruedAssertionRewards = BigInt.fromI32(0)
   }
-  
+
   sentryWallet.keyCount = sentryWallet.keyCount.plus(BigInt.fromI32(1))
   sentryWallet.save();
-  
-  //Decrease the keyCount of the from address if not a mint event
-  if (event.params.from != Address.zero()) {
-    const fromSentryWallet = SentryWallet.load(event.params.from.toHexString());
-    if (fromSentryWallet) {
-      fromSentryWallet.keyCount = fromSentryWallet.keyCount.minus(BigInt.fromI32(1));
-      fromSentryWallet.save();
-    }
-  }else{
-    log.warning("Failed to find SentryWallet for from address: " + event.params.from.toHexString() + ", TX: " + event.transaction.hash.toHexString(), []);
-    return;
-  }
 
   let sentryKey = SentryKey.load(event.params.tokenId.toString())
   if (!sentryKey) {
@@ -49,5 +43,16 @@ export function handleTransfer(event: TransferEvent): void {
     sentryKey.owner = event.params.to
     sentryKey.sentryWallet = event.params.to.toHexString()
     sentryKey.save()
+  }
+
+  //Decrease the keyCount of the from address if not a mint event
+  if (event.params.from != Address.zero()) {
+    const fromSentryWallet = SentryWallet.load(event.params.from.toHexString());
+    if (fromSentryWallet) {
+      fromSentryWallet.keyCount = fromSentryWallet.keyCount.minus(BigInt.fromI32(1));
+      fromSentryWallet.save();
+    } else {
+      log.warning("Failed to find SentryWallet for from address: " + event.params.from.toHexString() + ", TX: " + event.transaction.hash.toHexString(), []);
+    }
   }
 }

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
@@ -63,6 +63,7 @@ import "../../RefereeCalculations.sol";
 // 48: Not owner of key.
 // 49: Maximum staking amount exceeded.
 // 50: Invalid amount.
+// 51: Cannot submit for airdropped key
 
 contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
     using EnumerableSetUpgradeable for EnumerableSetUpgradeable.AddressSet;
@@ -70,6 +71,9 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
     // Define roles
     bytes32 public constant CHALLENGER_ROLE = keccak256("CHALLENGER_ROLE");
     bytes32 public constant KYC_ADMIN_ROLE = keccak256("KYC_ADMIN_ROLE");
+
+    // Used to not allow submissions for keys airdropped by the TK Airdrop
+    uint256 public constant MAX_KEY_SOLO_SUBMISSION = 35180;
 
     // The Challenger's public key of their registered BLS-Pair
     bytes public challengerPublicKey;
@@ -534,6 +538,8 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
         bytes memory _confirmData
     ) public {
 
+        require(_nodeLicenseId <= MAX_KEY_SOLO_SUBMISSION, "51");
+
         // Check the challenge is open for submissions
         require(challenges[_challengeId].openForSubmissions, "14");
         
@@ -571,7 +577,8 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
 
 		for (uint256 i = 0; i < keyLength; i++) {
             uint256 _nodeLicenseId = _nodeLicenseIds[i];
-            if (!submissions[_challengeId][_nodeLicenseId].submitted) {
+            
+            if(_nodeLicenseId <= MAX_KEY_SOLO_SUBMISSION && !submissions[_challengeId][_nodeLicenseId].submitted) {
                 
                 address licenseOwner = NodeLicense(nodeLicenseAddress).ownerOf(_nodeLicenseId);
                 address assignedPool = assignedKeyToPool[_nodeLicenseId];


### PR DESCRIPTION
[sc-6292]
[sc-6293]

Add constant to Referee.
Add check for max key id on submit assertion
Add return in subgraph ony sync Sentrywallet
Updated the sepolia subgraph config with new addresses.

Deployed to sepolia with new contract deployments from https://github.com/xai-foundation/sentry/pull/496 tagged `1.3.4-sepolia-skip-tk`

Ran test suite with Referee Upgrade, everything passed like before.