### PR TITLE
Add sale info modal for tk release

### DIFF
--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -8,8 +8,6 @@ on:
 
   pull_request_review:
     types: [submitted]
-    branches:
-        - '*'
 
 jobs:
   build:

--- a/apps/web-connect/src/features/checkout/Checkout.tsx
+++ b/apps/web-connect/src/features/checkout/Checkout.tsx
@@ -11,6 +11,7 @@ import { ActionSection } from "./components/ActionSection";
 import { BiLoaderAlt } from "react-icons/bi";
 import PurchaseSuccessful from "./components/PurchaseSuccessful";
 import { useWebBuyKeysContext } from './contexts/useWebBuyKeysContext';
+import SaleInfoModal from "@/features/checkout/components/SaleInfoModal";
 
 export const stakingPageURL = "https://app.xai.games/staking?modal=true&page=1&showKeys=true&hideFull=true&sort=tierIndex&sortOrder=-1";
 
@@ -59,6 +60,7 @@ export function Checkout() {
 
     return (
         <div>
+            <SaleInfoModal />
             <div className="h-full xl:min-h-screen flex-1 flex flex-col justify-center items-center">
                 {mintWithEth.isPending || mintWithXai.isPending || approve.isPending || mintWithCrossmint.isPending ? (
                     <TransactionInProgress />

--- a/apps/web-connect/src/features/checkout/components/SaleInfoModal.tsx
+++ b/apps/web-connect/src/features/checkout/components/SaleInfoModal.tsx
@@ -1,0 +1,23 @@
+const SaleInfoModal = () => {
+
+    document.body.style.overflow = "hidden"
+
+    return (
+        <div className={"bg-black/70 absolute top-0 left-0 w-screen h-screen z-[99999] flex items-center justify-center"}>
+            <div className="bg-black w-full md:max-w-[75%] h-full md:max-h-[700px] text-white flex flex-col items-center justify-center">
+                <h1 className="font-bold md:text-4xl text-lg">Tiny Sentry Keys </h1>
+                <div className="block md:text-2xl text-center ">
+                    <h2 className='font-bold md:text-2xl my-2'>Sale Starts</h2>
+                    <p>Dec. 13th 6:00pm Vancouver, Canada</p>
+                    <p>Dec. 13th 11:00pm Buenos Aires, Argentina</p>
+                    <p>Dec 14th 2:00am London, England (UTC)</p>
+                    <p>Dec 14th 7:30am Mumbai, India</p>
+                    <p>Dec 14th 9:00am Seoul, South Korea</p>
+                    <p>Dec 14th 10:00am Hong Kong</p>
+                    <p>&#42; please note sale starts at the same time, just different time zones</p>
+                </div>
+            </div>
+        </div>
+    )
+}
+export default SaleInfoModal


### PR DESCRIPTION
Adding the SaleInfoModal blocking the checkout page for info about tk sale release.

This PR is for having the test env.
We will deploy manually to cf pages to release this when business is ready.