### PR TITLE
Update max stake/unstake keys to 200 per txn

### DIFF
--- a/apps/web-staking/src/app/components/createPool/StakePoolKeyComponent.tsx
+++ b/apps/web-staking/src/app/components/createPool/StakePoolKeyComponent.tsx
@@ -38,7 +38,7 @@ const StakePoolKeyComponent = ({
     setInputValue(roundNum.toString());
   };
 
-  const validationInput = () => Number(inputValue) > Math.min(100, unstakedKeyCount);
+  const validationInput = () => Number(inputValue) > Math.min(200, unstakedKeyCount);
 
   const checkDisabledButton =
     !address || !inputValue || Number(inputValue) <= 0 || validationInput();
@@ -74,18 +74,18 @@ const StakePoolKeyComponent = ({
                 label="You stake"
                 onChange={handleChange}
                 currencyLabel={Number(inputValue) === 1 ? StakingInputCurrency.SENTRY_KEY : StakingInputCurrency.SENTRY_KEYS}
-                error={validationInput() ? { message: Number(inputValue) > 100 ? "Invalid amount" : "Not enough keys" } : {}}
+                error={validationInput() ? { message: Number(inputValue) > 200 ? "Invalid amount" : "Not enough keys" } : {}}
                 extraClasses={{
                   input: "sm:!max-w-[37%] !lg:max-w-[50%] placeholder:!text-foggyLondon",
                   calloutWrapper: "h-[160px]",
                   currency: "sm:text-3xl lg:text-4xl",
                   currencyWrapper: "justify-between"
                 }}
-                availableBalance={Math.min(100, unstakedKeyCount)}
-                availableCurrency={Math.min(100, unstakedKeyCount) === 1 ? "key" : "keys"}
+                availableBalance={Math.min(200, unstakedKeyCount)}
+                availableCurrency={Math.min(200, unstakedKeyCount) === 1 ? "key" : "keys"}
                 withTooltip
                 handleMaxValue={() =>
-                  setInputValue(String(Math.min(100, unstakedKeyCount)))
+                  setInputValue(String(Math.min(200, unstakedKeyCount)))
                 }
               />
               <span

--- a/apps/web-staking/src/app/components/stakeKeysComponent.tsx/StakingKeysDetailComponent.tsx
+++ b/apps/web-staking/src/app/components/stakeKeysComponent.tsx/StakingKeysDetailComponent.tsx
@@ -56,11 +56,11 @@ export default function StakingKeysDetailComponent({
         unstakeCount -= 1;
       }
     }
-    return Math.min(100, unstakeCount);
+    return Math.min(200, unstakeCount);
   }
 
   const getMaxKeysForStake = (): number => {
-    return Math.min(100, unstakedKeyCount, maxKeyPerPool - userPool.keyCount)
+    return Math.min(200, unstakedKeyCount, maxKeyPerPool - userPool.keyCount)
   }
 
   const isInvalidInput = () => {
@@ -180,7 +180,7 @@ export default function StakingKeysDetailComponent({
                     label={unstakeKey ? "You unstake" : "You stake"}
                     currencyLabel={Number(inputValue) === 1 ? StakingInputCurrency.SENTRY_KEY : StakingInputCurrency.SENTRY_KEYS}
                     onChange={handleChange}
-                    error={isInvalidInput() ? { message: Number(inputValue) > 100 ? "Invalid amount" : "Not enough keys" } : {}}
+                    error={isInvalidInput() ? { message: Number(inputValue) > 200 ? "Invalid amount" : "Not enough keys" } : {}}
                     availableCurrency={(unstakeKey ? getMaxKeysForUnstake() : getMaxKeysForStake()) === 1 ? "key" : "keys"}
                     availableBalance={unstakeKey ? getMaxKeysForUnstake() : getMaxKeysForStake()}
                     handleMaxValue={() =>


### PR DESCRIPTION
Update staking app input validation from max 100 to max 200.

Tested locally by confirming U/I validation and by completing a [stake tx with 200 keys](https://sepolia.arbiscan.io/tx/0xadf97dc6f424e7ab8f4e79780ec4bf568f504fcb4e577f19a436a796678b0b99). 