### PR TITLE
Moving to keyAmounts instead of key ids in staking Pool

### DIFF
--- a/apps/web-staking/src/services/web3.service.ts
+++ b/apps/web-staking/src/services/web3.service.ts
@@ -423,6 +423,9 @@ export const getMaxKeyCount = async (network: NetworkKey): Promise<number> => {
 	return MAX_KEY_COUNT_PER_POOL;
 }
 
+
+// TODO getUnstakedKeyIdsFromUser is deprecated in PoolFactory2
+// We do no longer track key ids for staking / unstaking
 export const getUnstakedKeysOfUser = async (network: NetworkKey, walletAddress: string, requestedCount: number): Promise<BigInt[]> => {
 	const web3Instance = getWeb3Instance(network);
 	const factoryContract = new web3Instance.web3.eth.Contract(PoolFactoryAbi, web3Instance.poolFactoryAddress);

--- a/infrastructure/smart-contracts/contracts/drops/TinyKeysAirdrop.sol
+++ b/infrastructure/smart-contracts/contracts/drops/TinyKeysAirdrop.sol
@@ -152,30 +152,32 @@ contract TinyKeysAirdrop is Initializable, AccessControlUpgradeable {
             address poolAddress = referee.assignedKeyToPool(i);
 
             // If the pool address is not 0, stake the newly minted keys
-            if(poolAddress != address(0)){           
-                uint256[] memory stakeKeyIds = new uint256[](keyMultiplier);
+            if(poolAddress != address(0)){
+                // DEPRECATED we do no longer track key IDs
+                // uint256[] memory stakeKeyIds = new uint256[](keyMultiplier);
                 // Determine the initial token id for the newly minted keys
                 // Calculate the starting ID for the new batch of tokens
-                uint256 tokensAlreadyProcessed = (i - 1) * keyMultiplier;
-                uint256 newTokenStartId = totalSupplyAtStart + tokensAlreadyProcessed + 1;
+                // uint256 tokensAlreadyProcessed = (i - 1) * keyMultiplier;
+                // uint256 newTokenStartId = totalSupplyAtStart + tokensAlreadyProcessed + 1;
 
-                // Create an array of key ids to stake
-                for (uint256 j = 0; j < keyMultiplier; j++) {
-                    stakeKeyIds[j] = newTokenStartId + j;
-                }
+                // // Create an array of key ids to stake
+                // for (uint256 j = 0; j < keyMultiplier; j++) {
+                //     stakeKeyIds[j] = newTokenStartId + j;
+                // }
                 
                 // Stake the keys
-                PoolFactory2(poolFactoryAddress).stakeKeysAdmin(poolAddress, stakeKeyIds, owner);
+                PoolFactory2(poolFactoryAddress).stakeKeysAdmin(poolAddress, keyMultiplier, owner);
                 poolsProcessed++;
 
                 // Emit the event
-                emit AirdropSegmentStakeComplete(owner, poolAddress, stakeKeyIds[0], stakeKeyIds[stakeKeyIds.length-1]);
+                emit AirdropSegmentStakeComplete(owner, poolAddress, i, i);
             }
-
-            if (poolsProcessed == 2) {
-                endingKeyId = i;
-                break;
-            }
+            
+            // This gas exception guard should not be needed anymore since we now process much more keys even if staked
+            // if (poolsProcessed == 2) {
+            //     endingKeyId = i;
+            //     break;
+            // }
         }
 
         // Update the stake counter

--- a/infrastructure/smart-contracts/contracts/drops/TinyKeysAirdrop.sol
+++ b/infrastructure/smart-contracts/contracts/drops/TinyKeysAirdrop.sol
@@ -140,7 +140,7 @@ contract TinyKeysAirdrop is Initializable, AccessControlUpgradeable {
         NodeLicense8 nodeLicense = NodeLicense8(nodeLicenseAddress);
         Referee9 referee = Referee9(refereeAddress);
 
-        uint8 poolsProcessed;
+        // uint8 poolsProcessed;
 
         // Loop through the range of node licenses
         // Needs to be <= to include the last key
@@ -167,7 +167,7 @@ contract TinyKeysAirdrop is Initializable, AccessControlUpgradeable {
                 
                 // Stake the keys
                 PoolFactory2(poolFactoryAddress).stakeKeysAdmin(poolAddress, keyMultiplier, owner);
-                poolsProcessed++;
+                // poolsProcessed++;
 
                 // Emit the event
                 emit AirdropSegmentStakeComplete(owner, poolAddress, i, i);

--- a/infrastructure/smart-contracts/contracts/drops/TinyKeysAirdrop.sol
+++ b/infrastructure/smart-contracts/contracts/drops/TinyKeysAirdrop.sol
@@ -49,7 +49,7 @@ contract TinyKeysAirdrop is Initializable, AccessControlUpgradeable {
     // Events for various actions within the contract
     event AirdropStarted(uint256 totalSupplyAtStart, uint256 keyMultiplier);
     event AirdropSegmentComplete(uint256 startingKeyId, uint256 endingKeyId);
-    event AirdropSegmentStakeComplete(address indexed owner, address indexed poolAddress, uint256 startingKeyId, uint256 endingKeyId);
+    event AirdropSegmentStakeComplete(address indexed owner, address indexed poolAddress, uint256 keyId, uint256 amount);
     event AirdropEnded();
 
     /**
@@ -170,7 +170,7 @@ contract TinyKeysAirdrop is Initializable, AccessControlUpgradeable {
                 // poolsProcessed++;
 
                 // Emit the event
-                emit AirdropSegmentStakeComplete(owner, poolAddress, i, i);
+                emit AirdropSegmentStakeComplete(owner, poolAddress, i, keyMultiplier);
             }
             
             // This gas exception guard should not be needed anymore since we now process much more keys even if staked

--- a/infrastructure/smart-contracts/contracts/staking-v2/StakingPool.sol
+++ b/infrastructure/smart-contracts/contracts/staking-v2/StakingPool.sol
@@ -30,8 +30,10 @@ contract StakingPool is AccessControlUpgradeable {
     BucketTracker public keyBucket;
     BucketTracker public esXaiStakeBucket;
 
+    // DEPRECATED: key are no longer being tracked on stake & unstake
     mapping(address => uint256[]) public stakedKeysOfOwner;
     mapping(uint256 => uint256) public keyIdIndex;
+
     mapping(address => uint256) public stakedAmounts;
 
 	uint256[] public stakedKeys;
@@ -49,7 +51,11 @@ contract StakingPool is AccessControlUpgradeable {
 	// mapping userAddress to requested unstake esXai amount
 	mapping(address => uint256) private userRequestedUnstakeEsXaiAmount;
 
-    uint256[500] __gap;
+    // Used for setting if we already migrated to key amounts instead of ids
+	mapping(address => bool) private hasMigratedToKeyAmount;
+    mapping(address => uint256) public stakedKeyAmounts;
+
+    uint256[498] __gap;
 
 	struct PoolBaseInfo {
 		address poolAddress;
@@ -110,13 +116,18 @@ contract StakingPool is AccessControlUpgradeable {
     function getStakedKeysCountForUser(
         address user
     ) external view returns (uint256) {
-        return stakedKeysOfOwner[user].length;
+        if(!hasMigratedToKeyAmount[user]){
+            return stakedKeysOfOwner[user].length;
+        }
+        return stakedKeyAmounts[user];
     }
 
     function getStakedAmounts(address user) external view returns (uint256) {
         return stakedAmounts[user];
     }
 
+    // DEPRECATED We no longer track keys by their IDs
+    // TODO update core function
 	function getStakedKeys() external view returns (uint256[] memory) {
 		return stakedKeys;
 	}
@@ -209,26 +220,39 @@ contract StakingPool is AccessControlUpgradeable {
 
     function stakeKeys(
         address owner,
-        uint256[] memory keyIds
+        uint256 keyAmount
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        uint256 keyLength = keyIds.length;
-        for (uint i = 0; i < keyLength; i++) {
-			// Update indexes of this user's staked keys
-            keyIdIndex[keyIds[i]] = stakedKeysOfOwner[owner].length;
-            stakedKeysOfOwner[owner].push(keyIds[i]);
 
-			// Update indexes of the pool's staked keys
-			stakedKeysIndices[keyIds[i]] = stakedKeys.length;
-			stakedKeys.push(keyIds[i]);
+        // Handle migration for key amounts
+        if(!hasMigratedToKeyAmount[owner]){
+            stakedKeyAmounts[owner] = stakedKeysOfOwner[owner].length;
+            hasMigratedToKeyAmount[owner] = true;
         }
+
+        // DEPRECATED WE NO LONGER TRACK KEY IDS
+        // uint256 keyLength = keyIds.length;
+        // for (uint i = 0; i < keyLength; i++) {
+		// 	// Update indexes of this user's staked keys
+        //     keyIdIndex[keyIds[i]] = stakedKeysOfOwner[owner].length;
+        //     stakedKeysOfOwner[owner].push(keyIds[i]);
+
+		// 	// Update indexes of the pool's staked keys
+		// 	stakedKeysIndices[keyIds[i]] = stakedKeys.length;
+		// 	stakedKeys.push(keyIds[i]);
+        // }
 
         distributeRewards();
         keyBucket.processAccount(owner);
-        keyBucket.setBalance(owner, stakedKeysOfOwner[owner].length);
+        keyBucket.setBalance(owner, stakedKeyAmounts[owner]);
     }
 
 	function createUnstakeKeyRequest(address user, uint256 keyAmount, uint256 period) external onlyRole(DEFAULT_ADMIN_ROLE) {
-		uint256 stakedKeysCount = stakedKeysOfOwner[user].length;
+        if(!hasMigratedToKeyAmount[user]){
+            stakedKeyAmounts[user] = stakedKeysOfOwner[user].length;
+            hasMigratedToKeyAmount[user] = true;
+        }
+
+		uint256 stakedKeysCount = stakedKeyAmounts[user];
 		uint256 requestKeys = userRequestedUnstakeKeyAmount[user];
 
 		if (poolOwner == user) {
@@ -263,7 +287,11 @@ contract StakingPool is AccessControlUpgradeable {
 
 	function createUnstakeOwnerLastKeyRequest(address owner, uint256 period) external onlyRole(DEFAULT_ADMIN_ROLE) {
 		require(owner == poolOwner, "17");
-		uint256 stakedKeysCount = stakedKeysOfOwner[owner].length;
+        if(!hasMigratedToKeyAmount[owner]){
+            stakedKeyAmounts[owner] = stakedKeysOfOwner[owner].length;
+            hasMigratedToKeyAmount[owner] = true;
+        }
+		uint256 stakedKeysCount = stakedKeyAmounts[owner];
 
 		require(
 			stakedKeysCount == userRequestedUnstakeKeyAmount[owner] + 1,

--- a/infrastructure/smart-contracts/contracts/staking-v2/StakingPool.sol
+++ b/infrastructure/smart-contracts/contracts/staking-v2/StakingPool.sol
@@ -242,6 +242,8 @@ contract StakingPool is AccessControlUpgradeable {
 		// 	stakedKeys.push(keyIds[i]);
         // }
 
+		stakedKeyAmounts[owner] += keyAmount;
+
         distributeRewards();
         keyBucket.processAccount(owner);
         keyBucket.setBalance(owner, stakedKeyAmounts[owner]);
@@ -379,6 +381,8 @@ contract StakingPool is AccessControlUpgradeable {
 		// 	stakedKeys[indexOfStakedKeyToRemove] = lastStakedKeyId;
 		// 	stakedKeys.pop();
         // }
+
+		stakedKeyAmounts[owner] -= keyAmount;
 
         distributeRewards();
         keyBucket.processAccount(owner);

--- a/infrastructure/smart-contracts/contracts/upgrades/StakingPool/StakingPool2.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/StakingPool/StakingPool2.sol
@@ -513,7 +513,7 @@ contract StakingPool2 is AccessControlUpgradeable {
         returns (
             uint256 userStakedEsXaiAmount,
             uint256 userClaimAmount,
-            uint256[] memory userStakedKeyIds,
+            uint256 userStakedKeyAmount,
             uint256 unstakeRequestkeyAmount, 
             uint256 unstakeRequestesXaiAmount
         )
@@ -534,9 +534,7 @@ contract StakingPool2 is AccessControlUpgradeable {
             userClaimAmount += poolOwnerClaimableRewards + ownerAmount;
         }
 
-        uint256 _userStakedKeysCount = getCurrentKeyAmount(user);
-        // TODO need to make sure what this will imply on the staking app
-        userStakedKeyIds = new uint256[](_userStakedKeysCount);
+        userStakedKeyAmount = getCurrentKeyAmount(user);
         
 		unstakeRequestkeyAmount = userRequestedUnstakeKeyAmount[user];
 		unstakeRequestesXaiAmount = userRequestedUnstakeEsXaiAmount[user];

--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense8.sol
@@ -864,7 +864,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         emit AdminMintTo(msg.sender, to, amount);
     }
 
-    
+    // TODO this will not work correctly until we refactor the logic about staked keys, we do not track key ids anymore
     /**
      * @notice Admin function to transfer batch. This wil not allow the same transferId to be used multiple times
      * @param to The address to transfer the tokens to
@@ -892,6 +892,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         emit AdminTransferBatch(msg.sender, to, transferId, tokenIds);
     }
 
+    // TODO this will not work correctly until we refactor the logic about staked keys, we do not track key ids anymore
     /**
      * @notice Overwrite ERC721 tranferFrom require TRANSFER_ROLE on msg.sender
      */
@@ -905,6 +906,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to);
     }
 
+    // TODO this will not work correctly until we refactor the logic about staked keys, we do not track key ids anymore
     /**
      * @notice Overwrite ERC721 safeTransferFrom require TRANSFER_ROLE on msg.sender
      */
@@ -918,6 +920,7 @@ contract NodeLicense8 is ERC721EnumerableUpgradeable, AccessControlUpgradeable  
         Referee10(refereeAddress).updateBulkSubmissionOnTransfer(from, to);
     }
 
+    // TODO this will not work correctly until we refactor the logic about staked keys, we do not track key ids anymore
     /**
      * @notice Overwrite ERC721 safeTransferFrom require TRANSFER_ROLE on msg.sender
      */

--- a/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
@@ -10,7 +10,7 @@ import "../../upgrades/referee/Referee10.sol";
 import "../../Xai.sol";
 import "../../upgrades/esXai/esXai2.sol";
 import "../../upgrades/node-license/NodeLicense8.sol";
-import "../../staking-v2/StakingPool.sol";
+import "../../upgrades/StakingPool/StakingPool2.sol";
 import "../../staking-v2/PoolProxyDeployer.sol";
 import "../../staking-v2/PoolBeacon.sol";
 
@@ -300,7 +300,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
             address esXaiBucketProxy
         ) = PoolProxyDeployer(deployerAddress).createPool();
 
-        StakingPool(poolProxy).initialize(
+        StakingPool2(poolProxy).initialize(
             refereeAddress,
             esXaiAddress,
             msg.sender,
@@ -309,13 +309,13 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
             esXaiBucketProxy
         );
 
-        StakingPool(poolProxy).initShares(
+        StakingPool2(poolProxy).initShares(
             _shareConfig[0],
             _shareConfig[1],
             _shareConfig[2]
         );
 
-        StakingPool(poolProxy).updateMetadata(_poolMetadata, _poolSocials);
+        StakingPool2(poolProxy).updateMetadata(_poolMetadata, _poolSocials);
 
         BucketTracker(keyBucketProxy).initialize(
             poolProxy,
@@ -379,7 +379,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         string[3] memory _poolMetadata,
         string[] memory _poolSocials
     ) external {
-        StakingPool stakingPool = StakingPool(pool);
+        StakingPool2 stakingPool = StakingPool2(pool);
         require(poolsCreatedViaFactory[pool], "35"); // Pool must be created via factory
         require(stakingPool.getPoolOwner() == msg.sender, "5"); // Only pool owner can update metadata
         stakingPool.updateMetadata(_poolMetadata, _poolSocials);
@@ -396,7 +396,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         address pool,
         uint32[3] memory _shareConfig
     ) external {
-        StakingPool stakingPool = StakingPool(pool);
+        StakingPool2 stakingPool = StakingPool2(pool);
         require(poolsCreatedViaFactory[pool], "35"); // Pool must be created via factory
         require(stakingPool.getPoolOwner() == msg.sender, "6"); // Only pool owner can update shares
         require(validateShareValues(_shareConfig), "7"); // Validate share configuration
@@ -431,7 +431,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
      * @param delegate The address of the new delegate owner.
      */
     function updateDelegateOwner(address pool, address delegate) external {
-        StakingPool stakingPool = StakingPool(pool);
+        StakingPool2 stakingPool = StakingPool2(pool);
         require(poolsCreatedViaFactory[pool], "34"); // Pool must be created via factory
         require(stakingPool.getPoolOwner() == msg.sender, "8"); // Only pool owner can update delegate
         require(msg.sender != delegate, "9"); // New delegate cannot be pool owner
@@ -480,7 +480,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         // The Referee will check for stakingEnabled and will only allow the admin to stake if staking is disabled
         referee.stakeKeys(pool, staker, keyAmounts, _asAdmin);
 
-        StakingPool stakingPool = StakingPool(pool);
+        StakingPool2 stakingPool = StakingPool2(pool);
         stakingPool.stakeKeys(staker, keyAmounts);
 
         associateUserWithPool(staker, pool);
@@ -553,7 +553,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
     function createUnstakeKeyRequest(address pool, uint256 keyAmount) external {
         require(keyAmount > 0, "13"); // At least 1 key required
         require(poolsCreatedViaFactory[pool], "14"); // Pool must be created via factory
-        StakingPool(pool).createUnstakeKeyRequest(
+        StakingPool2(pool).createUnstakeKeyRequest(
             msg.sender,
             keyAmount,
             unstakeKeysDelayPeriod
@@ -562,7 +562,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         emit UnstakeRequestStarted(
             msg.sender,
             pool,
-            StakingPool(pool).getUnstakeRequestCount(msg.sender) - 1,
+            StakingPool2(pool).getUnstakeRequestCount(msg.sender) - 1,
             keyAmount,
             true
         );
@@ -574,7 +574,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
      */
     function createUnstakeOwnerLastKeyRequest(address pool) external {
         require(poolsCreatedViaFactory[pool], "18"); // Pool must be created via factory
-        StakingPool(pool).createUnstakeOwnerLastKeyRequest(
+        StakingPool2(pool).createUnstakeOwnerLastKeyRequest(
             msg.sender,
             unstakeGenesisKeyDelayPeriod
         );
@@ -582,7 +582,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         emit UnstakeRequestStarted(
             msg.sender,
             pool,
-            StakingPool(pool).getUnstakeRequestCount(msg.sender) - 1,
+            StakingPool2(pool).getUnstakeRequestCount(msg.sender) - 1,
             1,
             true
         );
@@ -596,7 +596,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
     function createUnstakeEsXaiRequest(address pool, uint256 amount) external {
         require(amount > 0, "20"); // Amount must be greater than 0
         require(poolsCreatedViaFactory[pool], "22"); // Pool must be created via factory
-        StakingPool(pool).createUnstakeEsXaiRequest(
+        StakingPool2(pool).createUnstakeEsXaiRequest(
             msg.sender,
             amount,
             unstakeEsXaiDelayPeriod
@@ -605,7 +605,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         emit UnstakeRequestStarted(
             msg.sender,
             pool,
-            StakingPool(pool).getUnstakeRequestCount(msg.sender) - 1,
+            StakingPool2(pool).getUnstakeRequestCount(msg.sender) - 1,
             amount,
             false
         );
@@ -624,9 +624,9 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
     ) external {
         require(poolsCreatedViaFactory[pool], "23"); // Pool must be created via factory
 
-        StakingPool stakingPool = StakingPool(pool);
+        StakingPool2 stakingPool = StakingPool2(pool);
         // The Referee will check for stakingEnabled and will only allow the admin to stake if staking is disabled
-        stakingPool.unstakeKeys(msg.sender, unstakeRequestIndex, keyIds.length);
+        stakingPool.unstakeKeys(msg.sender, unstakeRequestIndex);
 
         Referee10(refereeAddress).unstakeKeys(pool, msg.sender, keyIds.length);
 
@@ -664,7 +664,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
 
         Referee10(refereeAddress).stakeEsXai(pool, amount);
         esXai(esXaiAddress).transferFrom(msg.sender, address(this), amount);
-        StakingPool stakingPool = StakingPool(pool);
+        StakingPool2 stakingPool = StakingPool2(pool);
         stakingPool.stakeEsXai(msg.sender, amount);
 
         associateUserWithPool(msg.sender, pool);
@@ -699,7 +699,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
     ) external {
         require(poolsCreatedViaFactory[pool], "28"); // Pool must be created via factory
 
-        StakingPool stakingPool = StakingPool(pool);
+        StakingPool2 stakingPool = StakingPool2(pool);
         stakingPool.unstakeEsXai(msg.sender, unstakeRequestIndex, amount);
 
         if (!stakingPool.isUserEngagedWithPool(msg.sender)) {
@@ -785,7 +785,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         for (uint i = 0; i < poolsLength; i++) {
             address stakingPool = pools[i];
             require(poolsCreatedViaFactory[stakingPool], "33"); // Pool must be created via factory
-            StakingPool(stakingPool).claimRewards(msg.sender);
+            StakingPool2(stakingPool).claimRewards(msg.sender);
             emit ClaimFromPool(msg.sender, stakingPool);
         }
     }
@@ -814,7 +814,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         return
             (poolsOfDelegate[delegate].length > poolsOfDelegateIndices[pool] &&
                 poolsOfDelegate[delegate][poolsOfDelegateIndices[pool]] ==
-                pool) || StakingPool(pool).getPoolOwner() == delegate;
+                pool) || StakingPool2(pool).getPoolOwner() == delegate;
     }
 
     /**
@@ -867,39 +867,39 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         return interactedPoolsOfUser[user][index];
     }
 
-    /**
-     * @dev DEPRECATED we do no longer track key IDs
-     * @notice Returns the list of unstaked key IDs for a user.
-     * @param user The address of the user.
-     * @param offset The offset for pagination.
-     * @param pageLimit The limit for pagination.
-     * @return unstakedKeyIds Array of unstaked key IDs.
-     */
-    function getUnstakedKeyIdsFromUser(
-        address user,
-        uint16 offset,
-        uint16 pageLimit
-    ) external view returns (uint256[] memory unstakedKeyIds) {
-        uint256 userKeyBalance = NodeLicense(nodeLicenseAddress).balanceOf(
-            user
-        );
-        unstakedKeyIds = new uint256[](pageLimit);
-        uint256 currentIndexUnstaked = 0;
-        uint256 limit = offset + pageLimit;
+    // /**
+    //  * @dev DEPRECATED we do no longer track key IDs
+    //  * @notice Returns the list of unstaked key IDs for a user.
+    //  * @param user The address of the user.
+    //  * @param offset The offset for pagination.
+    //  * @param pageLimit The limit for pagination.
+    //  * @return unstakedKeyIds Array of unstaked key IDs.
+    //  */
+    // function getUnstakedKeyIdsFromUser(
+    //     address user,
+    //     uint16 offset,
+    //     uint16 pageLimit
+    // ) external view returns (uint256[] memory unstakedKeyIds) {
+    //     uint256 userKeyBalance = NodeLicense(nodeLicenseAddress).balanceOf(
+    //         user
+    //     );
+    //     unstakedKeyIds = new uint256[](pageLimit);
+    //     uint256 currentIndexUnstaked = 0;
+    //     uint256 limit = offset + pageLimit;
 
-        for (uint256 i = offset; i < userKeyBalance && i < limit; i++) {
-            uint256 keyId = NodeLicense(nodeLicenseAddress).tokenOfOwnerByIndex(
-                user,
-                i
-            );
-            if (
-                Referee10(refereeAddress).assignedKeyToPool(keyId) == address(0)
-            ) {
-                unstakedKeyIds[currentIndexUnstaked] = keyId;
-                currentIndexUnstaked++;
-            }
-        }
-    }
+    //     for (uint256 i = offset; i < userKeyBalance && i < limit; i++) {
+    //         uint256 keyId = NodeLicense(nodeLicenseAddress).tokenOfOwnerByIndex(
+    //             user,
+    //             i
+    //         );
+    //         if (
+    //             Referee10(refereeAddress).assignedKeyToPool(keyId) == address(0)
+    //         ) {
+    //             unstakedKeyIds[currentIndexUnstaked] = keyId;
+    //             currentIndexUnstaked++;
+    //         }
+    //     }
+    // }
 
     // DEPRECATED we do no longer track key IDs
     // THis function is not used anywhere
@@ -925,7 +925,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         require(poolsCreatedViaFactory[pool], "35"); // Pool must be created via factory
 
         if(!isDelegateOfPoolOrOwner(user, pool)){
-            (uint256 userStakedEsXaiAmount, ,uint256[] memory userStakedKeyIds, ,) = StakingPool(pool).getUserPoolData(user);
+            (uint256 userStakedEsXaiAmount, ,uint256[] memory userStakedKeyIds, ,) = StakingPool2(pool).getUserPoolData(user);
             return userStakedEsXaiAmount > 0 || userStakedKeyIds.length > 0;
         }
 
@@ -957,7 +957,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         uint256 totalStakeAmount = 0;
         address[] memory userPools = interactedPoolsOfUser[user];
         for (uint256 i = 0; i < userPools.length; i++) {
-            totalStakeAmount += StakingPool(userPools[i]).getStakedAmounts(user);
+            totalStakeAmount += StakingPool2(userPools[i]).getStakedAmounts(user);
         }
         return totalStakeAmount;
     }
@@ -978,7 +978,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
             address[] storage userPools = interactedPoolsOfUser[users[i]]; // Use storage instead of memory
             uint256 poolCount = userPools.length; // Cache length for gas optimization
             for (uint256 j = 0; j < poolCount; j++) {
-                totalStakeAmount += StakingPool(userPools[j]).getStakedAmounts(users[i]);
+                totalStakeAmount += StakingPool2(userPools[j]).getStakedAmounts(users[i]);
             }
             _totalEsXaiStakeByUser[users[i]] = totalStakeAmount;
             totalEsXaiStakeCalculated[users[i]] = true;

--- a/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
@@ -624,12 +624,11 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
     ) external {
         require(poolsCreatedViaFactory[pool], "23"); // Pool must be created via factory
 
-        Referee10(refereeAddress).unstakeKeys(pool, msg.sender, keyIds.length);
-
         StakingPool stakingPool = StakingPool(pool);
-        
         // The Referee will check for stakingEnabled and will only allow the admin to stake if staking is disabled
         stakingPool.unstakeKeys(msg.sender, unstakeRequestIndex, keyIds.length);
+
+        Referee10(refereeAddress).unstakeKeys(pool, msg.sender, keyIds.length);
 
         if (!stakingPool.isUserEngagedWithPool(msg.sender)) {
             removeUserFromPool(msg.sender, pool);

--- a/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory2.sol
@@ -135,6 +135,8 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         address indexed poolOwner,
         uint256 stakedKeyCount
     );
+
+    // "keyIds" field is deprecated, we do no longer track key ids on stake
     event PoolCreatedV2(
         uint256 indexed poolIndex,
         address indexed poolAddress,
@@ -175,6 +177,8 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         uint256 totalUserKeysStaked,
         uint256 totalKeysStaked
     );
+
+    // "keyIds" field is deprecated, we do no longer track key ids on stake
     event StakeKeysV2(
         address indexed user,
         address indexed pool,
@@ -190,6 +194,8 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
         uint256 totalUserKeysStaked,
         uint256 totalKeysStaked
     );
+
+    // "keyIds" field is deprecated, we do no longer track key ids on stake
     event UnstakeKeysV2(
         address indexed user,
         address indexed pool,
@@ -498,7 +504,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
             keyAmounts,
             stakingPool.getStakedKeysCountForUser(staker),
             stakingPool.getStakedKeysCount(),
-            new uint256[](keyAmounts)
+            new uint256[](0)
         );
     }
 
@@ -648,7 +654,7 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
             stakingPool.getStakedKeysCountForUser(msg.sender),
             stakingPool.getStakedKeysCount(),
             unstakeRequestIndex,
-            keyIds
+            new uint256[](0)
         );
     }
 
@@ -923,9 +929,9 @@ contract PoolFactory2 is Initializable, AccessControlEnumerableUpgradeable {
     ) external view returns (bool) {
         require(poolsCreatedViaFactory[pool], "35"); // Pool must be created via factory
 
+            (uint256 userStakedEsXaiAmount, ,uint256 userStakedKeyAmount, ,) = StakingPool2(pool).getUserPoolData(user);
         if(!isDelegateOfPoolOrOwner(user, pool)){
-            (uint256 userStakedEsXaiAmount, ,uint256[] memory userStakedKeyIds, ,) = StakingPool2(pool).getUserPoolData(user);
-            return userStakedEsXaiAmount > 0 || userStakedKeyIds.length > 0;
+            return userStakedEsXaiAmount > 0 || userStakedKeyAmount > 0;
         }
 
         return true;

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee10.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee10.sol
@@ -57,10 +57,10 @@ import "../../RefereeCalculations.sol";
 // 42: Must complete KYC.
 // 43: Maximum staking amount exceeded.
 // 44: Key already assigned.
-// 45: Not owner of key.
+// 45: Not enough unstaked keys available for stake.
 // 46: Pool owner needs at least 1 staked key.
 // 47: Key not assigned to pool.
-// 48: Not owner of key.
+// 48: Not enough staked keys in pool for unstake.
 // 49: Maximum staking amount exceeded.
 // 50: Invalid amount.
 // 51: Invalid stake rewards tier percentage.
@@ -143,6 +143,7 @@ contract Referee10 is Initializable, AccessControlEnumerableUpgradeable {
     // Enabling staking on the Referee
     bool public stakingEnabled;
 
+    // DEPRECATED We do not track keyIds anymore, this mapping is not updated anymore
     // Mapping for a key id assigned to a staking pool
     mapping(uint256 => address) public assignedKeyToPool;
 
@@ -618,6 +619,7 @@ contract Referee10 is Initializable, AccessControlEnumerableUpgradeable {
             address owner = NodeLicense(nodeLicenseAddress).ownerOf(_nodeLicenseId);
             Submission storage submission = submissions[_challengeId][_nodeLicenseId];
             
+            // TODO we need to find a way to have people claim their old key based submissions and transfer the reward to the right pool / owner
             address rewardReceiver = assignedKeyToPool[_nodeLicenseId];
             if (rewardReceiver == address(0)) {
                 rewardReceiver = owner;
@@ -759,31 +761,35 @@ contract Referee10 is Initializable, AccessControlEnumerableUpgradeable {
         emit UnstakeV1(msg.sender, amount, stakedAmounts[msg.sender]);
     }
 
-    function stakeKeys(address pool, address staker, uint256[] memory keyIds, bool isAdminStake) external onlyPoolFactory {
+    function stakeKeys(address pool, address staker, uint256 keyAmount, bool isAdminStake) external onlyPoolFactory {
         require(isAdminStake || stakingEnabled, "52");
 
-        uint256 keysLength = keyIds.length;
         // Check if the pool has enough capacity to stake the keys
-        require(assignedKeysToPoolCount[pool] + keysLength <= maxKeysPerPool, "43");
-
-        uint256 currentChallenge = challengeCounter - 1;
+        require(assignedKeysToPoolCount[pool] + keyAmount <= maxKeysPerPool, "43");
 
         NodeLicense nodeLicenseContract = NodeLicense(nodeLicenseAddress);
+        uint256 ownedKeyAmount = nodeLicenseContract.balanceOf(staker);
+
+        require(ownedKeyAmount >= assignedKeysOfUserCount[staker] + keyAmount, "45");
+
+        // DEPRECATED We do not track keyIds anymore, we only check if the staker has enough unstaked keys available
         // Assign the keys to the pool
-        for (uint256 i = 0; i < keysLength; i++) {
-            uint256 keyId = keyIds[i];
-            // Check if the key is not already assigned to a pool
-            require(assignedKeyToPool[keyId] == address(0), "44");
-            if(!isAdminStake){
-                // If not admin stake, check if the staker is the owner of the key
-                require(nodeLicenseContract.ownerOf(keyId) == staker, "45");
-            }
-            assignedKeyToPool[keyId] = pool;
-        }
+        // for (uint256 i = 0; i < keysLength; i++) {
+        //     uint256 keyId = keyIds[i];
+        //     // Check if the key is not already assigned to a pool
+        //     require(assignedKeyToPool[keyId] == address(0), "44");
+        //     if(!isAdminStake){
+        //         // If not admin stake, check if the staker is the owner of the key
+        //         require(nodeLicenseContract.ownerOf(keyId) == staker, "45");
+        //     }
+        //     assignedKeyToPool[keyId] = pool;
+        // }
 
         // Update the user and pool staked key counts
-        assignedKeysToPoolCount[pool] += keysLength;
-        assignedKeysOfUserCount[staker] += keysLength;
+        assignedKeysToPoolCount[pool] += keyAmount;
+        assignedKeysOfUserCount[staker] += keyAmount;
+
+        uint256 currentChallenge = challengeCounter - 1;
 
         // If the pool has submitted for the current challenge, update the pool bulk submission
         if(bulkSubmissions[currentChallenge][pool].submitted){
@@ -796,20 +802,21 @@ contract Referee10 is Initializable, AccessControlEnumerableUpgradeable {
         }
     }
 
-    function unstakeKeys(address pool, address staker, uint256[] memory keyIds) external onlyPoolFactory {
+    function unstakeKeys(address pool, address staker, uint256 keyAmount) external onlyPoolFactory {
         require(stakingEnabled, "52");
 
-        uint256 keysLength = keyIds.length;
         NodeLicense nodeLicenseContract = NodeLicense(nodeLicenseAddress);
 
-        for (uint256 i = 0; i < keysLength; i++) {
-            uint256 keyId = keyIds[i];
-            require(assignedKeyToPool[keyId] == pool, "47");
-            require(nodeLicenseContract.ownerOf(keyId) == staker, "48");
-            assignedKeyToPool[keyId] = address(0);
-        }
-        assignedKeysToPoolCount[pool] -= keysLength;
-        assignedKeysOfUserCount[staker] -= keysLength;
+        // DEPRECATED We do not track keyIds anymore, we only check if the staker has enough staked keys
+        // for (uint256 i = 0; i < keysLength; i++) {
+        //     uint256 keyId = keyIds[i];
+        //     require(assignedKeyToPool[keyId] == pool, "47");
+        //     require(nodeLicenseContract.ownerOf(keyId) == staker, "48");
+        //     assignedKeyToPool[keyId] = address(0);
+        // }
+
+        assignedKeysToPoolCount[pool] -= keyAmount;
+        assignedKeysOfUserCount[staker] -= keyAmount;
         
         uint256 currentChallenge = challengeCounter - 1;
 

--- a/infrastructure/smart-contracts/test/stakingv2/StakeKeysToPool.mjs
+++ b/infrastructure/smart-contracts/test/stakingv2/StakeKeysToPool.mjs
@@ -32,7 +32,7 @@ export function StakeKeysToPool(deployInfrastructure, poolConfigurations) {
 	} = poolConfigurations;
 
 	return function () {
-		it("Verify the Pool Info for the staked user (should have keyCount, userStakedKeyIds)", async function () {
+		it("Verify the Pool Info for the staked user (should have keyCount, userStakedKeyAmount)", async function () {
 			const {poolFactory, addr1, nodeLicense, referee, challenger} = await loadFixture(deployInfrastructure);
 
 			// Mint a node key & save the id
@@ -71,8 +71,7 @@ export function StakeKeysToPool(deployInfrastructure, poolConfigurations) {
 			const userPoolData = await stakingPool.connect(addr1).getUserPoolData(await addr1.getAddress());
 
 			expect(stakedKeysCountForUser).to.equal(1);
-			expect(userPoolData.userStakedKeyIds.length).to.equal(1);
-			expect(userPoolData.userStakedKeyIds[0]).to.equal(mintedKeyId);
+			expect(userPoolData.userStakedKeyAmount).to.equal(1);
 		});
 
 		it("Check that the key is assigned to the pool in the Referee (assignedKeyToPool)", async function () {

--- a/packages/core/src/node-license/getKeysOfPool.ts
+++ b/packages/core/src/node-license/getKeysOfPool.ts
@@ -4,6 +4,8 @@ import { getProvider } from '../utils/getProvider.js';
 import { retry } from "../index.js";
 import { StakingPoolAbi } from '../abis/StakingPoolAbi.js';
 
+// TODO REMOVE for deprecation for key id amounts
+
 /**
  * Fetches all keys staked in a pool.
  * @param poolAddress - The address of the pool.

--- a/packages/core/src/node-license/getUnStakedKeysOfUser.ts
+++ b/packages/core/src/node-license/getUnStakedKeysOfUser.ts
@@ -4,6 +4,8 @@ import { config } from '../config.js';
 import { ethers } from 'ethers';
 import { getUserNodeLicenseBalance } from './index.js';
 
+
+// TODO getUnstakedKeyIdsFromUser is deprecated in PoolFactory2
 /**
  * Retrieves a specified number of unstaked keys for a given user.
  * 


### PR DESCRIPTION
This removes all key id dependencies from the staking implementation.

Update the StakingPool to version 2 that will only receive keyAmounts and will handle the internal state migration.
Update the PoolFactory2 to only pass keyAmounts to the StakingPool.
Update the Referee10 to not track the state for key ids assigned to a pool.
Update the TinyKeyAidrop to not stop processing and remove the id mapping.

This will compile, however, the testcases need to be updated for not having assignedKeyToPool on the Referee anymore.

