### PR TITLE
Add Checkout with USDC to Key sale page

### DIFF
--- a/apps/web-connect/src/features/checkout/Checkout.tsx
+++ b/apps/web-connect/src/features/checkout/Checkout.tsx
@@ -35,8 +35,8 @@ export function Checkout() {
         handleApplyPromoCode,
         mintWithEth,
         mintWithXai,
+        mintWithUsdc,
         approve,
-        mintWithCrossmint
     } = useWebBuyKeysContext();
 
     useEffect(() => {
@@ -51,18 +51,18 @@ export function Checkout() {
     }
 
     useEffect(() => {
-        if (!stakingTabOpened && (mintWithEth.isSuccess || mintWithXai.isSuccess || mintWithCrossmint.txHash != "")) {
+        if (!stakingTabOpened && (mintWithEth.isSuccess || mintWithXai.isSuccess  || mintWithUsdc.isSuccess)) {
             setStakingTabOpened(true);
             window.open(stakingPageURL, '_blank');
         }
-    }, [mintWithEth.isSuccess, mintWithXai.isSuccess, mintWithCrossmint.txHash]);
+    }, [mintWithEth.isSuccess, mintWithXai.isSuccess, mintWithUsdc.isSuccess]);
 
     return (
         <div>
             <div className="h-full xl:min-h-screen flex-1 flex flex-col justify-center items-center">
-                {mintWithEth.isPending || mintWithXai.isPending || approve.isPending || mintWithCrossmint.isPending ? (
+                {mintWithEth.isPending || mintWithXai.isPending || approve.isPending || mintWithUsdc.isPending ? (
                     <TransactionInProgress />
-                ) : mintWithEth.isSuccess || mintWithXai.isSuccess || mintWithCrossmint.txHash != "" ? (
+                ) : mintWithEth.isSuccess || mintWithXai.isSuccess || mintWithUsdc.isSuccess ? (
                     <PurchaseSuccessful returnToClient={returnToClient} />
                 ) : (
                     <div className="h-auto sm:w-[90%] lg:w-auto flex sm:flex-col lg:flex-row justify-center bg-darkLicorice shadow-main md:my-0 my-[24px]">

--- a/apps/web-connect/src/features/checkout/components/ActionSection.tsx
+++ b/apps/web-connect/src/features/checkout/components/ActionSection.tsx
@@ -141,7 +141,7 @@ export function ActionSection(): JSX.Element {
                     </div>
                 )}
 
-                {/* Error section for Xai/esXai transactions */}
+                {/* Error section for USDC transactions */}
                 {mintWithUsdc.error && (
                     <div>
                         {mapWeb3Error(mintWithUsdc.error) === "User rejected the request" && (

--- a/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
+++ b/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
@@ -20,7 +20,7 @@ const salePageBaseURL = "https://sentry.xai.games";
 const operatorDownloadLink = "https://github.com/xai-foundation/sentry/releases/latest"
 
 const PurchaseSuccessful: React.FC<IPurchaseSuccessful> = ({ returnToClient }) => {
-	const { mintWithEth, mintWithXai, mintWithCrossmint, blockExplorer } = useWebBuyKeysContext();
+	const { mintWithEth, mintWithXai, mintWithUsdc, blockExplorer } = useWebBuyKeysContext();
 
 	const { address } = useAccount();
 	const [isTooltipAllowedToOpen, setIsTooltipAllowedToOpen] = useState(false);
@@ -31,7 +31,7 @@ const PurchaseSuccessful: React.FC<IPurchaseSuccessful> = ({ returnToClient }) =
 	}, []);
 
 	const getHash = () => {
-		const hash = mintWithEth.data ?? mintWithXai.data ?? mintWithCrossmint.txHash;
+		const hash = mintWithEth.data ?? mintWithXai.data ?? mintWithUsdc.data;
 		if (!hash) {
 			throw new Error("No hash found");
 		}

--- a/apps/web-connect/src/features/hooks/currency/useCurrencyHandler.ts
+++ b/apps/web-connect/src/features/hooks/currency/useCurrencyHandler.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { getEsXaiAllowance, getXaiAllowance, config } from "@sentry/core";
+import { getEsXaiAllowance, getXaiAllowance, config, getUsdcAllowance } from "@sentry/core";
 import { CURRENCIES, Currency } from '..';
 
 // Define TypeScript types for better type safety
@@ -28,9 +28,20 @@ export function useCurrencyHandler(currency: Currency, address: string | undefin
       if (currency === CURRENCIES.AETH) {
         setTokenAllowance(0n);
       } else {
-        const allowance: AllowanceResponse = currency === CURRENCIES.XAI
-          ? await getXaiAllowance(address, config.nodeLicenseAddress)
-          : await getEsXaiAllowance(address, config.nodeLicenseAddress);
+        let allowance: AllowanceResponse;
+        switch(currency) {
+          case CURRENCIES.XAI:
+            allowance = await getXaiAllowance(address, config.nodeLicenseAddress);
+            break;
+          case CURRENCIES.ES_XAI:
+            allowance = await getEsXaiAllowance(address, config.nodeLicenseAddress);
+            break;
+          case CURRENCIES.USDC:
+                allowance = {approvalAmount: (await getUsdcAllowance(address, config.nodeLicenseAddress)).approvalAmount * 10n ** 12n}; // Scale USDC allowance to 18 decimals
+            break;
+          default:
+            allowance = {approvalAmount: 0n};
+        }
         setTokenAllowance(allowance.approvalAmount);
       }
     } catch (error) {

--- a/apps/web-connect/src/features/hooks/exchange-rate/useGetExchangeRate.ts
+++ b/apps/web-connect/src/features/hooks/exchange-rate/useGetExchangeRate.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "react-query";
-import { getEthXaiExchangeRate } from "@sentry/core";
+import { getEthUsdcExchangeRate, getEthXaiExchangeRate } from "@sentry/core";
+import { Currency } from "../shared";
 
 // Define TypeScript type for better type safety
 interface ExchangeRate {
@@ -11,13 +12,18 @@ interface ExchangeRate {
  * Uses react-query for data fetching and caching.
  * @returns An object containing the exchange rate data and query status.
  */
-export function useGetExchangeRate() {
+export function useGetExchangeRate(currency: Currency) {
   return useQuery<ExchangeRate, Error>({
-    queryKey: ["eth-xai-exchange-rate"],
+    queryKey: ["get-exchange-rate", currency], // Include currency in the queryKey
     queryFn: async () => {
       try {
-        const data = await getEthXaiExchangeRate();
-        return { exchangeRate: data.exchangeRate };
+        if (currency === 'XAI' || currency === 'ESXAI') {
+          return await getEthXaiExchangeRate();
+        }
+        if (currency === 'USDC') {
+          return await getEthUsdcExchangeRate();
+        }
+        return { exchangeRate: 0n };
       } catch (error) {
         console.error('Failed to fetch exchange rate:', error);
         throw new Error('Failed to fetch exchange rate');

--- a/apps/web-connect/src/features/hooks/shared/shared.ts
+++ b/apps/web-connect/src/features/hooks/shared/shared.ts
@@ -14,11 +14,20 @@ export const getTokenAddress = (currency: string): string => {
   }
 
   // Check if config is properly set up
-  if (!config.xaiAddress || !config.esXaiAddress) {
+  if (!config.xaiAddress || !config.esXaiAddress || !config.usdcContractAddress) {
     throw new Error("Configuration error: Token addresses not found in config.");
   }
 
-  return currency === CURRENCIES.XAI ? config.xaiAddress : config.esXaiAddress;
+  switch (currency) {
+    case CURRENCIES.XAI:
+      return config.xaiAddress;
+    case CURRENCIES.ES_XAI:
+      return config.esXaiAddress;
+    case CURRENCIES.USDC:
+      return config.usdcContractAddress;
+    default:
+      return "";
+  }
 };
 
 // Define supported currencies as constants
@@ -26,6 +35,7 @@ export const CURRENCIES = {
   AETH: "AETH",
   XAI: "XAI",
   ES_XAI: "ESXAI",
+  USDC: "USDC",
 } as const;
 
 // Define a type for supported currencies

--- a/apps/web-connect/src/features/hooks/user/useUserBalances.ts
+++ b/apps/web-connect/src/features/hooks/user/useUserBalances.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useAccount } from 'wagmi';
-import { getEsXaiBalance, getXaiBalance, getWalletBalance } from "@sentry/core";
+import { getEsXaiBalance, getXaiBalance, getWalletBalance, getUsdcBalance } from "@sentry/core";
 import { CURRENCIES, Currency } from '..';
 
 /**
@@ -33,6 +33,11 @@ export function useUserBalances(currency: Currency) {
         case CURRENCIES.ES_XAI:
           tokenBalance = (await getEsXaiBalance(address)).balance;
           break;
+        case CURRENCIES.USDC:
+          tokenBalance = (await getUsdcBalance(address)).balance * 10n ** 12n; // Scale USDC balance to 18 decimals
+          break;
+        default:
+          tokenBalance = 0n;  
       }
       setTokenBalance(tokenBalance);
     } catch (error) {

--- a/apps/web-connect/src/features/hooks/web-buy-keys/useWebBuyKeysOrderTotal.ts
+++ b/apps/web-connect/src/features/hooks/web-buy-keys/useWebBuyKeysOrderTotal.ts
@@ -79,9 +79,7 @@ export interface UseWebBuyKeysOrderTotalReturn extends UseContractWritesReturn {
 export function useWebBuyKeysOrderTotal(initialQuantity: number): UseWebBuyKeysOrderTotalReturn {
 
     const [crossmintOpen, setCrossmintOpen] = useState(false);
-    const [currency, setCurrency] = useState<Currency>(CURRENCIES.AETH);
     const { isLoading: isTotalLoading, data: getTotalData } = useGetTotalSupplyAndCap();
-    const { data: exchangeRateData, isLoading: isExchangeRateLoading } = useGetExchangeRate(currency);
     const { chainId, isConnected, address, isDevelopment } = useNetworkConfig();
 
     const { data: providerData } = useProvider();
@@ -95,10 +93,12 @@ export function useWebBuyKeysOrderTotal(initialQuantity: number): UseWebBuyKeysO
         two: false,
         three: false,
     });
+    const [currency, setCurrency] = useState<Currency>(CURRENCIES.AETH);
     const [quantity, setQuantity] = useState<number>(initialQuantity);
     const { tokenBalance, ethBalance } = useUserBalances(currency);
     const { tokenAllowance, refetchAllowance } = useCurrencyHandler(currency, address);
     const { promoCode, setPromoCode, discount, setDiscount, handleApplyPromoCode, isLoading: isPromoLoading } = usePromoCodeHandler(address);
+    const { data: exchangeRateData, isLoading: isExchangeRateLoading } = useGetExchangeRate(currency);
 
     const ready = checkboxes.one && checkboxes.two && checkboxes.three;
 

--- a/packages/core/src/abis/NodeLicenseAbi.ts
+++ b/packages/core/src/abis/NodeLicenseAbi.ts
@@ -1,1387 +1,990 @@
 export const NodeLicenseAbi = [
+  { inputs: [], name: "ClaimingPaused", type: "error" },
+  { inputs: [], name: "ExceedsMaxSupply", type: "error" },
+  { inputs: [], name: "InvalidAddress", type: "error" },
+  { inputs: [], name: "InvalidAmount", type: "error" },
+  { inputs: [], name: "MintingPaused", type: "error" },
+  { inputs: [], name: "MissingTokenIds", type: "error" },
+  { inputs: [], name: "TxIdPrevUsed", type: "error" },
   {
-      "anonymous": false,
-      "inputs": [
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "admin",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "receiver",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "AdminMintTo",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "admin",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "receiver",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "transferId",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "uint256[]",
+        name: "tokenIds",
+        type: "uint256[]",
+      },
+    ],
+    name: "AdminTransferBatch",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "owner",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "approved",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+    ],
+    name: "Approval",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "owner",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "operator",
+        type: "address",
+      },
+      { indexed: false, internalType: "bool", name: "approved", type: "bool" },
+    ],
+    name: "ApprovalForAll",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "admin",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "newClaimableState",
+        type: "bool",
+      },
+    ],
+    name: "ClaimableChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "admin",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "newFundsReceiver",
+        type: "address",
+      },
+    ],
+    name: "FundsReceiverChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: false, internalType: "uint8", name: "version", type: "uint8" },
+    ],
+    name: "Initialized",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "index",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "price",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "quantity",
+        type: "uint256",
+      },
+    ],
+    name: "PricingTierSetOrAdded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "string",
+        name: "promoCode",
+        type: "string",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+    ],
+    name: "PromoCodeCreated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "string",
+        name: "promoCode",
+        type: "string",
+      },
+    ],
+    name: "PromoCodeRemoved",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "buyer",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "referralAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "ReferralReward",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "referralDiscountPercentage",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "referralRewardPercentage",
+        type: "uint256",
+      },
+    ],
+    name: "ReferralRewardPercentagesChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "buyer",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "referralAddress",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "currency",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "string",
+        name: "promoCode",
+        type: "string",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "ReferralRewardV2",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "claimer",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "ethAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "xaiAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "esXaiAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "usdcAmount",
+        type: "uint256",
+      },
+    ],
+    name: "RewardClaimed",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "bytes32", name: "role", type: "bytes32" },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "previousAdminRole",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "newAdminRole",
+        type: "bytes32",
+      },
+    ],
+    name: "RoleAdminChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "bytes32", name: "role", type: "bytes32" },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+    ],
+    name: "RoleGranted",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "bytes32", name: "role", type: "bytes32" },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+    ],
+    name: "RoleRevoked",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "from", type: "address" },
+      { indexed: true, internalType: "address", name: "to", type: "address" },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+    ],
+    name: "Transfer",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "redeemer",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint16",
+        name: "newAmount",
+        type: "uint16",
+      },
+    ],
+    name: "WhitelistAmountRedeemed",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "redeemer",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint16",
+        name: "newAmount",
+        type: "uint16",
+      },
+    ],
+    name: "WhitelistAmountUpdatedByAdmin",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "ADMIN_MINT_ROLE",
+    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "AIRDROP_ADMIN_ROLE",
+    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "DEFAULT_ADMIN_ROLE",
+    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "TRANSFER_ROLE",
+    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    name: "_averageCost",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    name: "_mintTimestamps",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "to", type: "address" },
+      { internalType: "uint256", name: "amount", type: "uint256" },
+      { internalType: "bytes32", name: "mintId", type: "bytes32" },
+    ],
+    name: "adminMintTo",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "to", type: "address" },
+      { internalType: "uint256[]", name: "tokenIds", type: "uint256[]" },
+      { internalType: "bytes32", name: "transferId", type: "bytes32" },
+    ],
+    name: "adminTransferBatch",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "to", type: "address" },
+      { internalType: "uint256", name: "tokenId", type: "uint256" },
+    ],
+    name: "approve",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "owner", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "claimReferralReward",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "claimable",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "string", name: "_promoCode", type: "string" },
+      { internalType: "address", name: "_recipient", type: "address" },
+    ],
+    name: "createPromoCode",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "esXaiAddress",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_amount", type: "uint256" }],
+    name: "ethToXai",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "keyMultiplier", type: "uint256" },
+    ],
+    name: "finishAirdrop",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "fundsReceiver",
+    outputs: [{ internalType: "address payable", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "tokenId", type: "uint256" }],
+    name: "getApproved",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_tokenId", type: "uint256" }],
+    name: "getMintTimestamp",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_index", type: "uint256" }],
+    name: "getPricingTier",
+    outputs: [
+      {
+        components: [
+          { internalType: "uint256", name: "price", type: "uint256" },
+          { internalType: "uint256", name: "quantity", type: "uint256" },
+        ],
+        internalType: "struct NodeLicense8.Tier",
+        name: "",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getPricingTiersLength",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "string", name: "_promoCode", type: "string" }],
+    name: "getPromoCode",
+    outputs: [
+      {
+        components: [
+          { internalType: "address", name: "recipient", type: "address" },
+          { internalType: "bool", name: "active", type: "bool" },
           {
-              "indexed": true,
-              "internalType": "address",
-              "name": "owner",
-              "type": "address"
+            internalType: "uint256",
+            name: "receivedLifetime",
+            type: "uint256",
           },
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "approved",
-              "type": "address"
-          },
-          {
-              "indexed": true,
-              "internalType": "uint256",
-              "name": "tokenId",
-              "type": "uint256"
-          }
-      ],
-      "name": "Approval",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "owner",
-              "type": "address"
-          },
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "operator",
-              "type": "address"
-          },
-          {
-              "indexed": false,
-              "internalType": "bool",
-              "name": "approved",
-              "type": "bool"
-          }
-      ],
-      "name": "ApprovalForAll",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "admin",
-              "type": "address"
-          },
-          {
-              "indexed": false,
-              "internalType": "bool",
-              "name": "newClaimableState",
-              "type": "bool"
-          }
-      ],
-      "name": "ClaimableChanged",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "admin",
-              "type": "address"
-          },
-          {
-              "indexed": false,
-              "internalType": "address",
-              "name": "newFundsReceiver",
-              "type": "address"
-          }
-      ],
-      "name": "FundsReceiverChanged",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": false,
-              "internalType": "uint8",
-              "name": "version",
-              "type": "uint8"
-          }
-      ],
-      "name": "Initialized",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "index",
-              "type": "uint256"
-          },
-          {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "price",
-              "type": "uint256"
-          },
-          {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "quantity",
-              "type": "uint256"
-          }
-      ],
-      "name": "PricingTierSetOrAdded",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": false,
-              "internalType": "string",
-              "name": "promoCode",
-              "type": "string"
-          },
-          {
-              "indexed": false,
-              "internalType": "address",
-              "name": "recipient",
-              "type": "address"
-          }
-      ],
-      "name": "PromoCodeCreated",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": false,
-              "internalType": "string",
-              "name": "promoCode",
-              "type": "string"
-          }
-      ],
-      "name": "PromoCodeRemoved",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "buyer",
-              "type": "address"
-          },
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "referralAddress",
-              "type": "address"
-          },
-          {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-          }
-      ],
-      "name": "ReferralReward",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "referralDiscountPercentage",
-              "type": "uint256"
-          },
-          {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "referralRewardPercentage",
-              "type": "uint256"
-          }
-      ],
-      "name": "ReferralRewardPercentagesChanged",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "claimer",
-              "type": "address"
-          },
-          {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "ethAmount",
-              "type": "uint256"
-          },
-          {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "xaiAmount",
-              "type": "uint256"
-          },
-          {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "esXaiAmount",
-              "type": "uint256"
-          }
-      ],
-      "name": "RewardClaimed",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": true,
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-          },
-          {
-              "indexed": true,
-              "internalType": "bytes32",
-              "name": "previousAdminRole",
-              "type": "bytes32"
-          },
-          {
-              "indexed": true,
-              "internalType": "bytes32",
-              "name": "newAdminRole",
-              "type": "bytes32"
-          }
-      ],
-      "name": "RoleAdminChanged",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": true,
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-          },
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "account",
-              "type": "address"
-          },
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "sender",
-              "type": "address"
-          }
-      ],
-      "name": "RoleGranted",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": true,
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-          },
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "account",
-              "type": "address"
-          },
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "sender",
-              "type": "address"
-          }
-      ],
-      "name": "RoleRevoked",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "from",
-              "type": "address"
-          },
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "to",
-              "type": "address"
-          },
-          {
-              "indexed": true,
-              "internalType": "uint256",
-              "name": "tokenId",
-              "type": "uint256"
-          }
-      ],
-      "name": "Transfer",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "redeemer",
-              "type": "address"
-          },
-          {
-              "indexed": false,
-              "internalType": "uint16",
-              "name": "newAmount",
-              "type": "uint16"
-          }
-      ],
-      "name": "WhitelistAmountRedeemed",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "redeemer",
-              "type": "address"
-          },
-          {
-              "indexed": false,
-              "internalType": "uint16",
-              "name": "newAmount",
-              "type": "uint16"
-          }
-      ],
-      "name": "WhitelistAmountUpdatedByAdmin",
-      "type": "event"
-  },
-  {
-      "inputs": [],
-      "name": "AIRDROP_ADMIN_ROLE",
-      "outputs": [
-          {
-              "internalType": "bytes32",
-              "name": "",
-              "type": "bytes32"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "DEFAULT_ADMIN_ROLE",
-      "outputs": [
-          {
-              "internalType": "bytes32",
-              "name": "",
-              "type": "bytes32"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "to",
-              "type": "address"
-          },
-          {
-              "internalType": "uint256",
-              "name": "tokenId",
-              "type": "uint256"
-          }
-      ],
-      "name": "approve",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "owner",
-              "type": "address"
-          }
-      ],
-      "name": "balanceOf",
-      "outputs": [
-          {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "claimReferralReward",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "claimable",
-      "outputs": [
-          {
-              "internalType": "bool",
-              "name": "",
-              "type": "bool"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "string",
-              "name": "_promoCode",
-              "type": "string"
-          },
-          {
-              "internalType": "address",
-              "name": "_recipient",
-              "type": "address"
-          }
-      ],
-      "name": "createPromoCode",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "esXaiAddress",
-      "outputs": [
-          {
-              "internalType": "address",
-              "name": "",
-              "type": "address"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "_amount",
-              "type": "uint256"
-          }
-      ],
-      "name": "ethToXai",
-      "outputs": [
-          {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "refereeAddress",
-              "type": "address"
-          },
-          {
-              "internalType": "uint256",
-              "name": "keyMultiplier",
-              "type": "uint256"
-          }
-      ],
-      "name": "finishAirdrop",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "fundsReceiver",
-      "outputs": [
-          {
-              "internalType": "address payable",
-              "name": "",
-              "type": "address"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "tokenId",
-              "type": "uint256"
-          }
-      ],
-      "name": "getApproved",
-      "outputs": [
-          {
-              "internalType": "address",
-              "name": "",
-              "type": "address"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "_tokenId",
-              "type": "uint256"
-          }
-      ],
-      "name": "getAverageCost",
-      "outputs": [
-          {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "_tokenId",
-              "type": "uint256"
-          }
-      ],
-      "name": "getMintTimestamp",
-      "outputs": [
-          {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "_index",
-              "type": "uint256"
-          }
-      ],
-      "name": "getPricingTier",
-      "outputs": [
-          {
-              "components": [
-                  {
-                      "internalType": "uint256",
-                      "name": "price",
-                      "type": "uint256"
-                  },
-                  {
-                      "internalType": "uint256",
-                      "name": "quantity",
-                      "type": "uint256"
-                  }
-              ],
-              "internalType": "struct NodeLicense10.Tier",
-              "name": "",
-              "type": "tuple"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "getPricingTiersLength",
-      "outputs": [
-          {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "string",
-              "name": "_promoCode",
-              "type": "string"
-          }
-      ],
-      "name": "getPromoCode",
-      "outputs": [
-          {
-              "components": [
-                  {
-                      "internalType": "address",
-                      "name": "recipient",
-                      "type": "address"
-                  },
-                  {
-                      "internalType": "bool",
-                      "name": "active",
-                      "type": "bool"
-                  },
-                  {
-                      "internalType": "uint256",
-                      "name": "receivedLifetime",
-                      "type": "uint256"
-                  }
-              ],
-              "internalType": "struct NodeLicense10.PromoCode",
-              "name": "",
-              "type": "tuple"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-          }
-      ],
-      "name": "getRoleAdmin",
-      "outputs": [
-          {
-              "internalType": "bytes32",
-              "name": "",
-              "type": "bytes32"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-          },
-          {
-              "internalType": "address",
-              "name": "account",
-              "type": "address"
-          }
-      ],
-      "name": "grantRole",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-          },
-          {
-              "internalType": "address",
-              "name": "account",
-              "type": "address"
-          }
-      ],
-      "name": "hasRole",
-      "outputs": [
-          {
-              "internalType": "bool",
-              "name": "",
-              "type": "bool"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "_xaiAddress",
-              "type": "address"
-          },
-          {
-              "internalType": "address",
-              "name": "_esXaiAddress",
-              "type": "address"
-          },
-          {
-              "internalType": "address",
-              "name": "ethPriceFeedAddress",
-              "type": "address"
-          },
-          {
-              "internalType": "address",
-              "name": "xaiPriceFeedAddress",
-              "type": "address"
-          },
-          {
-              "internalType": "address",
-              "name": "airdropAdmin",
-              "type": "address"
-          }
-      ],
-      "name": "initialize",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "owner",
-              "type": "address"
-          },
-          {
-              "internalType": "address",
-              "name": "operator",
-              "type": "address"
-          }
-      ],
-      "name": "isApprovedForAll",
-      "outputs": [
-          {
-              "internalType": "bool",
-              "name": "",
-              "type": "bool"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "maxSupply",
-      "outputs": [
-          {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "_amount",
-              "type": "uint256"
-          },
-          {
-              "internalType": "string",
-              "name": "_promoCode",
-              "type": "string"
-          }
-      ],
-      "name": "mint",
-      "outputs": [],
-      "stateMutability": "payable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "_qtyToMint",
-              "type": "uint256"
-          },
-          {
-              "internalType": "address",
-              "name": "_theRecipient",
-              "type": "address"
-          }
-      ],
-      "name": "mintForAirdrop",
-      "outputs": [
-          {
-              "internalType": "uint256[]",
-              "name": "tokenIds",
-              "type": "uint256[]"
-          }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "_amount",
-              "type": "uint256"
-          },
-          {
-              "internalType": "string",
-              "name": "_promoCode",
-              "type": "string"
-          },
-          {
-              "internalType": "bool",
-              "name": "_useEsXai",
-              "type": "bool"
-          },
-          {
-              "internalType": "uint256",
-              "name": "_expectedCost",
-              "type": "uint256"
-          }
-      ],
-      "name": "mintWithXai",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "mintingPaused",
-      "outputs": [
-          {
-              "internalType": "bool",
-              "name": "",
-              "type": "bool"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "name",
-      "outputs": [
-          {
-              "internalType": "string",
-              "name": "",
-              "type": "string"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "tokenId",
-              "type": "uint256"
-          }
-      ],
-      "name": "ownerOf",
-      "outputs": [
-          {
-              "internalType": "address",
-              "name": "",
-              "type": "address"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "_amount",
-              "type": "uint256"
-          },
-          {
-              "internalType": "string",
-              "name": "_promoCode",
-              "type": "string"
-          }
-      ],
-      "name": "price",
-      "outputs": [
-          {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "redeemFromWhitelist",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "referralDiscountPercentage",
-      "outputs": [
-          {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "referralRewardPercentage",
-      "outputs": [
-          {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "string",
-              "name": "_promoCode",
-              "type": "string"
-          }
-      ],
-      "name": "removePromoCode",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-          },
-          {
-              "internalType": "address",
-              "name": "account",
-              "type": "address"
-          }
-      ],
-      "name": "renounceRole",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "_address",
-              "type": "address"
-          }
-      ],
-      "name": "revokeAirdropAdmin",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "bytes32",
-              "name": "role",
-              "type": "bytes32"
-          },
-          {
-              "internalType": "address",
-              "name": "account",
-              "type": "address"
-          }
-      ],
-      "name": "revokeRole",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "from",
-              "type": "address"
-          },
-          {
-              "internalType": "address",
-              "name": "to",
-              "type": "address"
-          },
-          {
-              "internalType": "uint256",
-              "name": "tokenId",
-              "type": "uint256"
-          }
-      ],
-      "name": "safeTransferFrom",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "from",
-              "type": "address"
-          },
-          {
-              "internalType": "address",
-              "name": "to",
-              "type": "address"
-          },
-          {
-              "internalType": "uint256",
-              "name": "tokenId",
-              "type": "uint256"
-          },
-          {
-              "internalType": "bytes",
-              "name": "data",
-              "type": "bytes"
-          }
-      ],
-      "name": "safeTransferFrom",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "operator",
-              "type": "address"
-          },
-          {
-              "internalType": "bool",
-              "name": "approved",
-              "type": "bool"
-          }
-      ],
-      "name": "setApprovalForAll",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "bool",
-              "name": "_claimable",
-              "type": "bool"
-          }
-      ],
-      "name": "setClaimable",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address payable",
-              "name": "_newFundsReceiver",
-              "type": "address"
-          }
-      ],
-      "name": "setFundsReceiver",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "_index",
-              "type": "uint256"
-          },
-          {
-              "internalType": "uint256",
-              "name": "_price",
-              "type": "uint256"
-          },
-          {
-              "internalType": "uint256",
-              "name": "_quantity",
-              "type": "uint256"
-          }
-      ],
-      "name": "setOrAddPricingTier",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "_referralDiscountPercentage",
-              "type": "uint256"
-          },
-          {
-              "internalType": "uint256",
-              "name": "_referralRewardPercentage",
-              "type": "uint256"
-          }
-      ],
-      "name": "setReferralPercentages",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "refereeAddress",
-              "type": "address"
-          }
-      ],
-      "name": "startAirdrop",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "bytes4",
-              "name": "interfaceId",
-              "type": "bytes4"
-          }
-      ],
-      "name": "supportsInterface",
-      "outputs": [
-          {
-              "internalType": "bool",
-              "name": "",
-              "type": "bool"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "symbol",
-      "outputs": [
-          {
-              "internalType": "string",
-              "name": "",
-              "type": "string"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "index",
-              "type": "uint256"
-          }
-      ],
-      "name": "tokenByIndex",
-      "outputs": [
-          {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "owner",
-              "type": "address"
-          },
-          {
-              "internalType": "uint256",
-              "name": "index",
-              "type": "uint256"
-          }
-      ],
-      "name": "tokenOfOwnerByIndex",
-      "outputs": [
-          {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "_tokenId",
-              "type": "uint256"
-          }
-      ],
-      "name": "tokenURI",
-      "outputs": [
-          {
-              "internalType": "string",
-              "name": "",
-              "type": "string"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "totalSupply",
-      "outputs": [
-          {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "from",
-              "type": "address"
-          },
-          {
-              "internalType": "address",
-              "name": "to",
-              "type": "address"
-          },
-          {
-              "internalType": "uint256",
-              "name": "tokenId",
-              "type": "uint256"
-          }
-      ],
-      "name": "transferFrom",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address[]",
-              "name": "_toWhitelist",
-              "type": "address[]"
-          },
-          {
-              "internalType": "uint16[]",
-              "name": "_amounts",
-              "type": "uint16[]"
-          }
-      ],
-      "name": "updateWhitelistAmounts",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "string",
-              "name": "_address",
-              "type": "string"
-          }
-      ],
-      "name": "validateAndConvertAddress",
-      "outputs": [
-          {
-              "internalType": "address",
-              "name": "",
-              "type": "address"
-          }
-      ],
-      "stateMutability": "pure",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "address",
-              "name": "",
-              "type": "address"
-          }
-      ],
-      "name": "whitelistAmounts",
-      "outputs": [
-          {
-              "internalType": "uint16",
-              "name": "",
-              "type": "uint16"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  },
-  {
-      "inputs": [],
-      "name": "xaiAddress",
-      "outputs": [
-          {
-              "internalType": "address",
-              "name": "",
-              "type": "address"
-          }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-  }
+        ],
+        internalType: "struct NodeLicense8.PromoCode",
+        name: "",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes32", name: "role", type: "bytes32" }],
+    name: "getRoleAdmin",
+    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "bytes32", name: "role", type: "bytes32" },
+      { internalType: "address", name: "account", type: "address" },
+    ],
+    name: "grantRole",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "bytes32", name: "role", type: "bytes32" },
+      { internalType: "address", name: "account", type: "address" },
+    ],
+    name: "hasRole",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "initialize",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "owner", type: "address" },
+      { internalType: "address", name: "operator", type: "address" },
+    ],
+    name: "isApprovedForAll",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "maxSupply",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "_amount", type: "uint256" },
+      { internalType: "string", name: "_promoCode", type: "string" },
+    ],
+    name: "mint",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "_qtyToMint", type: "uint256" },
+      { internalType: "uint256", name: "_keyId", type: "uint256" },
+    ],
+    name: "mintForAirdrop",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "_mintToAddress", type: "address" },
+      { internalType: "uint256", name: "_amount", type: "uint256" },
+      { internalType: "string", name: "_promoCode", type: "string" },
+    ],
+    name: "mintTo",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "_to", type: "address" },
+      { internalType: "uint256", name: "_amount", type: "uint256" },
+      { internalType: "string", name: "_promoCode", type: "string" },
+      { internalType: "uint256", name: "_expectedCostInUSDC", type: "uint256" },
+    ],
+    name: "mintToWithUSDC",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "_amount", type: "uint256" },
+      { internalType: "string", name: "_promoCode", type: "string" },
+      { internalType: "bool", name: "_useEsXai", type: "bool" },
+      { internalType: "uint256", name: "_expectedCost", type: "uint256" },
+    ],
+    name: "mintWithXai",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "mintingPaused",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "name",
+    outputs: [{ internalType: "string", name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "tokenId", type: "uint256" }],
+    name: "ownerOf",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "_amount", type: "uint256" },
+      { internalType: "string", name: "_promoCode", type: "string" },
+    ],
+    name: "price",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "refereeAddress",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "refereeCalculationsAddress",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "referralDiscountPercentage",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "referralRewardPercentage",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "string", name: "_promoCode", type: "string" }],
+    name: "removePromoCode",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "bytes32", name: "role", type: "bytes32" },
+      { internalType: "address", name: "account", type: "address" },
+    ],
+    name: "renounceRole",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "bytes32", name: "role", type: "bytes32" },
+      { internalType: "address", name: "account", type: "address" },
+    ],
+    name: "revokeRole",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "from", type: "address" },
+      { internalType: "address", name: "to", type: "address" },
+      { internalType: "uint256", name: "tokenId", type: "uint256" },
+    ],
+    name: "safeTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "from", type: "address" },
+      { internalType: "address", name: "to", type: "address" },
+      { internalType: "uint256", name: "tokenId", type: "uint256" },
+      { internalType: "bytes", name: "data", type: "bytes" },
+    ],
+    name: "safeTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "operator", type: "address" },
+      { internalType: "bool", name: "approved", type: "bool" },
+    ],
+    name: "setApprovalForAll",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bool", name: "_claimable", type: "bool" }],
+    name: "setClaimable",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "_index", type: "uint256" },
+      { internalType: "uint256", name: "_price", type: "uint256" },
+      { internalType: "uint256", name: "_quantity", type: "uint256" },
+    ],
+    name: "setOrAddPricingTier",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "startAirdrop",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes4", name: "interfaceId", type: "bytes4" }],
+    name: "supportsInterface",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "symbol",
+    outputs: [{ internalType: "string", name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "index", type: "uint256" }],
+    name: "tokenByIndex",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "owner", type: "address" },
+      { internalType: "uint256", name: "index", type: "uint256" },
+    ],
+    name: "tokenOfOwnerByIndex",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_tokenId", type: "uint256" }],
+    name: "tokenURI",
+    outputs: [{ internalType: "string", name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "totalSupply",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "from", type: "address" },
+      { internalType: "address", name: "to", type: "address" },
+      { internalType: "uint256", name: "tokenId", type: "uint256" },
+    ],
+    name: "transferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address[]", name: "_toWhitelist", type: "address[]" },
+      { internalType: "uint16[]", name: "_amounts", type: "uint16[]" },
+    ],
+    name: "updateWhitelistAmounts",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "usdcAddress",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    name: "usedAdminMintIds",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    name: "usedTransferIds",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "", type: "address" }],
+    name: "whitelistAmounts",
+    outputs: [{ internalType: "uint16", name: "", type: "uint16" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "xaiAddress",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
 ];

--- a/packages/core/src/utils/getUsdcAllowance.ts
+++ b/packages/core/src/utils/getUsdcAllowance.ts
@@ -1,0 +1,32 @@
+import {ethers} from 'ethers';
+import {getProvider} from './getProvider.js';
+import { XaiAbi } from '../abis/index.js';
+import { config } from '../index.js';
+
+/**
+ * Fetches the allowance amount of esXai token for a wallet and operator.
+ * @param wallet - The address of the wallet to fetch the allowance of.
+ * @param operator - The address of the operator.
+ * @returns bigint The approval amount of the wallet.
+ */
+
+export async function getUsdcAllowance(wallet: string, operator: string): Promise<{ approvalAmount: bigint}> {
+    if(!wallet || !operator || wallet.length !== 42 || operator.length !== 42) {
+        return { approvalAmount: BigInt(0) };
+    }
+
+    // Get the provider
+    const providerUrls = [
+        config.arbitrumOneJsonRpcUrl,
+        config.publicRPC,
+    ];
+    const provider = getProvider(providerUrls[Math.floor(Math.random() * providerUrls.length)]);
+
+    // Create an instance of the esXai token contract
+    const tokenContract = new ethers.Contract(config.usdcContractAddress, XaiAbi, provider);
+
+    // Get the operator allowance of the esXai token
+    const approvalAmount = await tokenContract.allowance(wallet, operator);
+
+    return { approvalAmount };
+}

--- a/packages/core/src/utils/getUsdcBalance.ts
+++ b/packages/core/src/utils/getUsdcBalance.ts
@@ -1,0 +1,31 @@
+import {ethers} from 'ethers';
+import {getProvider} from './getProvider.js';
+import { XaiAbi } from '../abis/index.js';
+import { config } from '../index.js';
+
+/**
+ * Fetches a wallet's Xai balance.
+ * @param walletAddress - The address of the wallet to fetch the balance of.
+ * @returns bigint The Xai balance of the wallet.
+ */
+
+export async function getUsdcBalance(wallet: string): Promise<{ balance: bigint}> {
+    if(!wallet || wallet.length !== 42) {
+        return { balance: BigInt(0) };
+    }
+
+    // Get the provider
+    const providerUrls = [ 
+        config.arbitrumOneJsonRpcUrl,
+        config.publicRPC,
+    ];
+    const provider = getProvider(providerUrls[Math.floor(Math.random() * providerUrls.length)]);
+
+    // Create an instance of the Xai token contract
+    const tokenContract = new ethers.Contract(config.usdcContractAddress, XaiAbi, provider);
+
+    // Get the wallet balance of the Xai token
+    const balance = await tokenContract.balanceOf(wallet);
+
+    return { balance };
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -23,3 +23,5 @@ export * from "./getNodeConfirmedEvents.js";
 export * from "./getRefereeCalculationsAddress.js";
 export * from "./isValidNetwork.js";
 export * from "./getEthUsdcExchangeRate.js";
+export * from "./getUsdcBalance.js";
+export * from "./getUsdcAllowance.js";


### PR DESCRIPTION
Ticket pending.

Added Mint with USDC to KeySale checkout Page

This is built on top of [PR#511](https://github.com/xai-foundation/sentry/pull/511) and is into that branch. 

This should be merged into that branch before that PR is approved/merged.

Tested locally, pending test on PR link.

Note: I think we should create a story for deploying new Mock Chainlink Oracles on Sepolia with a function to allow us to change the price. Since We have XAI at $1.00 in the mock oracle, it's hard to test the currency conversion amounts, because both USDC/XAI mocked at $1.00 cost the same when priced in ETH so the U/I(correctly) gives you the same price for all 3 tokens(USDC, XAI, ESXAI) but I'd like to test with variable prices and confirm the USDC decimal conversions are working properly.


Tested locally:

[Standard Mint](https://sepolia.arbiscan.io/tx/0x14adafa5f81a439cd06a4c1ee75bd7fd6b145e48fef88705a3b08faa10bc7984)
[Mint With Xai](https://sepolia.arbiscan.io/tx/0x150b4f40d46f110dd2e82bee49f7c0d611a72b5030d78517d0110ebb33c227a4)
[Mint With Usdc](https://sepolia.arbiscan.io/tx/0x2f66ac8e2c2cba87718a148d1aa996057cffd67ab0304bd36a0ee58291156431)