### PR TITLE
Allow NodeLicense to update bulkSubmissions on key transfer

### DIFF
--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -110,6 +110,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     error ReferrerCannotBeBuyer();
     error CannotTransferStakedKey();
     error TransferFailed();
+    error ReentrantCall();
 
     bytes32 public constant AIRDROP_ADMIN_ROLE = keccak256("AIRDROP_ADMIN_ROLE");
     bytes32 public constant ADMIN_MINT_ROLE = keccak256("ADMIN_MINT_ROLE");
@@ -134,8 +135,6 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         bool active;
         uint256 receivedLifetime;
     }
-
-    error ReentrantCall();
 
     event PromoCodeCreated(string promoCode, address recipient);
     event PromoCodeRemoved(string promoCode);

--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -310,7 +310,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         address currency = _useEsXai ? esXaiAddress : xaiAddress;
         (uint256 referralReward, address recipientAddress)  = _calculateReferralReward(finalPrice, _promoCode, currency);
         
-        IERC20 token = IERC20(_useEsXai ? esXaiAddress : xaiAddress);
+        IERC20 token = IERC20(currency);
         token.transferFrom(msg.sender, address(this), finalPrice);
         token.transfer(fundsReceiver, finalPrice - referralReward);
 
@@ -431,6 +431,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
      * as a string to this function
      * @param _finalPrice The final cost of the minting
      * @param _promoCode The promo code used
+     * @param _currency The currency used for payment of the mint
      * @return A tuple containing the referral reward and an address with 0 address indicating the promo code was not an address
      */
     function _calculateReferralReward(uint256 _finalPrice, string memory _promoCode, address _currency) internal returns(uint256, address) {

--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -842,8 +842,6 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     }
 
 
-
-
     /**
      * @notice Admin function mint tokens to a wallet
      * @param to The address to mint the tokens to
@@ -889,8 +887,8 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         for(uint256 i; i < tokenIdsLength; i++){
             if(Referee10(refereeAddress).assignedKeyToPool(tokenIds[i]) != address(0)) revert CannotTransferStakedKey();
             super.safeTransferFrom(msg.sender, to, tokenIds[i]);
-            Referee10(refereeAddress).updateBulkSubmissionOnTransfer(msg.sender, to, tokenIds[i]);
         }
+        Referee10(refereeAddress).updateBulkSubmissionOnTransfer(msg.sender, to);
         emit AdminTransferBatch(msg.sender, to, transferId, tokenIds);
     }
 
@@ -904,7 +902,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     ) public override onlyRole(TRANSFER_ROLE) {
         if(Referee10(refereeAddress).assignedKeyToPool(tokenId) != address(0)) revert CannotTransferStakedKey();
         super.transferFrom(from, to, tokenId);
-        Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to, tokenId);
+        Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to);
     }
 
     /**
@@ -917,7 +915,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     ) public override onlyRole(TRANSFER_ROLE) {
         if(Referee10(refereeAddress).assignedKeyToPool(tokenId) != address(0)) revert CannotTransferStakedKey();
         super.safeTransferFrom(from, to, tokenId);
-        Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to, tokenId);
+        Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to);
     }
 
     /**
@@ -931,7 +929,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     ) public override onlyRole(TRANSFER_ROLE) {
         if(Referee10(refereeAddress).assignedKeyToPool(tokenId) != address(0)) revert CannotTransferStakedKey();
         super.safeTransferFrom(from, to, tokenId, data);
-        Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to, tokenId);
+        Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to);
     }
 
 }

--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -107,6 +107,9 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     error MintingPaused();
     error ExceedsMaxSupply();
     error ClaimingPaused();
+    error ReferrerCannotBeBuyer();
+    error CannotTransferStakedKey();
+    error TransferFailed();
 
     bytes32 public constant AIRDROP_ADMIN_ROLE = keccak256("AIRDROP_ADMIN_ROLE");
     bytes32 public constant ADMIN_MINT_ROLE = keccak256("ADMIN_MINT_ROLE");
@@ -188,7 +191,6 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     
     modifier reentrancyGuardClaimReferralReward() {
         if(_reentrancyGuardClaimReferralReward) revert ReentrantCall();
-        //require(!_reentrancyGuardClaimReferralReward, "Reentrancy guard: reentrant call");
         _reentrancyGuardClaimReferralReward = true;
         _;
         _reentrancyGuardClaimReferralReward = false;
@@ -200,7 +202,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
      * @param _recipient The recipient address.
      */
     function createPromoCode(string calldata _promoCode, address _recipient) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(_recipient != address(0), "Recipient address cannot be zero");
+        if(_recipient == address(0)) revert InvalidAddress();
         require(_promoCodes[_promoCode].recipient == address(0), "Promo code already exists");
         require(bytes(_promoCode).length > 0, "Promo code cannot be empty");
         _promoCodes[_promoCode] = PromoCode(_recipient, true, 0);
