### PR TITLE
Implement transfer staked keys

### DIFF
--- a/infrastructure/smart-contracts/.openzeppelin/unknown-421614.json
+++ b/infrastructure/smart-contracts/.openzeppelin/unknown-421614.json
@@ -75642,6 +75642,1647 @@
         "0xF53A977E3cbA76285D3692EC048Bb4147AdBEc94",
         "0x7110b5D0e7E7Ba413f98EAE6D3481A160aaA3987"
       ]
+    },
+    "1c7c065e517a1ce0efd75fc05b24da3c85c51e23503e239a7d0de59a444a98e2": {
+      "address": "0x7C9a50e2aff41dEE6e8ed1F5170D5040A5D1339f",
+      "txHash": "0xc0f903b74bff21631707dba2fb553d91029069b118fd97f2542fd0f2298a5e8f",
+      "layout": {
+        "solcVersion": "0.8.9",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)169_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:57"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:260"
+          },
+          {
+            "label": "_roleMembers",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_bytes32,t_struct(AddressSet)5135_storage)",
+            "contract": "AccessControlEnumerableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlEnumerableUpgradeable.sol:17"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlEnumerableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlEnumerableUpgradeable.sol:76"
+          },
+          {
+            "label": "challengerPublicKey",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bytes_storage",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:83"
+          },
+          {
+            "label": "rollupAddress",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_address",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:86"
+          },
+          {
+            "label": "nodeLicenseAddress",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_address",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:89"
+          },
+          {
+            "label": "esXaiAddress",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:92"
+          },
+          {
+            "label": "xaiAddress",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_address",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:93"
+          },
+          {
+            "label": "challengeCounter",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_uint256",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:96"
+          },
+          {
+            "label": "gasSubsidyRecipient",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_address",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:99"
+          },
+          {
+            "label": "challenges",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_mapping(t_uint256,t_struct(Challenge)37465_storage)",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:102"
+          },
+          {
+            "label": "submissions",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_mapping(t_uint256,t_mapping(t_uint256,t_struct(Submission)37425_storage))",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:105"
+          },
+          {
+            "label": "isCheckingAssertions",
+            "offset": 0,
+            "slot": "210",
+            "type": "t_bool",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:108"
+          },
+          {
+            "label": "_operatorApprovals",
+            "offset": 0,
+            "slot": "211",
+            "type": "t_mapping(t_address,t_struct(AddressSet)5135_storage)",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:111"
+          },
+          {
+            "label": "_ownersForOperator",
+            "offset": 0,
+            "slot": "212",
+            "type": "t_mapping(t_address,t_struct(AddressSet)5135_storage)",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:114"
+          },
+          {
+            "label": "_lifetimeClaims",
+            "offset": 0,
+            "slot": "213",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:117"
+          },
+          {
+            "label": "rollupAssertionTracker",
+            "offset": 0,
+            "slot": "214",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:120"
+          },
+          {
+            "label": "kycWallets",
+            "offset": 0,
+            "slot": "215",
+            "type": "t_struct(AddressSet)5135_storage",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:123"
+          },
+          {
+            "label": "_allocatedTokens",
+            "offset": 0,
+            "slot": "217",
+            "type": "t_uint256",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:126"
+          },
+          {
+            "label": "_gasSubsidyPercentage",
+            "offset": 0,
+            "slot": "218",
+            "type": "t_uint256",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:129"
+          },
+          {
+            "label": "stakedAmounts",
+            "offset": 0,
+            "slot": "219",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:132"
+          },
+          {
+            "label": "stakeAmountTierThresholds",
+            "offset": 0,
+            "slot": "220",
+            "type": "t_array(t_uint256)dyn_storage",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:135"
+          },
+          {
+            "label": "stakeAmountBoostFactors",
+            "offset": 0,
+            "slot": "221",
+            "type": "t_array(t_uint256)dyn_storage",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:138"
+          },
+          {
+            "label": "maxStakeAmountPerLicense",
+            "offset": 0,
+            "slot": "222",
+            "type": "t_uint256",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:141"
+          },
+          {
+            "label": "stakingEnabled",
+            "offset": 0,
+            "slot": "223",
+            "type": "t_bool",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:144"
+          },
+          {
+            "label": "assignedKeyToPool",
+            "offset": 0,
+            "slot": "224",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:148"
+          },
+          {
+            "label": "assignedKeysToPoolCount",
+            "offset": 0,
+            "slot": "225",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:151"
+          },
+          {
+            "label": "maxKeysPerPool",
+            "offset": 0,
+            "slot": "226",
+            "type": "t_uint256",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:154"
+          },
+          {
+            "label": "poolFactoryAddress",
+            "offset": 0,
+            "slot": "227",
+            "type": "t_address",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:157"
+          },
+          {
+            "label": "assignedKeysOfUserCount",
+            "offset": 0,
+            "slot": "228",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:160"
+          },
+          {
+            "label": "poolSubmissions",
+            "offset": 0,
+            "slot": "229",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_struct(PoolSubmission)37398_storage))",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:163"
+          },
+          {
+            "label": "refereeCalculationsAddress",
+            "offset": 0,
+            "slot": "230",
+            "type": "t_address",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:175"
+          },
+          {
+            "label": "bulkSubmissions",
+            "offset": 0,
+            "slot": "231",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_struct(BulkSubmission)37436_storage))",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:178"
+          },
+          {
+            "label": "isBeforeBulkState",
+            "offset": 0,
+            "slot": "232",
+            "type": "t_bool",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:179"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "233",
+            "type": "t_array(t_uint256)486_storage",
+            "contract": "Referee11",
+            "src": "contracts\\upgrades\\referee\\Referee11.sol:186"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)486_storage": {
+            "label": "uint256[486]",
+            "numberOfBytes": "15552"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(AddressSet)5135_storage)": {
+            "label": "mapping(address => struct EnumerableSetUpgradeable.AddressSet)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(BulkSubmission)37436_storage)": {
+            "label": "mapping(address => struct Referee11.BulkSubmission)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(PoolSubmission)37398_storage)": {
+            "label": "mapping(address => struct Referee11.PoolSubmission)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(AddressSet)5135_storage)": {
+            "label": "mapping(bytes32 => struct EnumerableSetUpgradeable.AddressSet)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)169_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_struct(BulkSubmission)37436_storage))": {
+            "label": "mapping(uint256 => mapping(address => struct Referee11.BulkSubmission))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_struct(PoolSubmission)37398_storage))": {
+            "label": "mapping(uint256 => mapping(address => struct Referee11.PoolSubmission))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_uint256,t_struct(Submission)37425_storage))": {
+            "label": "mapping(uint256 => mapping(uint256 => struct Referee11.Submission))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Challenge)37465_storage)": {
+            "label": "mapping(uint256 => struct Referee11.Challenge)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Submission)37425_storage)": {
+            "label": "mapping(uint256 => struct Referee11.Submission)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AddressSet)5135_storage": {
+            "label": "struct EnumerableSetUpgradeable.AddressSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)4820_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(BulkSubmission)37436_storage": {
+            "label": "struct Referee11.BulkSubmission",
+            "members": [
+              {
+                "label": "submitted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "claimed",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "keyCount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "winningKeyCount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "assertionStateRootOrConfirmData",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(Challenge)37465_storage": {
+            "label": "struct Referee11.Challenge",
+            "members": [
+              {
+                "label": "openForSubmissions",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "expiredForRewarding",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "assertionId",
+                "type": "t_uint64",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "assertionStateRootOrConfirmData",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "assertionTimestamp",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "challengerSignedHash",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "activeChallengerPublicKey",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "rollupUsed",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "createdTimestamp",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "totalSupplyOfNodesAtChallengeStart",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "rewardAmountForClaimers",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "amountForGasSubsidy",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "numberOfEligibleClaimers",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "amountClaimedByClaimers",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(PoolSubmission)37398_storage": {
+            "label": "struct Referee11.PoolSubmission",
+            "members": [
+              {
+                "label": "submitted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "claimed",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "stakedKeyCount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "winningKeyCount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "assertionStateRootOrConfirmData",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(RoleData)169_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Set)4820_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Submission)37425_storage": {
+            "label": "struct Referee11.Submission",
+            "members": [
+              {
+                "label": "submitted",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "claimed",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "eligibleForPayout",
+                "type": "t_bool",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "nodeLicenseId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "assertionStateRootOrConfirmData",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
+    },
+    "127d4962c5993dae394c0de72c5a9bf52dd20785c839749e89a12d47256866ae": {
+      "address": "0x7483441942545a2A3E55d7B6d13346429e69Da41",
+      "txHash": "0x2cb50dd9994dee1d4cddeedb5128c03206bf84964c70b913c7834481afa260e0",
+      "layout": {
+        "solcVersion": "0.8.9",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)169_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:57"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:260"
+          },
+          {
+            "label": "_roleMembers",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_bytes32,t_struct(AddressSet)5135_storage)",
+            "contract": "AccessControlEnumerableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlEnumerableUpgradeable.sol:17"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlEnumerableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlEnumerableUpgradeable.sol:76"
+          },
+          {
+            "label": "nodeLicenseAddress",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_address",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:63"
+          },
+          {
+            "label": "esXaiAddress",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_address",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:66"
+          },
+          {
+            "label": "refereeAddress",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_address",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:67"
+          },
+          {
+            "label": "stakingEnabled",
+            "offset": 20,
+            "slot": "203",
+            "type": "t_bool",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:70"
+          },
+          {
+            "label": "stakingPools",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:73"
+          },
+          {
+            "label": "bucketshareMaxValues",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_array(t_uint32)3_storage",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:76"
+          },
+          {
+            "label": "interactedPoolsOfUser",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_mapping(t_address,t_array(t_address)dyn_storage)",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:79"
+          },
+          {
+            "label": "userToInteractedPoolIds",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:82"
+          },
+          {
+            "label": "poolsOfDelegate",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_mapping(t_address,t_array(t_address)dyn_storage)",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:86"
+          },
+          {
+            "label": "poolsOfDelegateIndices",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:89"
+          },
+          {
+            "label": "poolsCreatedViaFactory",
+            "offset": 0,
+            "slot": "210",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:92"
+          },
+          {
+            "label": "deployerAddress",
+            "offset": 0,
+            "slot": "211",
+            "type": "t_address",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:95"
+          },
+          {
+            "label": "unstakeKeysDelayPeriod",
+            "offset": 0,
+            "slot": "212",
+            "type": "t_uint256",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:98"
+          },
+          {
+            "label": "unstakeGenesisKeyDelayPeriod",
+            "offset": 0,
+            "slot": "213",
+            "type": "t_uint256",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:99"
+          },
+          {
+            "label": "unstakeEsXaiDelayPeriod",
+            "offset": 0,
+            "slot": "214",
+            "type": "t_uint256",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:100"
+          },
+          {
+            "label": "updateRewardBreakdownDelayPeriod",
+            "offset": 0,
+            "slot": "215",
+            "type": "t_uint256",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:103"
+          },
+          {
+            "label": "failedKyc",
+            "offset": 0,
+            "slot": "216",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:106"
+          },
+          {
+            "label": "totalEsXaiStakeCalculated",
+            "offset": 0,
+            "slot": "217",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:112"
+          },
+          {
+            "label": "_totalEsXaiStakeByUser",
+            "offset": 0,
+            "slot": "218",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:119"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "219",
+            "type": "t_array(t_uint256)497_storage",
+            "contract": "PoolFactory3",
+            "src": "contracts\\upgrades\\pool-factory\\PoolFactory3.sol:128"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)497_storage": {
+            "label": "uint256[497]",
+            "numberOfBytes": "15904"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint32)3_storage": {
+            "label": "uint32[3]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_array(t_address)dyn_storage)": {
+            "label": "mapping(address => address[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(AddressSet)5135_storage)": {
+            "label": "mapping(bytes32 => struct EnumerableSetUpgradeable.AddressSet)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)169_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AddressSet)5135_storage": {
+            "label": "struct EnumerableSetUpgradeable.AddressSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)4820_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(RoleData)169_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Set)4820_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
+    },
+    "4ec4ecd3980a89a3301cbae7118aa618042e88e278add5e5f68a373172d998ba": {
+      "address": "0xF92A15C12710a1eDe2F7eb48755e3C05fB832672",
+      "txHash": "0x03e1fb7c5f420361345977532174119c4b76420a17cf50302d60b644524e2a27",
+      "layout": {
+        "solcVersion": "0.8.9",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_string_storage",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:25"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_string_storage",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:28"
+          },
+          {
+            "label": "_owners",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:31"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:34"
+          },
+          {
+            "label": "_tokenApprovals",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:37"
+          },
+          {
+            "label": "_operatorApprovals",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:40"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_array(t_uint256)44_storage",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:477"
+          },
+          {
+            "label": "_ownedTokens",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))",
+            "contract": "ERC721EnumerableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\extensions\\ERC721EnumerableUpgradeable.sol:17"
+          },
+          {
+            "label": "_ownedTokensIndex",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "ERC721EnumerableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\extensions\\ERC721EnumerableUpgradeable.sol:20"
+          },
+          {
+            "label": "_allTokens",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_array(t_uint256)dyn_storage",
+            "contract": "ERC721EnumerableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\extensions\\ERC721EnumerableUpgradeable.sol:23"
+          },
+          {
+            "label": "_allTokensIndex",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "ERC721EnumerableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\extensions\\ERC721EnumerableUpgradeable.sol:26"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC721EnumerableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\extensions\\ERC721EnumerableUpgradeable.sol:171"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)169_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:57"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:260"
+          },
+          {
+            "label": "_tokenIds",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_struct(Counter)3484_storage",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:21"
+          },
+          {
+            "label": "fundsReceiver",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_address_payable",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:23"
+          },
+          {
+            "label": "maxSupply",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_uint256",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:25"
+          },
+          {
+            "label": "pricingTiers",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_array(t_struct(Tier)23732_storage)dyn_storage",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:28"
+          },
+          {
+            "label": "referralDiscountPercentage",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_uint256",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:30"
+          },
+          {
+            "label": "referralRewardPercentage",
+            "offset": 0,
+            "slot": "256",
+            "type": "t_uint256",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:31"
+          },
+          {
+            "label": "claimable",
+            "offset": 0,
+            "slot": "257",
+            "type": "t_bool",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:34"
+          },
+          {
+            "label": "_mintTimestamps",
+            "offset": 0,
+            "slot": "258",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:37"
+          },
+          {
+            "label": "_promoCodes",
+            "offset": 0,
+            "slot": "259",
+            "type": "t_mapping(t_string_memory_ptr,t_struct(PromoCode)23739_storage)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:40"
+          },
+          {
+            "label": "_referralRewards",
+            "offset": 0,
+            "slot": "260",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:43"
+          },
+          {
+            "label": "_averageCost",
+            "offset": 0,
+            "slot": "261",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:46"
+          },
+          {
+            "label": "whitelistAmounts",
+            "offset": 0,
+            "slot": "262",
+            "type": "t_mapping(t_address,t_uint16)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:49"
+          },
+          {
+            "label": "_promoCodesXai",
+            "offset": 0,
+            "slot": "263",
+            "type": "t_mapping(t_string_memory_ptr,t_struct(PromoCode)23739_storage)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:63"
+          },
+          {
+            "label": "_promoCodesEsXai",
+            "offset": 0,
+            "slot": "264",
+            "type": "t_mapping(t_string_memory_ptr,t_struct(PromoCode)23739_storage)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:66"
+          },
+          {
+            "label": "_referralRewardsXai",
+            "offset": 0,
+            "slot": "265",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:69"
+          },
+          {
+            "label": "_referralRewardsEsXai",
+            "offset": 0,
+            "slot": "266",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:72"
+          },
+          {
+            "label": "ethPriceFeed",
+            "offset": 0,
+            "slot": "267",
+            "type": "t_contract(IAggregatorV3Interface)23576",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:75"
+          },
+          {
+            "label": "xaiPriceFeed",
+            "offset": 0,
+            "slot": "268",
+            "type": "t_contract(IAggregatorV3Interface)23576",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:78"
+          },
+          {
+            "label": "xaiAddress",
+            "offset": 0,
+            "slot": "269",
+            "type": "t_address",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:81"
+          },
+          {
+            "label": "esXaiAddress",
+            "offset": 0,
+            "slot": "270",
+            "type": "t_address",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:82"
+          },
+          {
+            "label": "mintingPaused",
+            "offset": 20,
+            "slot": "270",
+            "type": "t_bool",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:85"
+          },
+          {
+            "label": "_reentrancyGuardClaimReferralReward",
+            "offset": 21,
+            "slot": "270",
+            "type": "t_bool",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:88"
+          },
+          {
+            "label": "usedTransferIds",
+            "offset": 0,
+            "slot": "271",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:91"
+          },
+          {
+            "label": "usdcAddress",
+            "offset": 0,
+            "slot": "272",
+            "type": "t_address",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:93"
+          },
+          {
+            "label": "_promoCodesUSDC",
+            "offset": 0,
+            "slot": "273",
+            "type": "t_mapping(t_string_memory_ptr,t_struct(PromoCode)23739_storage)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:94"
+          },
+          {
+            "label": "_referralRewardsUSDC",
+            "offset": 0,
+            "slot": "274",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:95"
+          },
+          {
+            "label": "refereeCalculationsAddress",
+            "offset": 0,
+            "slot": "275",
+            "type": "t_address",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:97"
+          },
+          {
+            "label": "refereeAddress",
+            "offset": 0,
+            "slot": "276",
+            "type": "t_address",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:98"
+          },
+          {
+            "label": "usedAdminMintIds",
+            "offset": 0,
+            "slot": "277",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:101"
+          },
+          {
+            "label": "_latestETHToUSDC",
+            "offset": 0,
+            "slot": "278",
+            "type": "t_uint256",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:103"
+          },
+          {
+            "label": "_lastUpdatedETHToUSDCRate",
+            "offset": 0,
+            "slot": "279",
+            "type": "t_uint256",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:104"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "280",
+            "type": "t_array(t_uint256)482_storage",
+            "contract": "NodeLicense10",
+            "src": "contracts\\upgrades\\node-license\\NodeLicense10.sol:128"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_address_payable": {
+            "label": "address payable",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(Tier)23732_storage)dyn_storage": {
+            "label": "struct NodeLicense10.Tier[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)44_storage": {
+            "label": "uint256[44]",
+            "numberOfBytes": "1408"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)482_storage": {
+            "label": "uint256[482]",
+            "numberOfBytes": "15424"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IAggregatorV3Interface)23576": {
+            "label": "contract IAggregatorV3Interface",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(address => mapping(uint256 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint16)": {
+            "label": "mapping(address => uint16)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)169_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_string_memory_ptr,t_struct(PromoCode)23739_storage)": {
+            "label": "mapping(string => struct NodeLicense10.PromoCode)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_memory_ptr": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)3484_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PromoCode)23739_storage": {
+            "label": "struct NodeLicense10.PromoCode",
+            "members": [
+              {
+                "label": "recipient",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "active",
+                "type": "t_bool",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "receivedLifetime",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(RoleData)169_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Tier)23732_storage": {
+            "label": "struct NodeLicense10.Tier",
+            "members": [
+              {
+                "label": "price",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "quantity",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/infrastructure/smart-contracts/contracts/upgrades/StakingPool/StakingPool3.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/StakingPool/StakingPool3.sol
@@ -575,4 +575,30 @@ contract StakingPool3 is AccessControlUpgradeable {
         }
         return stakedKeyAmounts[user];
 	}
+    
+    function transferStakedKeys(
+        address from,
+        address to,
+        uint256 amount
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+
+        handleMigrateKeyAmount(from);
+        handleMigrateKeyAmount(to);
+
+        require(stakedKeyAmounts[from] - userRequestedUnstakeKeyAmount[from] >= amount, "39");
+
+        if(from == poolOwner) {
+            require(stakedKeyAmounts[from] > amount, "40");
+        }
+
+		stakedKeyAmounts[from] -= amount;
+		stakedKeyAmounts[to] += amount;
+        
+        distributeRewards();
+
+        keyBucket.processAccount(from);
+        keyBucket.processAccount(to);
+        keyBucket.setBalance(from, stakedKeyAmounts[from]);
+        keyBucket.setBalance(to, stakedKeyAmounts[to]);
+    }
 }

--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense10.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense10.sol
@@ -901,7 +901,20 @@ contract NodeLicense10 is ERC721EnumerableUpgradeable, AccessControlUpgradeable 
         address poolAddress,
         uint256[] memory tokenIds
     ) external onlyRole(TRANSFER_ROLE) {
-        revert("Not implemented");
+        if (to == address(0) || to == address(this)) revert InvalidAddress();
+
+        uint256 tokenIdsLength = tokenIds.length;
+        if (tokenIdsLength == 0) revert MissingTokenIds();
+
+        for (uint256 i; i < tokenIdsLength; i++) {
+            require(super._isApprovedOrOwner(msg.sender, tokenIds[i]), "ERC721: caller is not token owner or approved");
+            super._safeTransfer(from, to, tokenIds[i], "");
+        }
+
+        PoolFactory3(Referee10(refereeAddress).poolFactoryAddress())
+            .transferStakedKeys(from, to, poolAddress, tokenIdsLength);
+        
+        emit TransferStaked(msg.sender, poolAddress);
     }
 
 }

--- a/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense10.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/node-license/NodeLicense10.sol
@@ -906,13 +906,13 @@ contract NodeLicense10 is ERC721EnumerableUpgradeable, AccessControlUpgradeable 
         uint256 tokenIdsLength = tokenIds.length;
         if (tokenIdsLength == 0) revert MissingTokenIds();
 
+        PoolFactory3(Referee10(refereeAddress).poolFactoryAddress())
+            .transferStakedKeys(from, to, poolAddress, tokenIdsLength);
+
         for (uint256 i; i < tokenIdsLength; i++) {
             require(super._isApprovedOrOwner(msg.sender, tokenIds[i]), "ERC721: caller is not token owner or approved");
             super._safeTransfer(from, to, tokenIds[i], "");
         }
-
-        PoolFactory3(Referee10(refereeAddress).poolFactoryAddress())
-            .transferStakedKeys(from, to, poolAddress, tokenIdsLength);
         
         emit TransferStaked(msg.sender, poolAddress);
     }

--- a/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory3.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory3.sol
@@ -959,9 +959,11 @@ contract PoolFactory3 is Initializable, AccessControlEnumerableUpgradeable {
         uint256 amount
     ) external {
 
-        require(msg.sender == nodeLicenseAddress, "41");
-
         require(poolsCreatedViaFactory[pool], "23");
+
+        require(!failedKyc[from] && !failedKyc[to], "38");
+
+        require(msg.sender == nodeLicenseAddress, "41");
 
         StakingPool3 stakingPool = StakingPool3(pool);
         stakingPool.transferStakedKeys(from, to, amount);

--- a/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory3.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/pool-factory/PoolFactory3.sol
@@ -224,15 +224,6 @@ contract PoolFactory3 is Initializable, AccessControlEnumerableUpgradeable {
         bool isKey
     );
 
-    // /**
-    //  * @dev Initializes the contract with the provided addresses.
-    //  * Grants STAKE_KEYS_ADMIN_ROLE.
-    //  * @param _stakeKeysAdmin Address to be granted STAKE_KEYS_ADMIN_ROLE.
-    //  */
-    function initialize(address _stakeKeysAdmin) public reinitializer(2) {
-        _setupRole(STAKE_KEYS_ADMIN_ROLE, _stakeKeysAdmin);
-    }
-
     /**
      * @notice Enables staking on the Factory.
      */

--- a/infrastructure/smart-contracts/contracts/upgrades/referee/Referee11.sol
+++ b/infrastructure/smart-contracts/contracts/upgrades/referee/Referee11.sol
@@ -1130,4 +1130,15 @@ contract Referee11 is Initializable, AccessControlEnumerableUpgradeable {
             _updateBulkAssertion(to, currentChallenge);
         }
     }
+    
+    /**
+    * @notice On transfer staked keys update the Referee state for assignedKeysOfUserCount.
+    * Since the keys stay staked in the pool we do not have to update the owner bulk submissions.
+    */
+    function updateAssignedKeysOfUserCount(address from, address to, uint256 keyAmount) external onlyPoolFactory {
+        require(stakingEnabled, "52");
+
+        assignedKeysOfUserCount[from] -= keyAmount;
+        assignedKeysOfUserCount[to] += keyAmount;
+    }
 }

--- a/infrastructure/smart-contracts/package.json
+++ b/infrastructure/smart-contracts/package.json
@@ -41,6 +41,7 @@
     "deploy-tiny-keys": "hardhat run scripts/tiny-keys/deployTinyKeys.mjs",
     "start-tiny-keys-drop": "hardhat run scripts/tiny-keys/startAirdrop.mjs",
     "process-tiny-keys-drop": "hardhat run scripts/tiny-keys/processAirdrop.mjs",
+    "upgrade-transfer-staked-keys": "hardhat run scripts/transfer-staked-keys/upgrade-contracts.mjs",
     "check-flagged-accounts": "hardhat run scripts/flagged/flaggedNodeLicenses.mjs"
   },
   "dependencies": {

--- a/infrastructure/smart-contracts/scripts/transfer-staked-keys/upgrade-contracts.mjs
+++ b/infrastructure/smart-contracts/scripts/transfer-staked-keys/upgrade-contracts.mjs
@@ -18,11 +18,6 @@ async function main() {
     // get the deployer
     const [deployer] = (await ethers.getSigners());
 
-    /**
-     * Upgrade Referee Contract
-     * @description Upgrades the existing Referee contract to Referee9
-     * @param {string} refereeCalculationsAddress - Address of the RefereeCalculations contract
-     */
     console.log("Upgrading Referee...");
     const Referee11 = await ethers.getContractFactory("Referee11", deployer);
     console.log("Got Referee factory");

--- a/infrastructure/smart-contracts/scripts/transfer-staked-keys/upgrade-contracts.mjs
+++ b/infrastructure/smart-contracts/scripts/transfer-staked-keys/upgrade-contracts.mjs
@@ -1,0 +1,81 @@
+import { config } from "@sentry/core";
+import { safeVerify } from "../../utils/safeVerify.mjs";
+
+import { PoolBeaconAbi } from "@sentry/core";
+
+// Find this in the deployed PoolProxyDeployer's public fields. This should reflect which set of proxies you want to change; staking pools, key buckets, or esXai buckets
+// https://arbiscan.io/address/0x68D78D1E81379EfD9C61f8E9131D52CE571AF4fD#readProxyContract
+const beaconAddress = "0x5f9D168d3435747335b1B3dC7e4d42e3510087C7";
+const currentContractImplementationName = "StakingPool2";
+const newContractImplementationName = "StakingPool3";
+
+const REFEREE_ADDRESS = config.refereeAddress;
+const POOL_FACTORY_ADDRESS = config.poolFactoryAddress;
+const NODE_LICENSE_ADDRESS = config.nodeLicenseAddress;
+
+async function main() {
+
+    // get the deployer
+    const [deployer] = (await ethers.getSigners());
+
+    /**
+     * Upgrade Referee Contract
+     * @description Upgrades the existing Referee contract to Referee9
+     * @param {string} refereeCalculationsAddress - Address of the RefereeCalculations contract
+     */
+    console.log("Upgrading Referee...");
+    const Referee11 = await ethers.getContractFactory("Referee11", deployer);
+    console.log("Got Referee factory");
+    const referee11 = await upgrades.upgradeProxy(REFEREE_ADDRESS, Referee11);
+    console.log("Referee upgraded to version 11");
+
+    console.log("Upgrading PoolFactory...");
+    const PoolFactory3 = await ethers.getContractFactory("PoolFactory3");
+    console.log("Got PoolFactory factory");
+    const poolFactory3 = await upgrades.upgradeProxy(POOL_FACTORY_ADDRESS, PoolFactory3);
+    console.log("PoolFactory upgraded to version 3");
+    
+    console.log("Upgrading NodeLicense...");
+    const NodeLicense10 = await ethers.getContractFactory("NodeLicense10");
+    console.log("Got NodeLicense factory");
+    const nodeLicense10 = await upgrades.upgradeProxy(NODE_LICENSE_ADDRESS, NodeLicense10);
+    console.log("NodeLicense upgraded to version 10");
+
+    // UPGRADE PoolBeacon
+    // Create instance of the beacon
+    const beacon = new ethers.Contract(beaconAddress, PoolBeaconAbi, deployer);
+    console.log("Found beacon:", await beacon.getAddress());
+
+    // Validate the new implementation is upgrade safe
+    console.log("Validating upgrade viability...");
+    const CurrentImplementationFactory = await ethers.getContractFactory(currentContractImplementationName);
+    const NewImplementationFactory = await ethers.getContractFactory(newContractImplementationName);
+    await upgrades.validateUpgrade(CurrentImplementationFactory, NewImplementationFactory, { kind: "beacon" });
+    console.log("New implementation validated as upgrade safe");
+
+    // Deploy the new implementation
+    console.log("Deploying the new implementation");
+    const NewImplementation = await ethers.deployContract(newContractImplementationName);
+    await NewImplementation.waitForDeployment();
+    const newImplementationAddress = await NewImplementation.getAddress();
+
+    // Update the beacon with the new implementation address
+    console.log("Updating the beacon with the new implementation address");
+    await beacon.update(newImplementationAddress);
+
+    console.log("Verifying the new PoolBeacon implementation");
+
+    console.log("Starting verification... ");
+    await safeVerify({ skipWaitForDeployTx: true, contractAddress: newImplementationAddress });
+    await safeVerify({ skipWaitForDeployTx: true, contract: referee11 });
+    await safeVerify({ skipWaitForDeployTx: true, contract: nodeLicense10 });
+    await safeVerify({ skipWaitForDeployTx: true, contract: poolFactory3 });
+    console.log("Verification complete ");
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
Implement transfer staked keys in NodeLicense10, Referee11, PoolFactory3 and StakingPool3

[sc-6861]
Add script to deploy upgrades for staked keys

Ran against testscases from https://github.com/xai-foundation/sentry/pull/576, the whole testsuite passes.

Deployed upgrades to sepolia, tested tranfer staked
https://sepolia.arbiscan.io//tx/0x57c52c6b8d39f0d9b89c0079ca05433d0a71119d22df0e899812f657166d1532