### PR TITLE
Fix Broken links on Key sale and Staking pages

### DIFF
--- a/apps/web-connect/src/features/checkout/components/AgreementCheckboxes.tsx
+++ b/apps/web-connect/src/features/checkout/components/AgreementCheckboxes.tsx
@@ -38,7 +38,7 @@ export function AgreementCheckboxes(): JSX.Element {
                         <span className="sm:text-base text-elementalGrey sm:mr-2">I agree with the</span>
                         <a
                             className="cursor-pointer text-[#F30919] text-base"
-                            onClick={() => window.open("https://xai.games/sentrynodeagreement/")}
+                            onClick={() => window.open("https://xai.games/sentry-node-agreement/")}
                         >
                             Sentry Node Agreement
                         </a>

--- a/apps/web-connect/src/features/footer/ReactCookieConsent.tsx
+++ b/apps/web-connect/src/features/footer/ReactCookieConsent.tsx
@@ -16,7 +16,7 @@ export function ReactCookieConsent({ }) {
 		>
 			<div className="cookie-consent flex items-center justify-start text-white/[0.9] md:text-lg sm:text-sm opacity-70 !m-0">
 				<div className="min-w-[30px] mr-2"><WarningIcon fill="#FF0030" width={30} height={25}/></div>
-				<div className="sm:mb-4 md:mb-0 lg:mb-0">This website uses cookies to enhance the user experience. By staying on this website you agree to our <a target="_blank" className="mx-1 hover:text-white duration-200 ease-in font-bold" href="https://xai.games/generalterms">Terms of Agreement</a> and <a target="_blank" className="ml-1 hover:text-white duration-200 ease-in font-bold" href="https://xai.games/privacypolicy">Privacy Policy</a></div>
+				<div className="sm:mb-4 md:mb-0 lg:mb-0">This website uses cookies to enhance the user experience. By staying on this website you agree to our <a target="_blank" className="mx-1 hover:text-white duration-200 ease-in font-bold" href="https://xai.games/generalterms">Terms of Agreement</a> and <a target="_blank" className="ml-1 hover:text-white duration-200 ease-in font-bold" href="https://xai.games/privacy-policy">Privacy Policy</a></div>
 			</div>
 		</CookieConsent>
 	);

--- a/apps/web-connect/src/features/wallet/routes/DropClaim.tsx
+++ b/apps/web-connect/src/features/wallet/routes/DropClaim.tsx
@@ -118,7 +118,7 @@ export function DropClaim() {
 																I agree with the
 																<a
 																	className="cursor-pointer text-[#F30919]"
-																	onClick={() => window.open("https://xai.games/sentrynodeagreement/")}>
+																	onClick={() => window.open("https://xai.games/sentry-node-agreement/")}>
 																	Sentry Node Agreement
 																</a>
 															</XaiCheckbox>

--- a/apps/web-staking/src/app/components/ReactCookieConsent.tsx
+++ b/apps/web-staking/src/app/components/ReactCookieConsent.tsx
@@ -18,7 +18,7 @@ export function ReactCookieConsent({ }) {
 		>
 			<div className="cookie-consent flex items-center justify-start text-white/[0.9] md:text-lg sm:text-sm opacity-70 !m-0">
 				<div className="min-w-[30px] mr-2"><WarningIcon fill="#FF0030" width={30} height={25}/></div>
-				<div className="sm:mb-4 md:mb-0 lg:mb-0">This website uses cookies to enhance the user experience. By staying on this website you agree to our <a target="_blank" className="mx-1 hover:text-white duration-200 ease-in font-bold" href="https://xai.games/generalterms">Terms of Agreement</a> and <a target="_blank" className="ml-1 hover:text-white duration-200 ease-in font-bold" href="https://xai.games/privacypolicy">Privacy Policy</a></div>
+				<div className="sm:mb-4 md:mb-0 lg:mb-0">This website uses cookies to enhance the user experience. By staying on this website you agree to our <a target="_blank" className="mx-1 hover:text-white duration-200 ease-in font-bold" href="https://xai.games/generalterms">Terms of Agreement</a> and <a target="_blank" className="ml-1 hover:text-white duration-200 ease-in font-bold" href="https://xai.games/privacy-policy">Privacy Policy</a></div>
 			</div>
 		</CookieConsent>
 	);

--- a/apps/web-staking/src/app/components/modal/AgreeModalComponents.tsx
+++ b/apps/web-staking/src/app/components/modal/AgreeModalComponents.tsx
@@ -47,7 +47,7 @@ const AgreeModalComponent = ({ address }: { address: string | undefined }) => {
             />
             {" and "}
             <ExternalLinkComponent
-              link={"https://xai.games/privacypolicy"}
+              link={"https://xai.games/privacy-policy"}
               content={"Privacy Policy"}
               customClass="!text-base"
             />
@@ -72,7 +72,7 @@ const AgreeModalComponent = ({ address }: { address: string | undefined }) => {
                  {" and "}
                  <ExternalLinkComponent
                    externalTab
-                   link={"https://xai.games/privacypolicy"}
+                   link={"https://xai.games/privacy-policy"}
                    content={"Privacy Policy"}
                    customClass="!text-base"
                  />


### PR DESCRIPTION
Updated the broken Sentry node agreement and privacy policy links on the key sale and staking app. 

Tested locally by starting and confirming broken links now work.