### PR TITLE
Default Key Quantity

### DIFF
--- a/apps/sentry-client-desktop/src/features/keys/modals/buy-keys/BuyKeysFlow.tsx
+++ b/apps/sentry-client-desktop/src/features/keys/modals/buy-keys/BuyKeysFlow.tsx
@@ -5,7 +5,7 @@ import {BuyFlowBanner} from "@/features/keys/modals/buy-keys/BuyFlowBanner";
 import { RedSentryIcon } from "@sentry/ui/src/rebrand/icons/IconsComponents";
 
 export function BuyKeysFlow() {
-	const [displayQuantity, setDisplayQuantity] = useState<number>(1);
+	const [displayQuantity, setDisplayQuantity] = useState<number>(10);
 	const [queryQuantity, setQueryQuantity] = useState<number>(displayQuantity);
 	const [promoCode, setPromoCode] = useState<string>("");
 

--- a/apps/web-connect/src/features/checkout/CheckoutWrapper.tsx
+++ b/apps/web-connect/src/features/checkout/CheckoutWrapper.tsx
@@ -4,7 +4,7 @@ import { Checkout } from './Checkout';
 export function CheckoutWrapper() {
     const queryString = window.location.search;
     const queryParams = new URLSearchParams(queryString);
-    const prefilledAmount = queryParams.get("quantity") ? parseInt(queryParams.get("quantity") as string) : 1;
+    const prefilledAmount = queryParams.get("quantity") ? parseInt(queryParams.get("quantity") as string) : 10;
 
     return (
         <WebBuyKeysProvider initialQuantity={prefilledAmount}>


### PR DESCRIPTION
[Ticket](https://app.shortcut.com/ex-populus/story/5713/set-default-quantity-to-10)

Updated default purchase quantity of keys from 1 to 10.

Tested with default quantity on Arbitrum Sepolia [Tx Hash](https://sepolia.arbiscan.io/tx/0xbb90b526bd7bc5aba4eff1b1b9d1ebcdb812c296325ef99d351859f5ff10ee01)