### PR TITLE
Update Keysale Page to support batch mints

### DIFF
--- a/apps/web-connect/src/assets/pagecontent/de.json
+++ b/apps/web-connect/src/assets/pagecontent/de.json
@@ -84,6 +84,7 @@
         },
         "actionSection": {
             "mintWithOptions": "Prägen - Kredit/Debit, SOL, ETH, USDC",
+			"mintWithOptionsDisabled": "Crossmint maximal 175 Schlüssel pro Transaktion",
             "tokenButtonTexts": {
                 "isPending": "WARTET AUF BESTÄTIGUNG..",
                 "switchToArbitrum": "Bitte wechseln Sie zu Arbitrum"

--- a/apps/web-connect/src/assets/pagecontent/de.json
+++ b/apps/web-connect/src/assets/pagecontent/de.json
@@ -84,7 +84,7 @@
         },
         "actionSection": {
             "mintWithOptions": "Prägen - Kredit/Debit, SOL, ETH, USDC",
-			"mintWithOptionsDisabled": "Crossmint maximal 175 Schlüssel pro Transaktion",
+            "mintWithOptionsDisabled": "Crossmint maximal 175 Schlüssel pro Transaktion",
             "tokenButtonTexts": {
                 "isPending": "WARTET AUF BESTÄTIGUNG..",
                 "switchToArbitrum": "Bitte wechseln Sie zu Arbitrum"

--- a/apps/web-connect/src/assets/pagecontent/en.json
+++ b/apps/web-connect/src/assets/pagecontent/en.json
@@ -84,6 +84,7 @@
 		},
 		"actionSection": {
 			"mintWithOptions": "Mint - Credit/Debit, SOL, ETH, USDC",
+			"mintWithOptionsDisabled": "Crossmint Max 175 keys per txn",
 			"tokenButtonTexts": {
 				"isPending": "WAITING FOR CONFIRMATION..",
 				"switchToArbitrum": "Please Switch to Arbitrum"

--- a/apps/web-connect/src/features/checkout/Checkout.tsx
+++ b/apps/web-connect/src/features/checkout/Checkout.tsx
@@ -39,7 +39,10 @@ export function Checkout() {
         mintWithEth,
         mintWithXai,
         approve,
-        mintWithCrossmint
+        mintWithCrossmint,
+        isBatchMinting,
+        txHashes,
+        //batchMintTx
     } = useWebBuyKeysContext();
 
     useEffect(() => {
@@ -63,9 +66,9 @@ export function Checkout() {
     return (
         <div>
             <div className="h-full xl:min-h-screen flex-1 flex flex-col justify-center items-center">
-                {mintWithEth.isPending || mintWithXai.isPending || approve.isPending || mintWithCrossmint.isPending ? (
+                {mintWithEth.isPending || mintWithXai.isPending || approve.isPending || mintWithCrossmint.isPending || isBatchMinting ? (
                     <TransactionInProgress />
-                ) : mintWithEth.isSuccess || mintWithXai.isSuccess || mintWithCrossmint.txHash != "" ? (
+                ) : mintWithEth.isSuccess || mintWithXai.isSuccess || mintWithCrossmint.txHash != "" || (!isBatchMinting && txHashes.length > 0) ? (
                     <PurchaseSuccessful returnToClient={returnToClient} />
                 ) : (
                     <div className="h-auto sm:w-[90%] lg:w-auto flex sm:flex-col lg:flex-row justify-center bg-nulnOil shadow-main md:my-0 my-[24px]">

--- a/apps/web-connect/src/features/checkout/components/ActionSection.tsx
+++ b/apps/web-connect/src/features/checkout/components/ActionSection.tsx
@@ -5,12 +5,11 @@ import { WarningIcon } from "@sentry/ui/src/rebrand/icons";
 import { mapWeb3Error } from "@/utils/errors";
 import { useWebBuyKeysContext } from '../contexts/useWebBuyKeysContext';
 import CrossmintModal from './crossmint/CrossmintModal';
-import { isValidNetwork } from '@sentry/core';
+import { config, isValidNetwork } from '@sentry/core';
 import { useNetworkConfig } from '@/hooks/useNetworkConfig';
 import { convertEthAmountToUsdcAmount } from '@/utils/convertEthAmountToUsdcAmount';
 import { useTranslation } from "react-i18next";
 import ReactGA from "react-ga4";
-import { MAX_BATCH_SIZE } from '@/features/hooks/contract/useMintBatch';
 
 
 /**
@@ -27,6 +26,8 @@ export function ActionSection(): JSX.Element {
     const { isDevelopment } = useNetworkConfig();
     const [isInitialized, setIsInitialized] = useState(false);
     const [totalPriceInUsdc, setTotalPriceInUsdc] = useState<string>("0");
+    
+    const MAX_BATCH_SIZE = config.maxBatchMintSize;
 
     // Destructure values and functions from the context
     const {

--- a/apps/web-connect/src/features/checkout/components/ActionSection.tsx
+++ b/apps/web-connect/src/features/checkout/components/ActionSection.tsx
@@ -75,20 +75,12 @@ export function ActionSection(): JSX.Element {
         if (isApprove) {
             handleApproveClicked();
         } else {
-            if(quantity > MAX_BATCH_SIZE) { 
-                mintBatch(quantity);
-            }else{
-                mintWithXaiSingleTx();
-            }
+            quantity > MAX_BATCH_SIZE ? mintBatch(quantity) : mintWithXaiSingleTx();
         }
     };
 
     const handleMintWithEthButtonClicked = async () => {
-        if(quantity > MAX_BATCH_SIZE) { 
-            mintBatch(quantity);
-        }else{
-            mintWithEthSingleTx();
-        }
+        quantity > MAX_BATCH_SIZE ? mintBatch(quantity) : mintWithEthSingleTx();
     }
 
     useEffect(() => {

--- a/apps/web-connect/src/features/checkout/components/ActionSection.tsx
+++ b/apps/web-connect/src/features/checkout/components/ActionSection.tsx
@@ -51,7 +51,7 @@ export function ActionSection(): JSX.Element {
         mintWithCrossmint,
         discount,
         mintBatch,
-        //batchMintTx
+        mintBatchError
     } = useWebBuyKeysContext();
 
     const { t: translate } = useTranslation("Checkout");    
@@ -170,7 +170,10 @@ export function ActionSection(): JSX.Element {
                                 </div>
                             </BaseCallout>
                         )}
-                        {/* {mapWeb3Error(batchMintTx.error) === "User rejected the request" && (
+                    </div>
+                )}
+                {/* Error section for Batch transactions */}                
+                {mintBatchError && mapWeb3Error(mintBatchError) === "User rejected the request" && (
                             <BaseCallout extraClasses={{ calloutWrapper: "md:h-[85px] h-[109px] mt-[12px]", calloutFront: "!justify-start" }} isWarning>
                                 <div className="flex md:gap-[21px] gap-[10px]">
                                     <span className="block mt-2"><WarningIcon /></span>
@@ -180,9 +183,7 @@ export function ActionSection(): JSX.Element {
                                     </div>
                                 </div>
                             </BaseCallout>
-                        )} */}
-                    </div>
-                )}
+                        )}
 
                 {/* Error section for Xai/esXai transactions */}
                 {mintWithXai.error && (

--- a/apps/web-connect/src/features/checkout/components/ActionSection.tsx
+++ b/apps/web-connect/src/features/checkout/components/ActionSection.tsx
@@ -49,8 +49,14 @@ export function ActionSection(): JSX.Element {
         setCurrency,
         mintWithCrossmint,
         discount,
+        mintBatch,
+        //batchMintTx
     } = useWebBuyKeysContext();
-    const { t: translate } = useTranslation("Checkout");
+
+    //const mintBatch = useMintBatch({promoCode, calculateTotalPrice, currency, discountInfo: discount});
+
+    const { t: translate } = useTranslation("Checkout");    
+    const exceedsCrossmintMax = quantity > 175;
 
     /**
      * Determines the text to display on the main action button for token transactions
@@ -69,9 +75,22 @@ export function ActionSection(): JSX.Element {
         if (isApprove) {
             handleApproveClicked();
         } else {
-            handleMintWithXaiClicked();
+            if(quantity > 5) { 
+                mintBatch(quantity);
+            }else{
+                handleMintWithXaiClicked();
+            }
         }
     };
+
+    const handleMintWithEthClicked2 = async () => {
+        console.log("quantity: ", quantity);
+        if(quantity > 5) { 
+            mintBatch(quantity);
+        }else{
+            handleMintWithEthClicked();
+        }
+    }
 
     useEffect(() => {
         async function setUsdcPrice(){
@@ -91,7 +110,7 @@ export function ActionSection(): JSX.Element {
                     <>
                     <PrimaryButton
                         onClick={() => {
-                            handleMintWithEthClicked()
+                            handleMintWithEthClicked2()
                             ReactGA.event({
                                 category: 'User',
                                 action: 'buttonClick',
@@ -123,9 +142,9 @@ export function ActionSection(): JSX.Element {
                         setCurrency("AETH"); // Currency must be AETH for USDC Calculation used in Crossmint
                     }}
                     className={`w-full h-16 ${ready ? "bg-[#F30919] global-clip-path" : "bg-gray-400 cursor-default !text-[#726F6F]"} text-lg text-hornetSting p-2 uppercase font-bold `}
-                    isDisabled={!ready || !isConnected}
+                    isDisabled={!ready || !isConnected || exceedsCrossmintMax}
                     colorStyle="outline-2"
-                    btnText={translate("actionSection.mintWithOptions")}
+                    btnText={exceedsCrossmintMax ? translate("actionSection.mintWithOptionsDisabled") : translate("actionSection.mintWithOptions")}
                 />}
 
                 {/* Error section for ETH transactions */}
@@ -153,6 +172,17 @@ export function ActionSection(): JSX.Element {
                                 </div>
                             </BaseCallout>
                         )}
+                        {/* {mapWeb3Error(batchMintTx.error) === "User rejected the request" && (
+                            <BaseCallout extraClasses={{ calloutWrapper: "md:h-[85px] h-[109px] mt-[12px]", calloutFront: "!justify-start" }} isWarning>
+                                <div className="flex md:gap-[21px] gap-[10px]">
+                                    <span className="block mt-2"><WarningIcon /></span>
+                                    <div>
+                                        <span className="block font-bold text-lg">{translate("actionSection.mintWithEthError.userRejectedRequest.title")}</span>
+                                        <span className="block font-medium text-lg">{translate("actionSection.mintWithEthError.userRejectedRequest.title")}</span>
+                                    </div>
+                                </div>
+                            </BaseCallout>
+                        )} */}
                     </div>
                 )}
 

--- a/apps/web-connect/src/features/checkout/components/ActionSection.tsx
+++ b/apps/web-connect/src/features/checkout/components/ActionSection.tsx
@@ -10,6 +10,7 @@ import { useNetworkConfig } from '@/hooks/useNetworkConfig';
 import { convertEthAmountToUsdcAmount } from '@/utils/convertEthAmountToUsdcAmount';
 import { useTranslation } from "react-i18next";
 import ReactGA from "react-ga4";
+import { MAX_BATCH_SIZE } from '@/features/hooks/contract/useMintBatch';
 
 
 /**
@@ -53,8 +54,6 @@ export function ActionSection(): JSX.Element {
         //batchMintTx
     } = useWebBuyKeysContext();
 
-    //const mintBatch = useMintBatch({promoCode, calculateTotalPrice, currency, discountInfo: discount});
-
     const { t: translate } = useTranslation("Checkout");    
     const exceedsCrossmintMax = quantity > 175;
 
@@ -75,7 +74,7 @@ export function ActionSection(): JSX.Element {
         if (isApprove) {
             handleApproveClicked();
         } else {
-            if(quantity > 5) { 
+            if(quantity > MAX_BATCH_SIZE) { 
                 mintBatch(quantity);
             }else{
                 handleMintWithXaiClicked();

--- a/apps/web-connect/src/features/checkout/components/ActionSection.tsx
+++ b/apps/web-connect/src/features/checkout/components/ActionSection.tsx
@@ -55,7 +55,7 @@ export function ActionSection(): JSX.Element {
     } = useWebBuyKeysContext();
 
     const { t: translate } = useTranslation("Checkout");    
-    const exceedsCrossmintMax = quantity > 175;
+    const exceedsCrossmintMax = quantity > MAX_BATCH_SIZE;
 
     /**
      * Determines the text to display on the main action button for token transactions

--- a/apps/web-connect/src/features/checkout/components/ActionSection.tsx
+++ b/apps/web-connect/src/features/checkout/components/ActionSection.tsx
@@ -167,16 +167,16 @@ export function ActionSection(): JSX.Element {
                 )}
                 {/* Error section for Batch transactions */}                
                 {mintBatchError && mapWeb3Error(mintBatchError) === "User rejected the request" && (
-                            <BaseCallout extraClasses={{ calloutWrapper: "md:h-[85px] h-[109px] mt-[12px]", calloutFront: "!justify-start" }} isWarning>
-                                <div className="flex md:gap-[21px] gap-[10px]">
-                                    <span className="block mt-2"><WarningIcon /></span>
-                                    <div>
-                                        <span className="block font-bold text-lg">{translate("actionSection.mintWithEthError.userRejectedRequest.title")}</span>
-                                        <span className="block font-medium text-lg">{translate("actionSection.mintWithEthError.userRejectedRequest.title")}</span>
-                                    </div>
-                                </div>
-                            </BaseCallout>
-                        )}
+                    <BaseCallout extraClasses={{ calloutWrapper: "md:h-[85px] h-[109px] mt-[12px]", calloutFront: "!justify-start" }} isWarning>
+                        <div className="flex md:gap-[21px] gap-[10px]">
+                            <span className="block mt-2"><WarningIcon /></span>
+                            <div>
+                                <span className="block font-bold text-lg">{translate("actionSection.mintWithEthError.userRejectedRequest.title")}</span>
+                                <span className="block font-medium text-lg">{translate("actionSection.mintWithEthError.userRejectedRequest.title")}</span>
+                            </div>
+                        </div>
+                    </BaseCallout>
+                )}
 
                 {/* Error section for Xai/esXai transactions */}
                 {mintWithXai.error && (

--- a/apps/web-connect/src/features/checkout/components/ActionSection.tsx
+++ b/apps/web-connect/src/features/checkout/components/ActionSection.tsx
@@ -82,9 +82,8 @@ export function ActionSection(): JSX.Element {
         }
     };
 
-    const handleMintWithEthClicked2 = async () => {
-        console.log("quantity: ", quantity);
-        if(quantity > 5) { 
+    const handleMintWithEthButtonClicked = async () => {
+        if(quantity > MAX_BATCH_SIZE) { 
             mintBatch(quantity);
         }else{
             handleMintWithEthClicked();
@@ -109,7 +108,7 @@ export function ActionSection(): JSX.Element {
                     <>
                     <PrimaryButton
                         onClick={() => {
-                            handleMintWithEthClicked2()
+                            handleMintWithEthButtonClicked()
                             ReactGA.event({
                                 category: 'User',
                                 action: 'buttonClick',

--- a/apps/web-connect/src/features/checkout/components/ActionSection.tsx
+++ b/apps/web-connect/src/features/checkout/components/ActionSection.tsx
@@ -43,8 +43,8 @@ export function ActionSection(): JSX.Element {
         isConnected,
         getApproveButtonText,
         handleApproveClicked,
-        handleMintWithEthClicked,
-        handleMintWithXaiClicked,
+        mintWithEthSingleTx,
+        mintWithXaiSingleTx,
         getEthButtonText,
         calculateTotalPrice,
         setCurrency,
@@ -77,7 +77,7 @@ export function ActionSection(): JSX.Element {
             if(quantity > MAX_BATCH_SIZE) { 
                 mintBatch(quantity);
             }else{
-                handleMintWithXaiClicked();
+                mintWithXaiSingleTx();
             }
         }
     };
@@ -86,7 +86,7 @@ export function ActionSection(): JSX.Element {
         if(quantity > MAX_BATCH_SIZE) { 
             mintBatch(quantity);
         }else{
-            handleMintWithEthClicked();
+            mintWithEthSingleTx();
         }
     }
 

--- a/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
+++ b/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
@@ -74,7 +74,7 @@ export function ChooseQuantityRow(): JSX.Element {
             </div>
             {/* Quantity input section */}
             <div className="flex w-full justify-end flex-row items-start gap-4 sm:mt-4 lg:mt-10">
-                <div className="flex sm:w-full lg:w-[210px] sm:px-2 lg:px-0">
+                <div className="flex sm:w-full lg:w-[240px] sm:px-2 lg:px-0">
                     {/* Custom number input component for selecting quantity */}
                     <XaiNumberInput
                         quantity={quantity}

--- a/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
+++ b/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
@@ -74,7 +74,7 @@ export function ChooseQuantityRow(): JSX.Element {
             </div>
             {/* Quantity input section */}
             <div className="flex w-full justify-end flex-row items-start gap-4 sm:mt-4 lg:mt-10">
-                <div className="flex sm:w-full lg:w-[200px] sm:px-2 lg:px-0 lg:mr-5">
+                <div className="flex sm:w-full lg:w-[200px] sm:px-2 lg:px-0">
                     {/* Custom number input component for selecting quantity */}
                     <XaiNumberInput
                         quantity={quantity}

--- a/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
+++ b/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from "react-i18next";
  */
 export function ChooseQuantityRow(): JSX.Element {
 
-    const MAX_PER_PURCHASE = 175;
+    const MAX_PER_PURCHASE = 99999;
 
     // Destructure necessary values from the WebBuyKeysContext
     const { quantity, setQuantity, maxSupply } = useWebBuyKeysContext();
@@ -68,13 +68,13 @@ export function ChooseQuantityRow(): JSX.Element {
 
 
                 {/* Description of Sentry Key functionality */}
-                <p className="sm:w-full lg:w-[400px] sm:text-center sm:px-8 lg:px-0 lg:text-left text-[18px] text-elementalGrey font-medium">
+                <p className="sm:w-full lg:w-[330px] sm:text-center sm:px-8 lg:px-0 lg:text-left text-[18px] text-elementalGrey font-medium">
                     {translate("chooseQuantity.description")}
                 </p>     
             </div>
             {/* Quantity input section */}
             <div className="flex w-full justify-end flex-row items-start gap-4 sm:mt-4 lg:mt-10">
-                <div className="flex sm:w-full lg:w-[175px] sm:px-2 lg:px-0 lg:mr-5">
+                <div className="flex sm:w-full lg:w-[200px] sm:px-2 lg:px-0 lg:mr-5">
                     {/* Custom number input component for selecting quantity */}
                     <XaiNumberInput
                         quantity={quantity}

--- a/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
+++ b/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
@@ -74,7 +74,7 @@ export function ChooseQuantityRow(): JSX.Element {
             </div>
             {/* Quantity input section */}
             <div className="flex w-full justify-end flex-row items-start gap-4 sm:mt-4 lg:mt-10">
-                <div className="flex sm:w-full lg:w-[230px] sm:px-2 lg:px-0">
+                <div className="flex sm:w-full lg:w-[200px] sm:px-2 lg:px-0">
                     {/* Custom number input component for selecting quantity */}
                     <XaiNumberInput
                         quantity={quantity}

--- a/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
+++ b/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
@@ -74,7 +74,7 @@ export function ChooseQuantityRow(): JSX.Element {
             </div>
             {/* Quantity input section */}
             <div className="flex w-full justify-end flex-row items-start gap-4 sm:mt-4 lg:mt-10">
-                <div className="flex sm:w-full lg:w-[200px] sm:px-2 lg:px-0">
+                <div className="flex sm:w-full lg:w-[210px] sm:px-2 lg:px-0">
                     {/* Custom number input component for selecting quantity */}
                     <XaiNumberInput
                         quantity={quantity}

--- a/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
+++ b/apps/web-connect/src/features/checkout/components/ChooseQuantityRow.tsx
@@ -74,7 +74,7 @@ export function ChooseQuantityRow(): JSX.Element {
             </div>
             {/* Quantity input section */}
             <div className="flex w-full justify-end flex-row items-start gap-4 sm:mt-4 lg:mt-10">
-                <div className="flex sm:w-full lg:w-[240px] sm:px-2 lg:px-0">
+                <div className="flex sm:w-full lg:w-[230px] sm:px-2 lg:px-0">
                     {/* Custom number input component for selecting quantity */}
                     <XaiNumberInput
                         quantity={quantity}

--- a/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
+++ b/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
@@ -33,16 +33,13 @@ const PurchaseSuccessful: React.FC<IPurchaseSuccessful> = ({ returnToClient }) =
 
 	useEffect(() => {
 		setCanShare(navigator.share !== undefined);
-		setAllTxHashes([...txHashes]);
-		if (mintWithEth.data) {
-			setAllTxHashes([...allTxHashes, mintWithEth.data]);
-		}
-		if (mintWithXai.data) {
-			setAllTxHashes([...allTxHashes, mintWithXai.data]);
-		}
-		if (mintWithCrossmint.txHash) {
-			setAllTxHashes([...allTxHashes, mintWithCrossmint.txHash]);
-		}
+		setAllTxHashes([
+			...allTxHashes,
+			...(mintWithEth.data ? [mintWithEth.data] : []),
+			...(mintWithXai.data ? [mintWithXai.data] : []),
+			...(mintWithCrossmint.txHash ? [mintWithCrossmint.txHash] : [])
+		]);
+
 	}, [mintWithEth.data, mintWithXai.data, mintWithCrossmint.txHash, txHashes]);
 
 	const getHash = () => {

--- a/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
+++ b/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
@@ -34,7 +34,7 @@ const PurchaseSuccessful: React.FC<IPurchaseSuccessful> = ({ returnToClient }) =
 	useEffect(() => {
 		setCanShare(navigator.share !== undefined);
 		setAllTxHashes([
-			...allTxHashes,
+			...txHashes,
 			...(mintWithEth.data ? [mintWithEth.data] : []),
 			...(mintWithXai.data ? [mintWithXai.data] : []),
 			...(mintWithCrossmint.txHash ? [mintWithCrossmint.txHash] : [])

--- a/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
+++ b/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
@@ -23,20 +23,34 @@ const salePageBaseURL = `https://${VITE_APP_ENV === "development" ? "develop." :
 const operatorDownloadLink = "https://github.com/xai-foundation/sentry/releases/latest"
 
 const PurchaseSuccessful: React.FC<IPurchaseSuccessful> = ({ returnToClient }) => {
-	const { mintWithEth, mintWithXai, mintWithCrossmint, blockExplorer } = useWebBuyKeysContext();
+	const { mintWithEth, mintWithXai, mintWithCrossmint, blockExplorer, txHashes } = useWebBuyKeysContext();
 
 	const { address } = useAccount();
 	const [isTooltipAllowedToOpen, setIsTooltipAllowedToOpen] = useState(false);
 	const [canShare, setCanShare] = useState(false);
 	const { t: translate } = useTranslation("Checkout");
+	const [allTxHashes, setAllTxHashes] = useState<string[]>([]);
 
 	useEffect(() => {
 		setCanShare(navigator.share !== undefined);
-	}, []);
+		setAllTxHashes([...txHashes]);
+		if (mintWithEth.data) {
+			setAllTxHashes([...allTxHashes, mintWithEth.data]);
+		}
+		if (mintWithXai.data) {
+			setAllTxHashes([...allTxHashes, mintWithXai.data]);
+		}
+		if (mintWithCrossmint.txHash) {
+			setAllTxHashes([...allTxHashes, mintWithCrossmint.txHash]);
+		}
+	}, [mintWithEth.data, mintWithXai.data, mintWithCrossmint.txHash, txHashes]);
 
 	const getHash = () => {
-		const hash = mintWithEth.data ?? mintWithXai.data ?? mintWithCrossmint.txHash;
+		let hash = mintWithEth.data ?? mintWithXai.data ?? mintWithCrossmint.txHash;
 		if (!hash) {
+			hash = txHashes[0];
+		}
+		if (!hash) {			
 			throw new Error("No hash found");
 		}
 		return hash;
@@ -88,19 +102,21 @@ const PurchaseSuccessful: React.FC<IPurchaseSuccessful> = ({ returnToClient }) =
 					className="text-3xl text-white text-center uppercase font-bold mt-2">{translate("successfulPurchase.title")}</span>
 				<span className="block text-foggyLondon font-bold text-base max-w-[260px] text-center my-[10px]">{translate("successfulPurchase.text")}</span>
 				<div className="bg-optophobia w-full ">
-					<div className="flex justify-between border-t border-chromaphobicBlack px-[20px] py-[15px]">
-						<span className="text-[18px] sm:text-center text-elementalGrey ">{translate("successfulPurchase.transactionId")}</span>
-						<a
-							onClick={() => window.open(`${blockExplorer}/tx/${getHash()}`)}
-							className="group hover:text-hornetSting duration-300 text-wrap text-elementalGrey text-center underline ml-1 cursor-pointer text-[18px] sm:max-w-[260px] lg:max-w-full"
-						>
-							<div className="flex items-center gap-[10px]">
-								{getHash().slice(0, 6)}...{getHash().slice(-4)}
-								<ExternalLinkIcon
-									extraClasses={{ svgClasses: "group-hover:fill-hornetSting fill-elementalGrey duration-300" }} />
-							</div>
-						</a>
-					</div>
+				{allTxHashes.map((hash, index) => (
+							<div className="flex justify-between border-t border-chromaphobicBlack px-[20px] py-[15px]" key={index}>
+							<span className="text-[18px] sm:text-center text-elementalGrey ">{translate("successfulPurchase.transactionId")}</span>
+							<a
+								onClick={() => window.open(`${blockExplorer}/tx/${hash}`)}
+								className="group hover:text-hornetSting duration-300 text-wrap text-elementalGrey text-center underline ml-1 cursor-pointer text-[18px] sm:max-w-[260px] lg:max-w-full"
+							>
+								<div className="flex items-center gap-[10px]">
+									{hash.slice(0, 6)}...{hash.slice(-4)}
+									<ExternalLinkIcon
+										extraClasses={{ svgClasses: "group-hover:fill-hornetSting fill-elementalGrey duration-300" }} />
+								</div>
+							</a>
+					</div>	
+				))}
 					<div className="w-full text-elementalGrey text-[18px] flex flex-col border-t border-b border-chromaphobicBlack px-[20px] py-[15px]">
 
 						<p className="text-base">{translate("successfulPurchase.promo.shareLink")}</p>

--- a/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
+++ b/apps/web-connect/src/features/checkout/components/PurchaseSuccessful.tsx
@@ -99,9 +99,14 @@ const PurchaseSuccessful: React.FC<IPurchaseSuccessful> = ({ returnToClient }) =
 					className="text-3xl text-white text-center uppercase font-bold mt-2">{translate("successfulPurchase.title")}</span>
 				<span className="block text-foggyLondon font-bold text-base max-w-[260px] text-center my-[10px]">{translate("successfulPurchase.text")}</span>
 				<div className="bg-optophobia w-full ">
-				{allTxHashes.map((hash, index) => (
-							<div className="flex justify-between border-t border-chromaphobicBlack px-[20px] py-[15px]" key={index}>
-							<span className="text-[18px] sm:text-center text-elementalGrey ">{translate("successfulPurchase.transactionId")}</span>
+					{allTxHashes.map((hash, index) => (
+						<div
+							key={index}
+							className="flex justify-between border-t border-chromaphobicBlack px-[20px] py-[15px]"
+						>
+							<span className="text-[18px] sm:text-center text-elementalGrey">
+								{translate("successfulPurchase.transactionId")}
+							</span>
 							<a
 								onClick={() => window.open(`${blockExplorer}/tx/${hash}`)}
 								className="group hover:text-hornetSting duration-300 text-wrap text-elementalGrey text-center underline ml-1 cursor-pointer text-[18px] sm:max-w-[260px] lg:max-w-full"
@@ -109,13 +114,15 @@ const PurchaseSuccessful: React.FC<IPurchaseSuccessful> = ({ returnToClient }) =
 								<div className="flex items-center gap-[10px]">
 									{hash.slice(0, 6)}...{hash.slice(-4)}
 									<ExternalLinkIcon
-										extraClasses={{ svgClasses: "group-hover:fill-hornetSting fill-elementalGrey duration-300" }} />
+										extraClasses={{
+											svgClasses: "group-hover:fill-hornetSting fill-elementalGrey duration-300",
+										}}
+									/>
 								</div>
 							</a>
-					</div>	
-				))}
+						</div>
+					))}
 					<div className="w-full text-elementalGrey text-[18px] flex flex-col border-t border-b border-chromaphobicBlack px-[20px] py-[15px]">
-
 						<p className="text-base">{translate("successfulPurchase.promo.shareLink")}</p>
 						<p className="text-base mb-3">{translate("successfulPurchase.promo.info")}</p>
 						<div className="p-[1px] w-full h-full bg-chromaphobicBlack global-clip-btn">

--- a/apps/web-connect/src/features/hooks/contract/useContractWrites.ts
+++ b/apps/web-connect/src/features/hooks/contract/useContractWrites.ts
@@ -22,9 +22,9 @@ export interface UseContractWritesReturn {
   clearErrors: () => void;
   resetTransactions: () => void;
   mintWithEthError: Error | null;
-  handleMintWithEthClicked: () => void;
+  mintWithEthSingleTx: () => void;
   handleApproveClicked: () => void;
-  handleMintWithXaiClicked: () => void;
+  mintWithXaiSingleTx: () => void;
 }
 
 export function useContractWrites({
@@ -89,7 +89,7 @@ export function useContractWrites({
     },
   };
 
-  const handleMintWithEthClicked = async () => {
+  const mintWithEthSingleTx = async () => {
     mintWithEth.writeContract(mintWithEthConfig);
   };
 
@@ -107,7 +107,7 @@ export function useContractWrites({
     hash: approveHash,
   });
 
-  const handleMintWithXaiClicked = async () => {
+  const mintWithXaiSingleTx = async () => {
     mintWithXai.writeContract(mintWithXaiConfig);
   };
 
@@ -145,8 +145,8 @@ export function useContractWrites({
     clearErrors,
     mintWithEthError,
     resetTransactions,
-    handleMintWithEthClicked,
+    mintWithEthSingleTx,
     handleApproveClicked,
-    handleMintWithXaiClicked,
+    mintWithXaiSingleTx,
   };
 }

--- a/apps/web-connect/src/features/hooks/contract/useMintBatch.ts
+++ b/apps/web-connect/src/features/hooks/contract/useMintBatch.ts
@@ -5,7 +5,7 @@ import { CURRENCIES, Currency } from '../shared';
 
 //const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const MAX_BATCH_SIZE = 2; // TODO Update Limit batch size to 175
+export const MAX_BATCH_SIZE = 2; // TODO Update Limit batch size to 175 after testing
 
 interface UseMintBatchProps {
   promoCode: string;

--- a/apps/web-connect/src/features/hooks/contract/useMintBatch.ts
+++ b/apps/web-connect/src/features/hooks/contract/useMintBatch.ts
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import {  useAccount, useWriteContract } from 'wagmi';
+import { NodeLicenseAbi, config } from "@sentry/core";
+import { CURRENCIES, Currency } from '../shared';
+
+//const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const MAX_BATCH_SIZE = 2; // TODO Update Limit batch size to 175
+
+interface UseMintBatchProps {
+  promoCode: string;
+  calculateTotalPrice: () => bigint;
+  currency: Currency;
+}
+
+export interface UseMintBatchReturn {
+  txHashes: string[];
+  mintBatchError: Error | undefined;
+  isBatchMinting: boolean;
+  clearMintBatchErrors: () => void;
+  resetMintBatchTransactions: () => void;
+  mintBatch: (qtyToMint: number) => Promise<void>;
+  batchMintTx: ReturnType<typeof useWriteContract>
+}
+
+type MintConfig = {
+  address: `0x${string}`;
+  abi: typeof NodeLicenseAbi;
+  functionName: string;
+  args: unknown[];
+  value?: bigint;
+  onSuccess: (data: `0x${string}`) => void;
+  onError: (error: Error) => void;
+}
+
+export function useMintBatch({
+  promoCode,
+  calculateTotalPrice,
+  currency,
+}: UseMintBatchProps): UseMintBatchReturn {
+  const [txHashes, setTxHashes] = useState<string[]>([]);
+  const [mintBatchError, setMintBatchError] = useState<Error | undefined>(undefined);
+  const [isMinting, setIsMinting] = useState<boolean>(false);
+  const { address } = useAccount();
+  const batchMintTx = useWriteContract();
+
+  const getConfig = (quantity: number) => {
+    const functionName = currency === CURRENCIES.AETH ? "mint" : "mintWithXai";
+    const mintWithEthArgs = [quantity, promoCode];
+    const mintWithXaiArgs = [address, quantity, promoCode, currency === CURRENCIES.ES_XAI, calculateTotalPrice()];
+    const args = currency === CURRENCIES.AETH ? mintWithEthArgs : mintWithXaiArgs;
+
+    return {
+      address: config.nodeLicenseAddress as `0x${string}`,
+      abi: NodeLicenseAbi,
+      functionName,
+      args,
+      value: currency === CURRENCIES.AETH ? calculateTotalPrice() : undefined,
+      onSuccess: () => {
+        setMintBatchError(undefined);
+      },
+      onError: (error: Error) => {
+        setMintBatchError(error);
+        console.error('Error minting:', error);
+      },
+    }
+  }
+
+  const mintBatch = async (qtyToMint: number) => {
+    setTxHashes([]);
+    const config = getConfig(qtyToMint);
+    executeMint(qtyToMint, config);
+  }
+
+  const executeMint = async (qtyToMint: number, config: MintConfig) => {
+    let qtyRemaining = qtyToMint; 
+    setMintBatchError(undefined);
+    const txHashesLocal: string[] = []; // Local variable to accumulate hashes
+    const batches = Math.ceil(qtyToMint / MAX_BATCH_SIZE); // TODO Update Limit batch size to 175
+
+  setIsMinting(true);
+
+    for (let i = 0; i < batches; i++) {
+      if (mintBatchError) return;
+      const qtyToProcess = Math.min(qtyRemaining, MAX_BATCH_SIZE);
+      try {
+        // Initiate transaction
+        const result = await batchMintTx.writeContractAsync(config);
+        txHashesLocal.push(result);
+        qtyRemaining -= qtyToProcess;
+
+        // Transactions fail if they are sent too quickly when minting with an ERC20 token
+        // AETH seems to not experience this issue
+        if(currency !== CURRENCIES.AETH){
+          // If not AETH, wait 3 seconds between transactions
+          await new Promise((resolve) => setTimeout(resolve, 3000));
+        }
+        // Reset for the next iteration
+        batchMintTx.reset();
+      } catch (error) {
+        console.error('Error minting:', error);
+        setMintBatchError(error as Error);
+        setIsMinting(false);
+      }
+    }
+  
+    setIsMinting(false);
+
+    setTxHashes(txHashesLocal);
+    console.log("txHashes", txHashes);
+  };
+  
+  const clearMintBatchErrors = () => {
+    setMintBatchError(undefined);
+    batchMintTx.reset();
+  };
+
+  const resetMintBatchTransactions = () => {
+    setMintBatchError(undefined);
+    setTxHashes([]);
+    batchMintTx.reset();
+  };
+
+
+
+  return {
+    clearMintBatchErrors,
+    mintBatchError,
+    resetMintBatchTransactions,
+    mintBatch,
+    txHashes,
+    isBatchMinting: isMinting,
+    batchMintTx,
+  };
+}

--- a/apps/web-connect/src/features/hooks/contract/useMintBatch.ts
+++ b/apps/web-connect/src/features/hooks/contract/useMintBatch.ts
@@ -3,9 +3,7 @@ import { useAccount, useWriteContract } from "wagmi";
 import { NodeLicenseAbi, config } from "@sentry/core";
 import { CURRENCIES, Currency } from "../shared";
 
-//const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-export const MAX_BATCH_SIZE = config.maxBatchMintSize;
+const MAX_BATCH_SIZE = config.maxBatchMintSize;
 
 interface UseMintBatchProps {
   promoCode: string;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -41,7 +41,8 @@ const mainnetConfig = {
   crossmintClientApiKey: "ck_production_32yBiDshXuuH1Cam3g8KoLTSRnCCyjjMsYfsm3chP7kjLRDjPci6G7SuZNHSqRMDi8tr6WyDztunoszrAvyfYsFxTb16Avggt9eXhsBuZfqQU8Y21UA9z3Dk2QQZx9sYSKoQvaV7mbRJJoNiQhGjqjswzrVxyxt9mMp8e7h4wE8aX94K7yviqpBwfH5i715f24u5Q6RXC8chBKSufeCquBD", //Crossmint Production Client API Key
   minSecondsBetweenChallenges: 50 * 60, // 1 hour
   sentryKeySaleURI: "https://sentry.xai.games", // redirect from within desktop client for web3 interaction
-  usdcContractAddress: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+  usdcContractAddress: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+  maxBatchMintSize: 175,
 };
 
 const testnetConfig: Config = {
@@ -83,7 +84,8 @@ const testnetConfig: Config = {
   crossmintClientApiKey: "ck_staging_9zhFqkBiSWwUeS4HqVvjuqaVtrwgh552SrAQ5aQqrHU7wP4F9PZoyd13WdiEZZQgjbUFKiZbgf6kkJi6XwyoiVjrqgUZ2QM4kxPweju1QNuD9FYWjeLW6f9HUzvD2rzwi3HjYa788s7oPPo5P2oyJiDV36MPNj3HTRHEHmfSEPoHzzYummqrWM6uRw7VbiRgXgjUvmdedqV51PLjuiZbruTx", 
   minSecondsBetweenChallenges: 5 * 60, // 5 minutes on testnet
   sentryKeySaleURI: "https://develop.sentry.xai.games", // redirect from within desktop client for web3 interaction
-  usdcContractAddress: "0x14196F08a4Fa0B66B7331bC40dd6bCd8A1dEeA9F"
+  usdcContractAddress: "0x14196F08a4Fa0B66B7331bC40dd6bCd8A1dEeA9F",
+  maxBatchMintSize: 2,
 };
 
 export let config: Config = mainnetConfig;

--- a/packages/ui/src/features/inputs/XaiNumberInput.tsx
+++ b/packages/ui/src/features/inputs/XaiNumberInput.tsx
@@ -28,7 +28,7 @@ export function XaiNumberInput({quantity, setQuantity, maxSupply = 50000, wrappe
   };
 
   return (
-    <div className="relative sm:w-full lg:w-auto">
+    <div className="relative sm:w-full">
       <MainStepper onChange={handleInputChange} quantity={quantity} setQuantity={setQuantity} maxSupply={maxSupply} wrapperClassName={wrapperClassName} containerClassName={containerClassName} btnClassName={btnClassName} inputClassName={inputClassName} />
     </div>
   );

--- a/packages/ui/src/rebrand/steppers/MainStepper.tsx
+++ b/packages/ui/src/rebrand/steppers/MainStepper.tsx
@@ -40,7 +40,7 @@ const MainStepper = ({
           min={1}
           max={99}
           onChange={onChange}
-          className={`font-bold text-3xl text-center indent-3 min-w-[30%] text-white bg-nulnOil py-[7px] focus:outline-none ${inputClassName}`}
+          className={`font-bold text-3xl text-center min-w-[30%] text-white bg-nulnOil py-[7px] focus:outline-none ${inputClassName}`}
         />
         <button
           className={`bg-nulnOil p-[20px] global-cta-clip-path hover:bg-velvetBlack duration-200 ease-in ${btnClassName}`}

--- a/packages/ui/src/rebrand/steppers/MainStepper.tsx
+++ b/packages/ui/src/rebrand/steppers/MainStepper.tsx
@@ -38,9 +38,9 @@ const MainStepper = ({
           type="number"
           value={quantity}
           min={1}
-          max={99}
+          max={maxSupply ?? 99999}
           onChange={onChange}
-          className={`font-bold text-3xl text-center min-w-[30%] text-white bg-nulnOil py-[7px] focus:outline-none ${inputClassName}`}
+          className={`font-bold text-3xl text-center w-full text-white bg-nulnOil py-[7px] focus:outline-none ${inputClassName}`}
         />
         <button
           className={`bg-nulnOil p-[20px] global-cta-clip-path hover:bg-velvetBlack duration-200 ease-in ${btnClassName}`}


### PR DESCRIPTION
Update Keysale Page to support batch mints

- Added Crossmint Disabled button text to translations
- Created new hook to manage Batch Mints
- Updated sale page Transaction InProgress/Purchase Successful conditional display to include batch mint txs
- Renamed some functions for clarity
- Cleaned up buy keys hook to return merged hooks vs destructuring and returning individual properties.
- Updated ActionsSection to call different mint functions based on qty
- Added Mint Batch Error Section
- Added button validation for max crossmint qty per tx
- Updated choose quantity row css to allow for larger numbers in the input box
- Updated PurchaseSuccess page to map all minted tx hashes
- Added maxBatchMintSize to config to allow us to test with batch sizes of 2 to save test net tokens

Tested locally and on the PR link by minting batches with both currencies and seeing the success page with the hashes.

*Note: I started to get errors on the mint with Xai loop after 2 or 3 txs. Adding the 3 second delay seemed to fix that, we may be able to use a lower delay, but we'd need to test at different intervals.

