### PR TITLE
Fix Staking App Max Keys per tx Copy

### DIFF
--- a/apps/web-staking/src/app/components/createPool/StakePoolKeyComponent.tsx
+++ b/apps/web-staking/src/app/components/createPool/StakePoolKeyComponent.tsx
@@ -74,7 +74,7 @@ const StakePoolKeyComponent = ({
                 label="You stake"
                 onChange={handleChange}
                 currencyLabel={Number(inputValue) === 1 ? StakingInputCurrency.SENTRY_KEY : StakingInputCurrency.SENTRY_KEYS}
-                error={validationInput() ? { message: Number(inputValue) > 200 ? "Invalid amount" : "Not enough keys" } : {}}
+                error={validationInput() ? { message: Number(inputValue) > 200 ? "Max 200 Keys per tx" : "Not enough keys" } : {}}
                 extraClasses={{
                   input: "sm:!max-w-[37%] !lg:max-w-[50%] placeholder:!text-foggyLondon",
                   calloutWrapper: "h-[160px]",

--- a/apps/web-staking/src/app/components/stakeKeysComponent.tsx/StakingKeysDetailComponent.tsx
+++ b/apps/web-staking/src/app/components/stakeKeysComponent.tsx/StakingKeysDetailComponent.tsx
@@ -180,7 +180,7 @@ export default function StakingKeysDetailComponent({
                     label={unstakeKey ? "You unstake" : "You stake"}
                     currencyLabel={Number(inputValue) === 1 ? StakingInputCurrency.SENTRY_KEY : StakingInputCurrency.SENTRY_KEYS}
                     onChange={handleChange}
-                    error={isInvalidInput() ? { message: Number(inputValue) > 200 ? "Invalid amount" : "Not enough keys" } : {}}
+                    error={isInvalidInput() ? { message: Number(inputValue) > 200 ? "Max 200 Keys per tx" : "Not enough keys" } : {}}
                     availableCurrency={(unstakeKey ? getMaxKeysForUnstake() : getMaxKeysForStake()) === 1 ? "key" : "keys"}
                     availableBalance={unstakeKey ? getMaxKeysForUnstake() : getMaxKeysForStake()}
                     handleMaxValue={() =>


### PR DESCRIPTION
Fix incorrect max staked keys copy.

Tested locally by starting app, confirming copy and performing an [unstake](https://sepolia.arbiscan.io/tx/0x0b32849b10b5bf3e48d1e5e5e61e30433ec112b2710e058b9f604cd45f5308df).