### PR TITLE
fix: configure root deployment and add Cloudflare deploy

### DIFF
--- a/.github/workflows/deploy-web-connect.yml
+++ b/.github/workflows/deploy-web-connect.yml
@@ -2,6 +2,14 @@ name: Deploy Web Connect
 
 on:
   workflow_dispatch:
+    inputs:
+      cloudflare_project:
+        description: 'Cloudflare project to deploy to'
+        required: true
+        type: choice
+        options:
+          - sentry
+          - sentry-develop
 
 jobs:
   build:
@@ -26,6 +34,13 @@ jobs:
         run: npx nx run @sentry/web-connect:build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy to Cloudflare Pages
+        run: |
+          rm apps/web-connect/dist/xai-drop-permits.JSON 
+          npx wrangler pages deploy dist --project-name=${{ github.event.inputs.cloudflare_project }} --branch=main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
         # Popular action to deploy to GitHub Pages:
         # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus

--- a/.github/workflows/deploy-web-connect.yml
+++ b/.github/workflows/deploy-web-connect.yml
@@ -30,10 +30,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build monorepo
+      - name: Build monorepo for development
+        if: ${{ github.event.inputs.cloudflare_project == 'sentry-develop' }}
         run: npx nx run @sentry/web-connect:build
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }
+          VITE_APP_ENV: development
+
+      - name: Build monorepo for production
+        if: ${{ github.event.inputs.cloudflare_project == 'sentry' }}
+        run: npx nx run @sentry/web-connect:build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }
 
       - name: Deploy to Cloudflare Pages
         run: |

--- a/apps/web-connect/vite.config.ts
+++ b/apps/web-connect/vite.config.ts
@@ -4,6 +4,7 @@ import svgr from "vite-plugin-svgr";
 import path from "node:path";
 
 export default defineConfig({
+	base: '/', // Use '/' for root deployment on Cloudflare Pages
 	resolve: {
 		alias: [
 			{


### PR DESCRIPTION
- Added `base: '/'` to `vite.config.ts` for root deployment on Cloudflare Pages.
- Added `cloudflare_project` input to workflow for specifying the Cloudflare project.
- Implemented Cloudflare Pages deployment step in the GitHub Actions workflow.
- Removed the `xai-drop-permits.JSON` file before deployment.
- Updated environment variables for Cloudflare API token usage.