### PR TITLE
Removed User Change Recipient Address

### DIFF
--- a/apps/web-connect/src/features/checkout/components/crossmint/CrossmintModal.tsx
+++ b/apps/web-connect/src/features/checkout/components/crossmint/CrossmintModal.tsx
@@ -71,6 +71,9 @@ const CrossmintModal: React.FC<CrossmintModalProps> = ({ isOpen, onClose, totalP
                                         colors:{
                                             text: styles.colors.textPrimary,
                                         },
+                                    },  
+                                    DestinationInput: {
+                                        display: "hidden",
                                     },
                                     Input: {
                                         font:{


### PR DESCRIPTION
Hide input to allow users to change the recipient address when minting with Crossmint.