### PR TITLE
Update copy on sentry page

### DIFF
--- a/apps/web-connect/src/features/checkout/components/ActionSection.tsx
+++ b/apps/web-connect/src/features/checkout/components/ActionSection.tsx
@@ -11,7 +11,7 @@ import { useNetworkConfig } from '@/hooks/useNetworkConfig';
 /**
  * ActionSection Component
  * 
- * This component renders the main action button for buying Sentry Node Keys
+ * This component renders the main action button for buying Sentry Keys
  * and displays relevant error messages. It uses the WebBuyKeysContext to
  * access shared state and functions.
  * 

--- a/apps/web-connect/src/features/checkout/components/AgreementCheckboxes.tsx
+++ b/apps/web-connect/src/features/checkout/components/AgreementCheckboxes.tsx
@@ -7,7 +7,7 @@ import { useWebBuyKeysContext } from '../contexts/useWebBuyKeysContext';
  * AgreementCheckboxes Component
  * 
  * This component renders a set of three checkboxes for user agreements
- * related to Sentry Node Keys. It uses the WebBuyKeysContext to manage
+ * related to Sentry Keys. It uses the WebBuyKeysContext to manage
  * the state of the checkboxes.
  * 
  * @returns {JSX.Element} The rendered AgreementCheckboxes component
@@ -53,7 +53,7 @@ export function AgreementCheckboxes(): JSX.Element {
                 >
                     <div className="sm:w-[300px] md:w-auto">
                         <span className="sm:text-base text-elementalGrey">
-                            I understand Sentry Node Keys are not transferable
+                            I understand Sentry Keys are not transferable
                         </span>
                     </div>
                 </MainCheckbox>

--- a/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
+++ b/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
@@ -6,7 +6,7 @@ import BaseCallout from "@sentry/ui/src/rebrand/callout/BaseCallout";
 /**
  * ChooseQuantityRow Component
  * 
- * This component renders the section for choosing the quantity of XAI Sentry Node Keys to purchase.
+ * This component renders the section for choosing the quantity of XAI Sentry Keys to purchase.
  * It displays information about the keys and provides an input for selecting the quantity.
  * 
  * @returns {JSX.Element} The rendered ChooseQuantityRow component
@@ -35,7 +35,7 @@ export function ChooseQuantityRow(): JSX.Element {
                 <div className="flex flex-row sm:w-full sm:justify-center lg:justify-start items-center gap-1">
                     <RedSentryIcon width={32} height={32} />
                     <p className="sm:text-2xl lg:text-3xl text-white font-bold">
-                        XAI SENTRY NODE KEY
+                        XAI SENTRY KEY
                     </p>
                     {/* Tooltip for additional information */}
                     <span className="h-full flex items-center ml-2">
@@ -48,9 +48,9 @@ export function ChooseQuantityRow(): JSX.Element {
                         </Tooltip>
                     </span>
                 </div>
-                {/* Description of Sentry Node Key functionality */}
+                {/* Description of Sentry Key functionality */}
                 <p className="sm:w-full lg:w-[400px] sm:text-center sm:px-8 lg:px-0 lg:text-left text-[18px] text-elementalGrey font-medium">
-                    Each Sentry Node Key enables you to submit up to 1 reward claim for each network challenge.
+                    Each Sentry Key enables you to submit up to 1 reward claim for each network challenge.
                 </p>     
             </div>
             {/* Quantity input section */}

--- a/apps/web-connect/src/features/checkout/components/PricePerKeyRow.tsx
+++ b/apps/web-connect/src/features/checkout/components/PricePerKeyRow.tsx
@@ -4,7 +4,7 @@ import { useWebBuyKeysContext } from '../contexts/useWebBuyKeysContext';
 /**
  * PricePerKeyRow Component
  * 
- * This component renders pricing information for Xai Sentry Node Keys.
+ * This component renders pricing information for Xai Sentry Keys.
  * It displays the quantity, total price, and price per key for each pricing tier.
  * It uses the WebBuyKeysContext to access shared state and functions.
  * 
@@ -33,7 +33,7 @@ export function PricePerKeyRow(): JSX.Element | null {
                         <div className="flex sm:flex-col lg:flex-row items-center justify-between text-xl">
                             {/* Quantity display */}
                             <div className="flex flex-row items-center gap-2 text-elementalGrey font-semibold">
-                                <span className="">{item.quantity.toString()} x Xai Sentry Node Key</span>
+                                <span className="">{item.quantity.toString()} x Xai Sentry Key</span>
                             </div>
                             {/* Price per key (mobile view) */}
                             <p className="text-base text-elementalGrey mb-4 sm:block lg:hidden">

--- a/apps/web-connect/src/features/checkout/components/PromoCodeRow.tsx
+++ b/apps/web-connect/src/features/checkout/components/PromoCodeRow.tsx
@@ -61,7 +61,7 @@ export function PromoCodeRow() {
                         <p className="text-lg text-bananaBoat">Your transaction may be reverted</p>
                     </div>
                     <p className="text-sm text-bananaBoat">
-                        Xai Sentry Node Key prices vary depending on the quantity of remaining supply. In general, as the quantity of available keys decreases, the price of a key will increase. If you purchase more Keys than are available in the current pricing tier, the transaction may revert. We recommend splitting the purchase into two transactions - one for the current pricing tier and another in the next pricing tier.
+                        Xai Sentry Key prices vary depending on the quantity of remaining supply. In general, as the quantity of available keys decreases, the price of a key will increase. If you purchase more Keys than are available in the current pricing tier, the transaction may revert. We recommend splitting the purchase into two transactions - one for the current pricing tier and another in the next pricing tier.
                     </p>
                 </div>
             )}