@@ -279,12 +281,12 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         // Send the funds to the fundsReceiver
         uint256 remainder = msg.value - finalPrice;
         (bool sent,) = fundsReceiver.call{value: finalPrice - referralReward}("");
-        require(sent, "Failed to send Ether");
+        if (!sent) revert TransferFailed();
 
         // Send back the remainder amount
         if (remainder > 0) {
             (bool sentRemainder,) = msg.sender.call{value: remainder}("");
-            require(sentRemainder, "Failed to send back the remainder Ether");
+            if(!sentRemainder) revert TransferFailed();
         }
     }
 
@@ -457,7 +459,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
             }
 
             // Confirm the recipient is not the sender
-            require(promoCode.recipient != msg.sender, "Referral address cannot be the sender's address");
+            if(promoCode.recipient == msg.sender) revert ReferrerCannotBeBuyer();
 
             // Calculate the referral reward
             referralReward = _finalPrice * referralRewardPercentage / 100;
@@ -480,7 +482,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         if(promoCodeAsAddress != address(0)){
 
             // Confirm the promo code is not the sender's address
-            require(promoCodeAsAddress != msg.sender, "Referral address cannot be the sender's address");
+            if(promoCode.recipient == msg.sender) revert ReferrerCannotBeBuyer();
 
             // Get the node license balance of the promo code address
             if(this.balanceOf(promoCodeAsAddress) == 0){
@@ -620,7 +622,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
 
         // Transfer the rewards to the caller
         (bool success, ) = msg.sender.call{value: reward}("");
-        require(success, "Transfer failed.");
+        if(!success) revert TransferFailed();
 
         //transfer ERC20 tokens
         if(rewardXai > 0){
@@ -886,7 +888,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         usedTransferIds[transferId] = true;
         
         for(uint256 i; i < tokenIdsLength; i++){
-            require(Referee10(refereeAddress).assignedKeyToPool(tokenIds[i]) == address(0), "Cannot transfer staked key");
+            if(Referee10(refereeAddress).assignedKeyToPool(tokenIds[i]) != address(0)) revert CannotTransferStakedKey();
             super.safeTransferFrom(msg.sender, to, tokenIds[i]);
             Referee10(refereeAddress).updateBulkSubmissionOnTransfer(msg.sender, to, tokenIds[i]);
         }
@@ -901,7 +903,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         address to,
         uint256 tokenId
     ) public override onlyRole(TRANSFER_ROLE) {
-        require(Referee10(refereeAddress).assignedKeyToPool(tokenId) == address(0), "Cannot transfer staked key");
+        if(Referee10(refereeAddress).assignedKeyToPool(tokenId) != address(0)) revert CannotTransferStakedKey();
         super.transferFrom(from, to, tokenId);
         Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to, tokenId);
     }
@@ -914,7 +916,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         address to,
         uint256 tokenId
     ) public override onlyRole(TRANSFER_ROLE) {
-        require(Referee10(refereeAddress).assignedKeyToPool(tokenId) == address(0), "Cannot transfer staked key");
+        if(Referee10(refereeAddress).assignedKeyToPool(tokenId) != address(0)) revert CannotTransferStakedKey();
         super.safeTransferFrom(from, to, tokenId);
         Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to, tokenId);
     }
@@ -928,7 +930,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         uint256 tokenId,
         bytes memory data
     ) public override onlyRole(TRANSFER_ROLE) {
-        require(Referee10(refereeAddress).assignedKeyToPool(tokenId) == address(0), "Cannot transfer staked key");
+        if(Referee10(refereeAddress).assignedKeyToPool(tokenId) != address(0)) revert CannotTransferStakedKey();
         super.safeTransferFrom(from, to, tokenId, data);
         Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to, tokenId);
     }

--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -888,6 +888,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         for(uint256 i; i < tokenIdsLength; i++){
             require(Referee10(refereeAddress).assignedKeyToPool(tokenIds[i]) == address(0), "Cannot transfer staked key");
             super.safeTransferFrom(msg.sender, to, tokenIds[i]);
+            Referee10(refereeAddress).updateBulkSubmissionOnTransfer(msg.sender, to, tokenIds[i]);
         }
         emit AdminTransferBatch(msg.sender, to, transferId, tokenIds);
     }
