### PR TITLE
Link to correct environment for referral link

### DIFF
--- a/apps/web-connect/src/features/checkout/Checkout.tsx
+++ b/apps/web-connect/src/features/checkout/Checkout.tsx
@@ -11,8 +11,9 @@ import { ActionSection } from "./components/ActionSection";
 import { BiLoaderAlt } from "react-icons/bi";
 import PurchaseSuccessful from "./components/PurchaseSuccessful";
 import { useWebBuyKeysContext } from './contexts/useWebBuyKeysContext';
+const { VITE_APP_ENV } = import.meta.env
 
-export const stakingPageURL = "https://app.xai.games/staking?modal=true&page=1&showKeys=true&hideFull=true&sort=tierIndex&sortOrder=-1";
+export const stakingPageURL = `https://${VITE_APP_ENV === "development" ? "develop." : ""}app.xai.games/staking?modal=true&page=1&showKeys=true&hideFull=true&sort=tierIndex&sortOrder=-1`;
 
 const LoadingState = () => (
     <div className="w-full h-[365px] flex flex-col justify-center items-center gap-2">

--- a/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
+++ b/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import BackArrow from "@sentry/ui/src/rebrand/icons/BackArrow";
 import { stakingPageURL } from "../Checkout";
 import ShareButton from "@sentry/ui/src/rebrand/buttons/ShareButton";
+const { VITE_APP_ENV } = import.meta.env
 
 let timeoutId: number;
 
@@ -16,7 +17,7 @@ interface IPurchaseSuccessful {
 	returnToClient: (hash: string) => void;
 }
 
-const salePageBaseURL = "https://sentry.xai.games";
+const salePageBaseURL = `https://${VITE_APP_ENV === "development" ? "develop." : ""}sentry.xai.games`;
 const operatorDownloadLink = "https://github.com/xai-foundation/sentry/releases/latest"
 
 const PurchaseSuccessful: React.FC<IPurchaseSuccessful> = ({ returnToClient }) => {


### PR DESCRIPTION
Will link to the correct environment domain on purchase success.

Tested locally with `pnpm preview-web` with VITE_APP_ENV=develop in the local .env