--- a/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
+++ b/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
@@ -73,7 +73,7 @@ const PurchaseSuccessful: React.FC<IPurchaseSuccessful> = ({ returnToClient }) =
 				<FaCircleCheck color={"#16A34A"} size={64} />
 				<span
 					className="text-3xl text-white text-center uppercase font-bold mt-2">Purchase successful</span>
-				<span className="block text-foggyLondon font-bold text-base max-w-[260px] text-center my-[10px]">You have successfully purchased a Xai Sentry Node Key</span>
+				<span className="block text-foggyLondon font-bold text-base max-w-[260px] text-center my-[10px]">You have successfully purchased a Xai Sentry Key</span>
 				<div className="bg-optophobia w-full ">
 					<div className="flex justify-between border-t border-chromaphobicBlack px-[20px] py-[15px]">
 						<span className="text-[18px] sm:text-center text-elementalGrey ">Transaction ID:</span>
@@ -106,7 +106,7 @@ const PurchaseSuccessful: React.FC<IPurchaseSuccessful> = ({ returnToClient }) =
 									{canShare ? <div className="mr-3 cursor-pointer absolute right-[10px] sx:top-[73px] sm:top-[96px] z-60">
 										<ShareButton
 										buttonText={"Mint a key on the Xai to stake and start earning rewards and qualify for airdrops."}
-										buttonTitle={"5% Off Sentry Node Key Purchase"}
+										buttonTitle={"5% Off Sentry Key Purchase"}
 										shareUrl={`${salePageBaseURL}?promoCode=${address}`}
 										shareButtonClasses={"w-full"}
 									/></div> : 

--- a/apps/web-connect/src/features/checkout/components/TotalCostRow.tsx
+++ b/apps/web-connect/src/features/checkout/components/TotalCostRow.tsx
@@ -6,7 +6,7 @@ import { CURRENCIES } from "@/features/hooks";
 /**
  * TotalCostRow Component
  *
- * This component displays the total cost and available balance for purchasing Xai Sentry Node Keys.
+ * This component displays the total cost and available balance for purchasing Xai Sentry Keys.
  * It uses the WebBuyKeysContext to access shared state and functions.
  *
  * @returns {JSX.Element} The rendered TotalCostRow component

--- a/apps/web-connect/src/features/wallet/routes/DropClaim.tsx
+++ b/apps/web-connect/src/features/wallet/routes/DropClaim.tsx
@@ -128,7 +128,7 @@ export function DropClaim() {
 																onClick={() => setCheckboxTwo(!checkboxTwo)}
 																condition={checkboxTwo}
 															>
-																I understand Sentry Node Keys are not transferable
+																I understand Sentry Keys are not transferable
 															</XaiCheckbox>
 
 															<XaiCheckbox

--- a/apps/web-connect/src/features/wallet/routes/RedEnvelope2024.tsx
+++ b/apps/web-connect/src/features/wallet/routes/RedEnvelope2024.tsx
@@ -209,7 +209,7 @@ export function RedEnvelope2024() {
 										<div className="mt-6 mb-6">
 											<a
 												className="twitter-share-button"
-												href="https://twitter.com/intent/tweet?text=Xai is a modular execution layer for game logic built on the Arbitrum Orbit stack to facilitate the onboarding of millions of gamers. And now they’re airdropping $XAI to Sentry Node Key holders to celebrate the Year of the Dragon. 🐉🧧"
+												href="https://twitter.com/intent/tweet?text=Xai is a modular execution layer for game logic built on the Arbitrum Orbit stack to facilitate the onboarding of millions of gamers. And now they’re airdropping $XAI to Sentry Key holders to celebrate the Year of the Dragon. 🐉🧧"
 												target="_blank"
 												rel="noopener noreferrer"
 												data-size="large"

--- a/apps/web-connect/src/main.tsx
+++ b/apps/web-connect/src/main.tsx
@@ -23,14 +23,14 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       <QueryClientProvider client={queryClient}>
         <Helmet>
           <meta name="title" property="og:title" content="Xai Sentry Node" />
-          <meta name="description" property="og:description" content="Xai Sentry Node Key Sale Page" />
+          <meta name="description" property="og:description" content="Xai Sentry Key Sale Page" />
           <meta name="image" property="og:image" content={xaiThumbnail} />
           <meta name="url" property="og:url" content="https://sentry.xai.games" />
           <meta name="type" property="og:type" content="website" />
           <meta name="twitter:card" content="summary_large_image" />
           <meta name="twitter:site" content="https://sentry.xai.games" />
           <meta name="twitter:title" content="Xai Sentry Node" />
-          <meta name="twitter:description" content="Xai Sentry Node Key Sale Page" />
+          <meta name="twitter:description" content="Xai Sentry Key Sale Page" />
           <meta name="twitter:image" content={xaiThumbnail} />
           <meta name="twitter:creator" content="@xai_games" />
           <base href={window.location.origin} />


### PR DESCRIPTION
Updated copy on sentry page to say Sentry Key instead of Sentry Node Key.

Tested locally by starting app and viewing new copy.