@@ -902,6 +903,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     ) public override onlyRole(TRANSFER_ROLE) {
         require(Referee10(refereeAddress).assignedKeyToPool(tokenId) == address(0), "Cannot transfer staked key");
         super.transferFrom(from, to, tokenId);
+        Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to, tokenId);
     }
 
     /**
@@ -914,6 +916,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     ) public override onlyRole(TRANSFER_ROLE) {
         require(Referee10(refereeAddress).assignedKeyToPool(tokenId) == address(0), "Cannot transfer staked key");
         super.safeTransferFrom(from, to, tokenId);
+        Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to, tokenId);
     }
 
     /**
@@ -927,14 +930,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
     ) public override onlyRole(TRANSFER_ROLE) {
         require(Referee10(refereeAddress).assignedKeyToPool(tokenId) == address(0), "Cannot transfer staked key");
         super.safeTransferFrom(from, to, tokenId, data);
+        Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to, tokenId);
     }
-	
-	function _afterTokenTransfer(address from, address to, uint256 firstTokenId, uint256 batchSize) override internal {
-        // Call the parent function
-        super._afterTokenTransfer(from, to, firstTokenId, batchSize);
-
-        Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to, firstTokenId);
-    }
-
 
 }

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee10.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee10.sol
@@ -1115,7 +1115,7 @@ contract Referee10 is Initializable, AccessControlEnumerableUpgradeable {
     function updateBulkSubmissionOnTransfer(address from, address to, uint256 keyId) external {
         if(msg.sender != nodeLicenseAddress) revert CallerNotAuthorized();
 
-        uint256 currentChallenge = challengeCounter - 1;  
+        uint256 currentChallenge = challengeCounter == 0 ? 0 : challengeCounter - 1;  
            // If the pool has submitted for the current challenge, update the pool bulk submission
         if(bulkSubmissions[currentChallenge][from].submitted){
             _updateBulkAssertion(from, currentChallenge);

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee10.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee10.sol
@@ -1112,7 +1112,7 @@ contract Referee10 is Initializable, AccessControlEnumerableUpgradeable {
 		}
     }
 
-    function updateBulkSubmissionOnTransfer(address from, address to, uint256 keyId) external {
+    function updateBulkSubmissionOnTransfer(address from, address to) external {
         if(msg.sender != nodeLicenseAddress) revert CallerNotAuthorized();
 
         uint256 currentChallenge = challengeCounter == 0 ? 0 : challengeCounter - 1;  

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee10.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee10.sol
@@ -1128,14 +1128,14 @@ contract Referee10 is Initializable, AccessControlEnumerableUpgradeable {
     }
 
     //TEST FUNCTION this is used only for test coverage
-    function toggleAssertionChecking() public {
-        isCheckingAssertions = !isCheckingAssertions;
-        emit AssertionCheckingToggled(isCheckingAssertions);
-    }
+    // function toggleAssertionChecking() public {
+    //     isCheckingAssertions = !isCheckingAssertions;
+    //     emit AssertionCheckingToggled(isCheckingAssertions);
+    // }
 
     //TEST FUNCTION this is used only for test coverage
-    function setRollupAddress(address newRollupAddress) public {
-        rollupAddress = newRollupAddress;
-        emit RollupAddressChanged(newRollupAddress);
-    }
+    // function setRollupAddress(address newRollupAddress) public {
+    //     rollupAddress = newRollupAddress;
+    //     emit RollupAddressChanged(newRollupAddress);
+    // }
 }

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
@@ -958,15 +958,15 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
     //TEST FUNCTION this is used only for test coverage
     // Leaving these functions in the contract for test coverage purposes
     // In the future these can be removed if size becomes an issue
-    // function toggleAssertionChecking() public {
-    //     isCheckingAssertions = !isCheckingAssertions;
-    //     emit AssertionCheckingToggled(isCheckingAssertions);
-    // }
+    function toggleAssertionChecking() public {
+        isCheckingAssertions = !isCheckingAssertions;
+        emit AssertionCheckingToggled(isCheckingAssertions);
+    }
 
     //TEST FUNCTION this is used only for test coverage
-    // function setRollupAddress(address newRollupAddress) public {
-    //     rollupAddress = newRollupAddress;
-    //     emit RollupAddressChanged(newRollupAddress);
-    // }
+    function setRollupAddress(address newRollupAddress) public {
+        rollupAddress = newRollupAddress;
+        emit RollupAddressChanged(newRollupAddress);
+    }
 }
 

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee9.sol
@@ -958,15 +958,15 @@ contract Referee9 is Initializable, AccessControlEnumerableUpgradeable {
     //TEST FUNCTION this is used only for test coverage
     // Leaving these functions in the contract for test coverage purposes
     // In the future these can be removed if size becomes an issue
-    function toggleAssertionChecking() public {
-        isCheckingAssertions = !isCheckingAssertions;
-        emit AssertionCheckingToggled(isCheckingAssertions);
-    }
+    // function toggleAssertionChecking() public {
+    //     isCheckingAssertions = !isCheckingAssertions;
+    //     emit AssertionCheckingToggled(isCheckingAssertions);
+    // }
 
     //TEST FUNCTION this is used only for test coverage
-    function setRollupAddress(address newRollupAddress) public {
-        rollupAddress = newRollupAddress;
-        emit RollupAddressChanged(newRollupAddress);
-    }
+    // function setRollupAddress(address newRollupAddress) public {
+    //     rollupAddress = newRollupAddress;
+    //     emit RollupAddressChanged(newRollupAddress);
+    // }
 }
 


### PR DESCRIPTION
Updated NodeLicense and Referee to support updating BulkSubmissions on Transfer.

Tests coming in separate PR.