### PR TITLE
fix: Display Purchase Success Page

### DIFF
--- a/apps/web-connect/src/features/hooks/contract/useMintBatch.ts
+++ b/apps/web-connect/src/features/hooks/contract/useMintBatch.ts
@@ -134,10 +134,7 @@ export function useMintBatch({
     }
 
     setIsMinting(false);
-
-    if (!encounteredError) {
-      setTxHashes(txHashesLocal);
-    }
+    setTxHashes(txHashesLocal);
   };
 
   const clearMintBatchErrors = () => {


### PR DESCRIPTION
Updated to display purchase successful if at least one mint succeded.